### PR TITLE
dbft: basic payloads implementation

### DIFF
--- a/consensus/dbft/block.go
+++ b/consensus/dbft/block.go
@@ -1,10 +1,12 @@
 package dbft
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	ecrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/nspcc-dev/dbft/block"
 	"github.com/nspcc-dev/dbft/crypto"
 	"github.com/nspcc-dev/neo-go/pkg/util"
@@ -100,7 +102,15 @@ func (b *Block) Sign(key crypto.PrivateKey) error {
 
 // Verify implements Block interface.
 func (b *Block) Verify(pub crypto.PublicKey, sign []byte) error {
-	panic("TODO")
+	sealHash := HonestSealHash(b.Header())
+	pubkey, err := ecrypto.Ecrecover(sealHash.Bytes(), sign)
+	if err != nil {
+		return fmt.Errorf("failed to recover public key from signature: %w", err)
+	}
+	if pub.(*PublicKey).Account != ecrypto.PubkeyBytesToAddress(pubkey) {
+		return errors.New("invalid block signature")
+	}
+	return nil
 }
 
 // Hash implements Block interface. Hash returns unsealed block hash that doesn't

--- a/consensus/dbft/block.go
+++ b/consensus/dbft/block.go
@@ -20,9 +20,10 @@ const NsInS = 1000_000_000
 // Block is a wrapper around Eth block that implements block.Block interface and is
 // sufficient for dBFT operations.
 type Block struct {
-	*types.Block
+	header              *types.Header
+	receipts            []*types.Receipt
+	transactions        []*types.Transaction
 	localSignatureBytes []byte
-	changeableExtra     []byte
 }
 
 // Version implements block.Block interface.
@@ -33,28 +34,28 @@ func (b *Block) Version() uint32 {
 
 // PrevHash implements block.Block interface.
 func (b *Block) PrevHash() util.Uint256 {
-	return b.ParentHash().Uint256()
+	return b.header.ParentHash.Uint256()
 }
 
 // Timestamp implements block.Block interface.
 func (b *Block) Timestamp() uint64 {
-	return b.Time() * NsInS
+	return b.header.Time * NsInS
 }
 
 // Index implements block.Block interface.
 func (b *Block) Index() uint32 {
-	return uint32(b.NumberU64())
+	return uint32(b.header.Number.Uint64())
 }
 
 // NextConsensus implements block.Block interface.
 func (b *Block) NextConsensus() (u util.Uint160) {
-	copy(u[:], b.MixDigest().Bytes()[common.HashLength-util.Uint160Size:])
+	copy(u[:], b.header.MixDigest.Bytes()[common.HashLength-util.Uint160Size:])
 	return
 }
 
 // MerkleRoot implements block.Block interface.
 func (b *Block) MerkleRoot() util.Uint256 {
-	return b.Root().Uint256()
+	return b.header.Root.Uint256()
 }
 
 // ConsensusData implements block.Block interface.
@@ -64,9 +65,8 @@ func (b *Block) ConsensusData() uint64 {
 
 // Transactions implements block.Block interface.
 func (b *Block) Transactions() []block.Transaction {
-	src := b.Body().Transactions
-	dst := make([]block.Transaction, len(src))
-	for i, tx := range src {
+	dst := make([]block.Transaction, len(b.transactions))
+	for i, tx := range b.transactions {
 		dst[i] = &Transaction{
 			Tx: tx,
 		}
@@ -81,7 +81,7 @@ func (b *Block) SetTransactions(txx []block.Transaction) {
 	for i, tx := range txx {
 		txs[i] = tx.(*Transaction).Tx
 	}
-	b.Block = b.Block.WithBody(txs, nil) // Uncles are always nil in Clique-like consensus.
+	b.transactions = txs
 }
 
 // Signature implements Block interface.
@@ -91,7 +91,7 @@ func (b *Block) Signature() []byte {
 
 // Sign implements Block interface.
 func (b *Block) Sign(key crypto.PrivateKey) error {
-	sighash, err := key.Sign(dbftRLP(b.Header()))
+	sighash, err := key.Sign(dbftRLP(b.header))
 	if err != nil {
 		return fmt.Errorf("failed to sign dbftRLP header: %w", err)
 	}
@@ -102,7 +102,7 @@ func (b *Block) Sign(key crypto.PrivateKey) error {
 
 // Verify implements Block interface.
 func (b *Block) Verify(pub crypto.PublicKey, sign []byte) error {
-	sealHash := HonestSealHash(b.Header())
+	sealHash := HonestSealHash(b.header)
 	pubkey, err := ecrypto.Ecrecover(sealHash.Bytes(), sign)
 	if err != nil {
 		return fmt.Errorf("failed to recover public key from signature: %w", err)
@@ -117,5 +117,5 @@ func (b *Block) Verify(pub crypto.PublicKey, sign []byte) error {
 // include Nonce, MixDigest fields and Extra's signature part, thus, can be used
 // only for worker's block identification and information purposes.
 func (b *Block) Hash() util.Uint256 {
-	return WorkerSealHash(b.Header()).Uint256()
+	return WorkerSealHash(b.header).Uint256()
 }

--- a/consensus/dbft/block.go
+++ b/consensus/dbft/block.go
@@ -21,7 +21,6 @@ const NsInS = 1000_000_000
 // sufficient for dBFT operations.
 type Block struct {
 	header              *types.Header
-	receipts            []*types.Receipt
 	transactions        []*types.Transaction
 	localSignatureBytes []byte
 }

--- a/consensus/dbft/blockqueue.go
+++ b/consensus/dbft/blockqueue.go
@@ -1,0 +1,78 @@
+package dbft
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// blockQueue is an entity that collects sealed blocks from dBFT and routs these
+// blocks to a proper place (either to miner or directly to chain).
+type blockQueue struct {
+	tasksLock sync.RWMutex
+	tasks     map[common.Hash]task // TODO: consider restricting queue capacity and make it a real queue.
+}
+
+// task holds information about miner sealing task.
+type task struct {
+	resCh    chan<- *types.Block
+	cancalCh <-chan struct{}
+}
+
+// newBlockQueue creates an instance of blockQueue ready to be used.
+func newBlockQueue() *blockQueue {
+	return &blockQueue{
+		tasks: make(map[common.Hash]task),
+	}
+}
+
+// PutBlock routs block either to miner or (if there's no suitable sealing task)
+// directly to blockchain. No block verification is performed, it is assumed that
+// provided block is sealed and valid.
+func (bq *blockQueue) PutBlock(b *types.Block) error {
+	h := WorkerSealHash(b.Header())
+
+	bq.tasksLock.Lock()
+	defer bq.tasksLock.Unlock()
+
+	task, ok := bq.tasks[h]
+	if !ok {
+		// We're OK with that, it just means that dBFT received some extra commits and trying to
+		// send block one more time.
+		return nil
+	}
+
+	// Seal interrupt is not possible with dBFT, thus, ignore stop channel.
+	// TODO: check whether worker removes cancelled task from the list of sealing works before closing stop channel.
+	var err error
+	select {
+	// TODO: ideally, we must replace this way of chain notification to some other (direct) way
+	// and send block not to the miner but to the chain directly.
+	case task.resCh <- b:
+	default:
+		err = fmt.Errorf("seaing result is not read by miner (sealhash %s)", h)
+	}
+
+	delete(bq.tasks, h)
+
+	return err
+}
+
+// SubmitTask adds subsequent miner task to the blockqueue instance.
+func (bq *blockQueue) SubmitTask(sealHash common.Hash, resCh chan<- *types.Block, cancelCh <-chan struct{}) error {
+	bq.tasksLock.Lock()
+	defer bq.tasksLock.Unlock()
+
+	if _, ok := bq.tasks[sealHash]; ok {
+		// Likely a program bug (incorrect Seal proposal verification), should never happen.
+		return fmt.Errorf("duplicating sealing task is not allowed for dBFT: %s", sealHash)
+	}
+
+	bq.tasks[sealHash] = task{
+		resCh:    resCh,
+		cancalCh: cancelCh,
+	}
+	return nil
+}

--- a/consensus/dbft/blockqueue.go
+++ b/consensus/dbft/blockqueue.go
@@ -91,17 +91,6 @@ func (bq *blockQueue) PutBlock(b *types.Block) error {
 		return nil
 	}
 
-	// TODO: it's a very invasive way, we must be VERY careful about it, we MUST
-	// review all the consequences of such insertion, because standard syncing
-	// mechanism currently doesn't allow P2P blocks sync for the current consensus
-	// nodes, see the code around:
-	// log.Warn("Snap syncing, discarded propagated block", "number", blocks[0].Number(), "hash", blocks[0].Hash())
-	//
-	// and event if snap sync is off, then read the comment starting with:
-	// // The blocks from the p2p network is regarded as untrusted
-	//
-	// So we may use either `h.chain.InsertBlockWithoutSetHead(block)` or bq.chain.InsertChain(types.Blocks{b}):
-	// err := bq.chain.InsertBlockWithoutSetHead(b)
 	_, err := bq.chain.InsertChain(types.Blocks{b})
 	if err != nil {
 		return fmt.Errorf("failed to insert block into chain: %w", err)

--- a/consensus/dbft/blockqueue.go
+++ b/consensus/dbft/blockqueue.go
@@ -11,6 +11,7 @@ import (
 // blockQueue is an entity that collects sealed blocks from dBFT and routs these
 // blocks to a proper place (either to miner or directly to chain).
 type blockQueue struct {
+	chain     ChainHeaderWriter
 	tasksLock sync.RWMutex
 	tasks     map[common.Hash]task // TODO: consider restricting queue capacity and make it a real queue.
 }
@@ -21,11 +22,18 @@ type task struct {
 	cancalCh <-chan struct{}
 }
 
-// newBlockQueue creates an instance of blockQueue ready to be used.
+// newBlockQueue creates an instance of blockQueue. It's not ready for usage until
+// an instance of ChainHeaderWriter is properly set.
 func newBlockQueue() *blockQueue {
 	return &blockQueue{
 		tasks: make(map[common.Hash]task),
 	}
+}
+
+// SetChain initializes ChainHeaderWriter instanse needed for proper blockQueue
+// functioning.
+func (bq *blockQueue) SetChain(chain ChainHeaderWriter) {
+	bq.chain = chain
 }
 
 // PutBlock routs block either to miner or (if there's no suitable sealing task)
@@ -35,27 +43,50 @@ func (bq *blockQueue) PutBlock(b *types.Block) error {
 	h := WorkerSealHash(b.Header())
 
 	bq.tasksLock.Lock()
-	defer bq.tasksLock.Unlock()
 
 	task, ok := bq.tasks[h]
 	if !ok {
-		// We're OK with that, it just means that dBFT received some extra commits and trying to
-		// send block one more time.
+		bq.tasksLock.Unlock()
+		// We're OK with that, it just means that:
+		//  1) either dBFT received some extra commits and trying to
+		//     send already constructed block one more time
+		//  2) or we're not a primary node in this consensus round and thus,
+		//     worker's task differs from the dBFT's proposal. In this case we
+		//     need to try to insert block right into chain.
+		if bq.chain.HasBlock(b.Hash(), b.NumberU64()) {
+			return nil
+		}
+
+		// TODO: it's a very invasive way, we must be VERY careful about it, we MUST
+		// review all the consequences of such insertion, because standard syncing
+		// mechanism currently doesn't allow P2P blocks sync for the current consensus
+		// nodes, see the code around:
+		// log.Warn("Snap syncing, discarded propagated block", "number", blocks[0].Number(), "hash", blocks[0].Hash())
+		//
+		// and event if snap sync is off, then read the comment starting with:
+		// // The blocks from the p2p network is regarded as untrusted
+		//
+		// So we may use either `h.chain.InsertBlockWithoutSetHead(block)` or bq.chain.InsertChain(types.Blocks{b}):
+		// err := bq.chain.InsertBlockWithoutSetHead(b)
+		_, err := bq.chain.InsertChain(types.Blocks{b})
+		if err != nil {
+			return fmt.Errorf("failed to insert block into chain: %w", err)
+		}
+
 		return nil
 	}
+	delete(bq.tasks, h)
+	bq.tasksLock.Unlock()
 
 	// Seal interrupt is not possible with dBFT, thus, ignore stop channel.
 	// TODO: check whether worker removes cancelled task from the list of sealing works before closing stop channel.
 	var err error
 	select {
-	// TODO: ideally, we must replace this way of chain notification to some other (direct) way
-	// and send block not to the miner but to the chain directly.
 	case task.resCh <- b:
+	case <-task.cancalCh:
 	default:
 		err = fmt.Errorf("seaing result is not read by miner (sealhash %s)", h)
 	}
-
-	delete(bq.tasks, h)
 
 	return err
 }

--- a/consensus/dbft/blockqueue.go
+++ b/consensus/dbft/blockqueue.go
@@ -15,11 +15,12 @@ import (
 type blockQueue struct {
 	chain     ChainHeaderWriter
 	tasksLock sync.RWMutex
-	tasks     map[common.Hash]task // TODO: consider restricting queue capacity and make it a real queue.
+	tasks     map[common.Hash]task
 }
 
 // task holds information about miner sealing task.
 type task struct {
+	height   uint64
 	resCh    chan<- *types.Block
 	cancelCh <-chan struct{}
 }
@@ -45,8 +46,10 @@ func (bq *blockQueue) PutBlock(b *types.Block) error {
 	h := WorkerSealHash(b.Header())
 
 	bq.tasksLock.Lock()
-
 	task, ok := bq.tasks[h]
+
+	bq.clearStaleTasks(b.NumberU64())
+
 	if ok {
 		var (
 			err         error
@@ -107,8 +110,18 @@ func (bq *blockQueue) PutBlock(b *types.Block) error {
 	return err
 }
 
+// clearStaleTasks removes all stale tasks up to the specified height (including
+// the height itself). It doesn't hold tasksLock, so it's the caller's responsibility.
+func (bq *blockQueue) clearStaleTasks(till uint64) {
+	for h, task := range bq.tasks {
+		if task.height <= till {
+			delete(bq.tasks, h)
+		}
+	}
+}
+
 // SubmitTask adds subsequent miner task to the blockqueue instance.
-func (bq *blockQueue) SubmitTask(sealHash common.Hash, resCh chan<- *types.Block, cancelCh <-chan struct{}) error {
+func (bq *blockQueue) SubmitTask(sealHash common.Hash, number uint64, resCh chan<- *types.Block, cancelCh <-chan struct{}) error {
 	bq.tasksLock.Lock()
 	defer bq.tasksLock.Unlock()
 
@@ -118,6 +131,7 @@ func (bq *blockQueue) SubmitTask(sealHash common.Hash, resCh chan<- *types.Block
 	}
 
 	bq.tasks[sealHash] = task{
+		height:   number,
 		resCh:    resCh,
 		cancelCh: cancelCh,
 	}

--- a/consensus/dbft/blockqueue.go
+++ b/consensus/dbft/blockqueue.go
@@ -21,7 +21,7 @@ type blockQueue struct {
 // task holds information about miner sealing task.
 type task struct {
 	resCh    chan<- *types.Block
-	cancalCh <-chan struct{}
+	cancelCh <-chan struct{}
 }
 
 // newBlockQueue creates an instance of blockQueue. It's not ready for usage until
@@ -53,7 +53,7 @@ func (bq *blockQueue) PutBlock(b *types.Block) error {
 			readByMiner bool
 		)
 		select {
-		case <-task.cancalCh:
+		case <-task.cancelCh:
 		case task.resCh <- b:
 			readByMiner = true
 		default:
@@ -119,7 +119,7 @@ func (bq *blockQueue) SubmitTask(sealHash common.Hash, resCh chan<- *types.Block
 
 	bq.tasks[sealHash] = task{
 		resCh:    resCh,
-		cancalCh: cancelCh,
+		cancelCh: cancelCh,
 	}
 	return nil
 }

--- a/consensus/dbft/blockqueue.go
+++ b/consensus/dbft/blockqueue.go
@@ -1,11 +1,13 @@
 package dbft
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 // blockQueue is an entity that collects sealed blocks from dBFT and routs these
@@ -45,47 +47,61 @@ func (bq *blockQueue) PutBlock(b *types.Block) error {
 	bq.tasksLock.Lock()
 
 	task, ok := bq.tasks[h]
-	if !ok {
-		bq.tasksLock.Unlock()
-		// We're OK with that, it just means that:
-		//  1) either dBFT received some extra commits and trying to
-		//     send already constructed block one more time
-		//  2) or we're not a primary node in this consensus round and thus,
-		//     worker's task differs from the dBFT's proposal. In this case we
-		//     need to try to insert block right into chain.
-		if bq.chain.HasBlock(b.Hash(), b.NumberU64()) {
+	if ok {
+		var (
+			err         error
+			readByMiner bool
+		)
+		select {
+		case <-task.cancalCh:
+		case task.resCh <- b:
+			readByMiner = true
+		default:
+			err = errors.New("sealing result is not read by miner, trying to insert block in chain manually")
+		}
+		delete(bq.tasks, h)
+
+		if readByMiner {
+			bq.tasksLock.Unlock()
 			return nil
 		}
 
-		// TODO: it's a very invasive way, we must be VERY careful about it, we MUST
-		// review all the consequences of such insertion, because standard syncing
-		// mechanism currently doesn't allow P2P blocks sync for the current consensus
-		// nodes, see the code around:
-		// log.Warn("Snap syncing, discarded propagated block", "number", blocks[0].Number(), "hash", blocks[0].Hash())
-		//
-		// and event if snap sync is off, then read the comment starting with:
-		// // The blocks from the p2p network is regarded as untrusted
-		//
-		// So we may use either `h.chain.InsertBlockWithoutSetHead(block)` or bq.chain.InsertChain(types.Blocks{b}):
-		// err := bq.chain.InsertBlockWithoutSetHead(b)
-		_, err := bq.chain.InsertChain(types.Blocks{b})
 		if err != nil {
-			return fmt.Errorf("failed to insert block into chain: %w", err)
+			log.Warn(err.Error(),
+				"number", b.Number(),
+				"seal hash", h.String(),
+				"hash", b.Hash().String(),
+			)
 		}
-
-		return nil
 	}
-	delete(bq.tasks, h)
 	bq.tasksLock.Unlock()
 
-	// Seal interrupt is not possible with dBFT, thus, ignore stop channel.
-	// TODO: check whether worker removes cancelled task from the list of sealing works before closing stop channel.
-	var err error
-	select {
-	case task.resCh <- b:
-	case <-task.cancalCh:
-	default:
-		err = fmt.Errorf("seaing result is not read by miner (sealhash %s)", h)
+	// If we're here then we're OK with that, it just means that:
+	//  1) either dBFT received some extra commits and trying to
+	//     send already constructed block one more time
+	//  2) or worker has received block with the same index via network. Then
+	//     we still need to save the block in case it has different hash.
+	//  3) or we're not a primary node in this consensus round and thus,
+	//     worker's task differs from the dBFT's proposal. In this case we
+	//     need to try to insert block right into chain.
+	if bq.chain.HasBlock(b.Hash(), b.NumberU64()) {
+		return nil
+	}
+
+	// TODO: it's a very invasive way, we must be VERY careful about it, we MUST
+	// review all the consequences of such insertion, because standard syncing
+	// mechanism currently doesn't allow P2P blocks sync for the current consensus
+	// nodes, see the code around:
+	// log.Warn("Snap syncing, discarded propagated block", "number", blocks[0].Number(), "hash", blocks[0].Hash())
+	//
+	// and event if snap sync is off, then read the comment starting with:
+	// // The blocks from the p2p network is regarded as untrusted
+	//
+	// So we may use either `h.chain.InsertBlockWithoutSetHead(block)` or bq.chain.InsertChain(types.Blocks{b}):
+	// err := bq.chain.InsertBlockWithoutSetHead(b)
+	_, err := bq.chain.InsertChain(types.Blocks{b})
+	if err != nil {
+		return fmt.Errorf("failed to insert block into chain: %w", err)
 	}
 
 	return err

--- a/consensus/dbft/chainreader.go
+++ b/consensus/dbft/chainreader.go
@@ -1,8 +1,10 @@
 package dbft
 
 import (
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 )
 
@@ -10,4 +12,13 @@ import (
 type ChainHeaderReader interface {
 	consensus.ChainHeaderReader
 	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
+	HasBlock(hash common.Hash, number uint64) bool
+}
+
+// ChainHeaderWriter is a Blockchain API abstraction needed for proper blockQueue
+// work.
+type ChainHeaderWriter interface {
+	ChainHeaderReader
+	InsertChain(chain types.Blocks) (int, error)
+	InsertBlockWithoutSetHead(b *types.Block) error
 }

--- a/consensus/dbft/chainreader.go
+++ b/consensus/dbft/chainreader.go
@@ -13,6 +13,7 @@ type ChainHeaderReader interface {
 	consensus.ChainHeaderReader
 	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
 	HasBlock(hash common.Hash, number uint64) bool
+	GetBlockByNumber(uint64) *types.Block
 }
 
 // ChainHeaderWriter is a Blockchain API abstraction needed for proper blockQueue

--- a/consensus/dbft/chainreader.go
+++ b/consensus/dbft/chainreader.go
@@ -1,0 +1,13 @@
+package dbft
+
+import (
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// ChainHeaderReader is a Blockchain API abstraction needed for proper dBFT work.
+type ChainHeaderReader interface {
+	consensus.ChainHeaderReader
+	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
+}

--- a/consensus/dbft/change_view.go
+++ b/consensus/dbft/change_view.go
@@ -1,0 +1,47 @@
+package dbft
+
+import (
+	"github.com/nspcc-dev/dbft/payload"
+	"github.com/nspcc-dev/neo-go/pkg/io"
+)
+
+// changeView represents dBFT ChangeView message.
+type changeView struct {
+	newViewNumber byte
+	// timestamp is nanoseconds-precision payload timestamp, exactly like the one
+	// that dBFT library operates internally with.
+	timestamp uint64
+	reason    payload.ChangeViewReason
+}
+
+var _ payload.ChangeView = (*changeView)(nil)
+
+// EncodeBinary implements the io.Serializable interface.
+func (c *changeView) EncodeBinary(w *io.BinWriter) {
+	w.WriteU64LE(c.timestamp)
+	w.WriteB(byte(c.reason))
+}
+
+// DecodeBinary implements the io.Serializable interface.
+func (c *changeView) DecodeBinary(r *io.BinReader) {
+	c.timestamp = r.ReadU64LE()
+	c.reason = payload.ChangeViewReason(r.ReadB())
+}
+
+// NewViewNumber implements the payload.ChangeView interface.
+func (c changeView) NewViewNumber() byte { return c.newViewNumber }
+
+// SetNewViewNumber implements the payload.ChangeView interface.
+func (c *changeView) SetNewViewNumber(view byte) { c.newViewNumber = view }
+
+// Timestamp implements the payload.ChangeView interface.
+func (c changeView) Timestamp() uint64 { return c.timestamp }
+
+// SetTimestamp implements the payload.ChangeView interface.
+func (c *changeView) SetTimestamp(ts uint64) { c.timestamp = ts }
+
+// Reason implements the payload.ChangeView interface.
+func (c changeView) Reason() payload.ChangeViewReason { return c.reason }
+
+// SetReason implements the payload.ChangeView interface.
+func (c *changeView) SetReason(reason payload.ChangeViewReason) { c.reason = reason }

--- a/consensus/dbft/change_view_test.go
+++ b/consensus/dbft/change_view_test.go
@@ -1,0 +1,17 @@
+package dbft
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChangeView_Setters(t *testing.T) {
+	var c changeView
+
+	c.SetTimestamp(123) // in nanoseconds, no conversion expected.
+	require.EqualValues(t, 123, c.Timestamp())
+
+	c.SetNewViewNumber(2)
+	require.EqualValues(t, 2, c.NewViewNumber())
+}

--- a/consensus/dbft/commit.go
+++ b/consensus/dbft/commit.go
@@ -1,0 +1,31 @@
+package dbft
+
+import (
+	"github.com/nspcc-dev/dbft/payload"
+	"github.com/nspcc-dev/neo-go/pkg/io"
+)
+
+// commit represents dBFT Commit message.
+type commit struct {
+	signature [extraSeal]byte
+}
+
+var _ payload.Commit = (*commit)(nil)
+
+// EncodeBinary implements the io.Serializable interface.
+func (c *commit) EncodeBinary(w *io.BinWriter) {
+	w.WriteBytes(c.signature[:])
+}
+
+// DecodeBinary implements the io.Serializable interface.
+func (c *commit) DecodeBinary(r *io.BinReader) {
+	r.ReadBytes(c.signature[:])
+}
+
+// Signature implements the payload.Commit interface.
+func (c commit) Signature() []byte { return c.signature[:] }
+
+// SetSignature implements the payload.Commit interface.
+func (c *commit) SetSignature(signature []byte) {
+	copy(c.signature[:], signature)
+}

--- a/consensus/dbft/commit_test.go
+++ b/consensus/dbft/commit_test.go
@@ -1,0 +1,19 @@
+package dbft
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommit_Setters(t *testing.T) {
+	var sign [extraSeal]byte
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r.Read(sign[:])
+
+	var c commit
+	c.SetSignature(sign[:])
+	require.Equal(t, sign[:], c.Signature())
+}

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -486,55 +486,66 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 		dbft.WithVerifyPrepareResponse(func(_ payload.ConsensusPayload) error { return nil }),
 		dbft.WithVerifyPrepareRequest(func(p payload.ConsensusPayload) error {
 			req := p.GetPrepareRequest().(*prepareRequest)
+			c.sealingLock.Lock()
+			defer c.sealingLock.Unlock()
 			if req.SealingProposal == nil {
-				return errors.New("invalid PrepareRequest: sealing proposal is nil")
+				return errors.New("failed to verify PrepareRequest: sealing proposal is nil")
 			}
 			if req.SealingProposal.ParentHash.Uint256() != c.dbft.PrevHash {
-				if c.dbft.BlockIndex <= 1 { // genesis block  is hard-coded, thus its hash (as a parent hash) must match the one that prepareRequest declares as a parent hash.
+				// Genesis block  is hard-coded, thus its hash (as a parent hash) must always match
+				// the one that prepareRequest declares as a parent hash, otherwise it's an error.
+				if c.dbft.BlockIndex <= 1 {
 					return fmt.Errorf("invalid parent: expected %s, got %s", c.dbft.PrevHash, req.SealingProposal.ParentHash)
 				}
 				if req.ParentSealHash != c.lastBlockSealHash {
 					return fmt.Errorf("parent seal hash doesn't match the last block seal hash: expected %s, got %s", c.lastBlockSealHash, req.ParentSealHash)
 				}
-				// TODO: to properly verify newly-provided witness of the parent block we need to
-				// fetch parent's parent NextConsensus. Or instead (if supported) just push the newly-constructed
-				// block to the chain and it will deal with the verification by itself.
-				// For simplicity, consider it as valid.
-				/*
-					err := c.verifyExtra(parentParentNextConsensus, req.ParentSealHash, req.ParentExtra)
-					if err != nil {
-						return err
-					}
-				*/
-				// After that we assume that parent block is valid and it can be sent to chain.
-				// For now, we'll hope that parent block will be fetched automatically and internal forks resolving mechanism will
-				// choose the right chain.
+				// Verify proposed parent's signature.
+				savedGrandparent := c.chain.GetBlockByNumber(req.SealingProposal.Number.Uint64() - 2)
+				if savedGrandparent == nil {
+					return errors.New("failed to verify parent: failed to retrieve grandparent from storage")
+				}
+				err := c.verifyExtra(savedGrandparent.Header().NextConsensus(), req.ParentSealHash, req.ParentExtra)
+				if err != nil {
+					return fmt.Errorf("invalid parent: parent's witness verification failed: %w", err)
+				}
+
+				// After that we assume that parent block is totally valid, and it can be inserted to chain.
+				// Internal fork resolving mechanism will deal with forks.
 				savedParent := c.chain.GetBlockByNumber(req.SealingProposal.Number.Uint64() - 1)
-				if savedParent != nil { // TODO: what if it's nil? Is it ever possible?
-					newHeader := savedParent.Header()
-					newHeader.Extra = req.ParentExtra
-					err := c.blockQueue.PutBlock(savedParent.WithSeal(newHeader)) // TODO: maybe send to a separate routine.
-					if err != nil {
-						// TODO: this error is very critical for further block processing.
-						log.Warn("failed to enqueue parent with updated extra: %w", err)
-					}
+				if savedParent == nil {
+					return fmt.Errorf("failed to put proposed parent to the storage: no parent found for height %d", req.SealingProposal.Number.Uint64()-1)
+				}
+				newHeader := savedParent.Header()
+				newHeader.Extra = req.ParentExtra
+				err = c.blockQueue.PutBlock(savedParent.WithSeal(newHeader))
+				if err != nil {
+					err = fmt.Errorf("failed to enqueue parent with updated extra for height %d (old hash %s, new hash %s): %w",
+						req.SealingProposal.Number.Uint64()-1,
+						savedParent.Hash(),
+						req.SealingProposal.ParentHash,
+						err)
+					// This error is critical for further dBFT functioning.
+					log.Warn(err.Error())
+					return err
 				}
 
 				c.lastBlockHash = req.SealingProposal.ParentHash
+				c.lastBlockExtra = req.ParentExtra
 				c.dbft.PrevHash = req.SealingProposal.ParentHash.Uint256()
 			}
-			// Save lastProposal for getVerified().
-			// c.lastProposal = req.TxHashes
 
-			// TODO: properly initialize the rest of dBFT context from prepareRequest
-			//  to be able to properly create commit.
-
-			c.sealingLock.Lock()
-			c.isSealing = true // TODO: get rid of this after moving dbft timer to a separate routine.
+			c.isSealing = true
 			c.sealingProposal = req.SealingProposal
 			c.sealingReceipts = req.SealingReceipts
-			// c.sealingTransactions? we can't get them directly from prepare request, need to store hashes and then provide callback to mempool
-			c.sealingLock.Unlock()
+
+			// Do not fill c.sealingTransactions. If the node is primary, then sealing txs must be
+			// properly filled by this moment from the new miner proposal in Seal (it happens even
+			// before the dBFT initialisation for this round). If the node is backup, then
+			// sealingTransactions are not needed for proper dBFT functioning (dBFT will collect
+			// transactions via internal mechanism in this consensus view).
+			c.sealingTransactions = nil
+
 			return nil
 		}),
 		dbft.WithBroadcast(func(p payload.ConsensusPayload) {

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -462,7 +462,6 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 			return res
 		}),
 		dbft.WithRequestTx(func(h ...util.Uint256) {
-			// TODO: integrate with transaction fetcher.
 		}),
 		dbft.WithGetConsensusAddress(func(keys ...dbftCrypto.PublicKey) util.Uint160 {
 			// NextConsensus is filled manually in NewBlockFromContext.

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -985,7 +985,15 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 		c.sealingLock.Unlock()
 		return errors.New("no initialized pending sealing task")
 	}
-	c.sealingProposal = c.lastProposal.Header()
+	lastHeader := c.lastProposal.Header()
+	sealingHash := c.SealHash(lastHeader)
+	if sealingHash != c.SealHash(b.Header()) {
+		c.lastProposalLock.RUnlock()
+		c.sealingLock.Unlock()
+		return errors.New("initialized pending sealing task mismatch with target sealing task")
+	}
+
+	c.sealingProposal = lastHeader
 	c.sealingTransactions = c.lastProposal.Transactions()
 	c.sealingReceipts = c.lastReceipts
 	c.lastProposalLock.RUnlock()

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1073,23 +1073,19 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 		return errors.New("initialized pending sealing task mismatch with target sealing task")
 	}
 
-	c.sealingProposal = lastHeader
-	c.sealingTransactions = c.lastProposal.Transactions()
-	c.sealingReceipts = c.lastReceipts
-	c.lastProposalLock.RUnlock()
-
-	c.isSealing = true
-	c.sealingLock.Unlock()
-
 	header := b.Header()
+	number := header.Number.Uint64()
 
 	// Sealing the genesis block is not supported
-	number := header.Number.Uint64()
 	if number == 0 {
+		c.lastProposalLock.RUnlock()
+		c.sealingLock.Unlock()
 		return errUnknownBlock
 	}
 	// For 0-period chains, refuse to seal empty blocks (no reward but would spin sealing)
 	if c.config.SecondsPerBlock == 0 && len(b.Transactions()) == 0 {
+		c.lastProposalLock.RUnlock()
+		c.sealingLock.Unlock()
 		return errors.New("sealing paused while waiting for transactions")
 	}
 	// Don't hold the signer fields for the entire sealing procedure
@@ -1101,19 +1097,33 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 	// TODO: replace with validators-based check and then don't need a snapshot.
 	snap, err := c.snapshot(chain, number-1, header.ParentHash, nil)
 	if err != nil {
+		c.lastProposalLock.RUnlock()
+		c.sealingLock.Unlock()
 		return err
 	}
 
 	// This check is duplicated in dBFT.WithGetKeyPair, but here we still need to
 	// keep it in order not to run the consensus if we're not the consensus node.
 	if _, authorized := snap.Signers[signer]; !authorized {
+		c.lastProposalLock.RUnlock()
+		c.sealingLock.Unlock()
 		return errUnauthorizedSigner
 	}
 
 	err = c.blockQueue.SubmitTask(sealingHash, b.NumberU64(), results, stop)
 	if err != nil {
+		c.lastProposalLock.RUnlock()
+		c.sealingLock.Unlock()
 		return fmt.Errorf("failed to submit sealing task to dBFT: %w", err)
 	}
+
+	c.sealingProposal = lastHeader
+	c.sealingTransactions = c.lastProposal.Transactions()
+	c.sealingReceipts = c.lastReceipts
+	c.isSealing = true
+
+	c.lastProposalLock.RUnlock()
+	c.sealingLock.Unlock()
 
 	// Start dBFT once and afterward reinitialize it every time new block should be accepted.
 	if c.dbftStarted.CompareAndSwap(false, true) {

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -43,6 +43,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/systemcontracts"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	dbftproto "github.com/ethereum/go-ethereum/eth/protocols/dbft"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/log"
@@ -53,6 +54,7 @@ import (
 	"github.com/nspcc-dev/dbft"
 	"github.com/nspcc-dev/dbft/block"
 	dbftCrypto "github.com/nspcc-dev/dbft/crypto"
+	"github.com/nspcc-dev/dbft/payload"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/sha3"
@@ -156,7 +158,7 @@ var (
 
 // getSignersAndSigs extracts the set of validators addresses (ValidatorsCount number of them)
 // and a set of validators signatures (BFT number of them) from a signed header.
-func getSignersAndSigs(cfg *params.DBFTConfig, header *types.Header) ([]common.Address, [][]byte, error) {
+func getSignersAndSigs(cfg *params.DBFTConfig, extra []byte) ([]common.Address, [][]byte, error) {
 	// Retrieve the signature from the header extra-data
 	var (
 		n             = int(cfg.ValidatorsCount)
@@ -164,7 +166,7 @@ func getSignersAndSigs(cfg *params.DBFTConfig, header *types.Header) ([]common.A
 		addrsBytesLen = common.AddressLength * n
 		sigsBytesLen  = extraSeal * m
 	)
-	if len(header.Extra) < extraVanity+addrsBytesLen+sigsBytesLen {
+	if len(extra) < extraVanity+addrsBytesLen+sigsBytesLen {
 		return nil, nil, errMissingSignature
 	}
 
@@ -175,11 +177,11 @@ func getSignersAndSigs(cfg *params.DBFTConfig, header *types.Header) ([]common.A
 	)
 	for i := range addrs {
 		addrOffset := extraVanity + i*common.AddressLength
-		copy(addrs[i][:], header.Extra[addrOffset:addrOffset+common.AddressLength])
+		copy(addrs[i][:], extra[addrOffset:addrOffset+common.AddressLength])
 	}
 	for i := range sigs {
-		sigOffset := len(header.Extra) - sigsBytesLen + i*extraSeal
-		sigs[i] = header.Extra[sigOffset : sigOffset+extraSeal]
+		sigOffset := len(extra) - sigsBytesLen + i*extraSeal
+		sigs[i] = extra[sigOffset : sigOffset+extraSeal]
 	}
 
 	return addrs, sigs, nil
@@ -187,6 +189,14 @@ func getSignersAndSigs(cfg *params.DBFTConfig, header *types.Header) ([]common.A
 
 // DBFT is the proof-of-authority consensus engine.
 type DBFT struct {
+	// TODO: we use only BroadcastMessage, need to replace with callback like in NeoGo.
+	service  *dbftproto.Service
+	messages chan Payload
+
+	// TODO: properly integrate chain.
+	transactions chan *types.Transaction
+	blockEvents  chan *types.Block
+
 	config *params.DBFTConfig // Consensus engine configuration parameters
 	epoch  uint64             // Epoch duration left for backwards compatibility.
 	db     ethdb.Database     // Database to store and retrieve snapshot checkpoints
@@ -207,18 +217,21 @@ type DBFT struct {
 	// lastTimestamp, lastIndex and lastBlockHash are updated on every new header
 	// received from dBFT or from chain. These fields have exactly those type
 	// that Eth offers, thus, they need to be converted before feeding to dBFT.
-	lastTimestamp uint64 // in seconds, like Eth requires.
-	lastIndex     uint64
-	lastBlockHash common.Hash
+	lastTimestamp     uint64 // in seconds, like Eth requires.
+	lastIndex         uint64
+	lastBlockHash     common.Hash
+	lastBlockSealHash common.Hash
+	lastBlockExtra    []byte
 
 	lastProposalLock sync.RWMutex
 	lastProposal     *types.Block
 	lastReceipts     []*types.Receipt
 
-	sealingLock     sync.RWMutex
-	isSealing       bool
-	sealingProposal *types.Block
-	sealingReceipts []*types.Receipt
+	sealingLock         sync.RWMutex
+	isSealing           bool
+	sealingProposal     *types.Header
+	sealingReceipts     []*types.Receipt
+	sealingTransactions types.Transactions
 
 	// chain instance needed for proper dBFT callbacks functioning.
 	chain    consensus.ChainHeaderReader
@@ -255,6 +268,7 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 
 	logger, _ := zap.NewDevelopment()
 	c.blockQueue = make(chan *Block)
+	c.messages = make(chan Payload, 100)
 	c.dbft = dbft.New(
 		dbft.WithLogger(logger),
 		dbft.WithSecondsPerBlock(time.Duration(conf.SecondsPerBlock)*time.Second),
@@ -332,7 +346,7 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 		}),
 		dbft.WithNewBlockFromContext(func(ctx *dbft.Context) block.Block {
 			var (
-				proposal *types.Block
+				proposal *types.Header
 				receipts []*types.Receipt
 			)
 			c.sealingLock.RLock()
@@ -344,7 +358,7 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 			receipts = c.sealingReceipts
 			c.sealingLock.RUnlock()
 
-			h := types.CopyHeader(proposal.Header())
+			h := types.CopyHeader(proposal)
 
 			// BlockIndex -> Number
 			h.Number = big.NewInt(int64(ctx.BlockIndex))
@@ -360,7 +374,8 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 			h.MixDigest = dbftutil.GetNextConsensusHash(nextVals)
 
 			// PrevHash -> ParentHash
-			h.ParentHash.SetBytes(ctx.PrevHash.BytesBE())
+			// TODO: don't pay attention to context's hash, we have it in the sealing proposal.
+			// h.ParentHash.SetBytes(ctx.PrevHash.BytesBE())
 
 			txs := make([]*types.Transaction, len(ctx.Transactions))
 			for i, txH := range ctx.TransactionHashes {
@@ -377,11 +392,11 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 		dbft.WithGetVerified(func() []block.Transaction {
 			var txs types.Transactions
 			c.sealingLock.RLock()
-			if c.sealingProposal == nil {
+			if c.sealingProposal == nil { // check the proposal, because c.sealingTransactions may be nil in case of empty transactions list.
 				// Program bug.
 				panic("missing pending sealing work")
 			}
-			txs = c.sealingProposal.Transactions()
+			txs = c.sealingTransactions
 			c.sealingLock.RUnlock()
 
 			res := make([]block.Transaction, len(txs))
@@ -395,6 +410,82 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 		dbft.WithGetConsensusAddress(func(keys ...dbftCrypto.PublicKey) util.Uint160 {
 			// NextConsensus is filled manually in NewBlockFromContext.
 			return util.Uint160{}
+		}),
+		dbft.WithNewConsensusPayload(c.newPayload),
+		dbft.WithNewPrepareRequest(func() payload.PrepareRequest {
+			var req = new(prepareRequest)
+			c.sealingLock.RLock()
+			if c.sealingProposal == nil {
+				panic("bug: sealing proposal is not initialized")
+			}
+			req.sealingProposal = c.sealingProposal
+			req.sealingReceipts = c.sealingReceipts
+			c.sealingLock.RUnlock()
+
+			req.parentSealHash = c.lastBlockSealHash
+			req.parentExtra = c.lastBlockExtra
+			return req
+		}),
+		dbft.WithNewCommit(func() payload.Commit { return new(commit) }),
+		dbft.WithNewPrepareResponse(func() payload.PrepareResponse { return new(prepareResponse) }),
+		dbft.WithNewChangeView(func() payload.ChangeView { return new(changeView) }),
+		dbft.WithNewRecoveryRequest(func() payload.RecoveryRequest { return new(recoveryRequest) }),
+		dbft.WithNewRecoveryMessage(func() payload.RecoveryMessage { return new(recoveryMessage) }),
+		dbft.WithVerifyPrepareResponse(func(_ payload.ConsensusPayload) error { return nil }),
+		dbft.WithVerifyPrepareRequest(func(p payload.ConsensusPayload) error {
+			req := p.GetPrepareRequest().(*prepareRequest)
+			if req.sealingProposal == nil {
+				return errors.New("invalid PrepareRequest: sealing proposal is nil")
+			}
+			if req.sealingProposal.ParentHash.Uint256() != c.dbft.PrevHash {
+				if c.dbft.BlockIndex <= 1 { // genesis block  is hard-coded, thus its hash (as a parent hash) must match the one that prepareRequest declares as a parent hash.
+					return fmt.Errorf("invalid parent: expected %s, got %s", c.dbft.PrevHash, req.sealingProposal.ParentHash)
+				}
+				if req.parentSealHash != c.lastBlockSealHash {
+					return fmt.Errorf("parent seal hash doesn't match the last block seal hash: expected %s, got %s", c.lastBlockSealHash, req.parentSealHash)
+				}
+				// TODO: to properly verify newly-provided witness of the parent block we need to
+				// fetch parent's parent NextConsensus. Or instead (if supported) just push the newly-constructed
+				// block to the chain and it will deal with the verification by itself.
+				// For simplicity, consider it as valid.
+				/*
+					err := c.verifyExtra(parentParentNextConsensus, req.parentSealHash, req.parentExtra)
+					if err != nil {
+						return err
+					}
+				*/
+				// After that we assume that parent block is valid and it can be sent to chain.
+				// For now, we'll hope that parent block will be fetched automatically and internal forks resolving mechanism will
+				// choose the right chain.
+
+				// TODO: lock it?
+				c.lastBlockHash = req.sealingProposal.ParentHash
+				c.dbft.PrevHash = req.sealingProposal.ParentHash.Uint256() // this may be skipped, we don't use context's prevHash.
+			}
+			// Save lastProposal for getVerified().
+			// c.lastProposal = req.transactionHashes
+
+			// TODO: properly initialize the rest of dBFT context from prepareRequest
+			//  to be able to properly create commit.
+
+			c.sealingLock.Lock()
+			c.isSealing = true // TODO: get rid of this after moving dbft timer to a separate routine.
+			c.sealingProposal = req.sealingProposal
+			c.sealingReceipts = req.sealingReceipts
+			// c.sealingTransactions? we can't get them directly from prepare request, need to store hashes and then provide callback to mempool
+			c.sealingLock.Unlock()
+			return nil
+		}),
+		dbft.WithBroadcast(func(p payload.ConsensusPayload) {
+			if err := p.(*Payload).Sign(c.dbft.Priv.(*Signer)); err != nil {
+				log.Warn("can't sign consensus payload", "error", err)
+			}
+
+			ep := &p.(*Payload).Message
+			err := c.service.BroadcastMessage(ep)
+			if err != nil {
+				log.Warn("can't broadcast consensus message", "error", err)
+			}
 		}),
 	)
 
@@ -437,18 +528,26 @@ func (c *DBFT) SetEthAPI(api *ethapi.BlockChainAPI) {
 	c.ethAPI = api
 }
 
+func (c *DBFT) SetService(srv *dbftproto.Service) {
+	c.service = srv
+}
+
 // postBlock is a callback that updates latest accepted block data and resets
 // last proposal data. It must be called every time new block arrives from chain
 // or from consensus.
 func (c *DBFT) postBlock(b *types.Block) {
 	if c.lastIndex < b.NumberU64() {
-		c.lastTimestamp = b.Time()
-		c.lastIndex = b.Number().Uint64()
+		h := b.Header()
+		c.lastTimestamp = h.Time
+		c.lastIndex = h.Number.Uint64()
 		c.lastBlockHash = b.Hash()
+		c.lastBlockSealHash = HonestSealHash(h)
+		c.lastBlockExtra = h.Extra
 
 		c.sealingLock.Lock()
 		c.sealingProposal = nil
 		c.sealingReceipts = nil
+		c.sealingTransactions = nil
 		c.sealingLock.Unlock()
 	}
 }
@@ -456,7 +555,7 @@ func (c *DBFT) postBlock(b *types.Block) {
 // Author implements consensus.Engine, returning the Ethereum address recovered
 // from the signature in the header's extra-data section.
 func (c *DBFT) Author(header *types.Header) (common.Address, error) {
-	vals, _, err := getSignersAndSigs(c.config, header)
+	vals, _, err := getSignersAndSigs(c.config, header.Extra)
 	if err != nil {
 		return common.Address{}, fmt.Errorf("failed to retrieve validators addresses and signatures from header: %w", err)
 	}
@@ -705,29 +804,40 @@ func (c *DBFT) verifySeal(snap *Snapshot, header *types.Header, parents []*types
 	if number == 0 {
 		return errUnknownBlock
 	}
+	err := c.verifyExtra(parent.NextConsensus(), HonestSealHash(header), header.Extra)
+	if err != nil {
+		return fmt.Errorf("invalid Extra: %w", err)
+	}
+	/*
+		// TODO: get rid of difficulty?
+		// Ensure that the difficulty corresponds to the turn-ness of the signer
+		if !c.fakeDiff {
+			signer := vals[header.Primary()]
+			inturn := snap.inturn(header.Number.Uint64(), signer)
+			if inturn && header.Difficulty.Cmp(diffInTurn) != 0 {
+				return errWrongDifficulty
+			}
+			if !inturn && header.Difficulty.Cmp(diffNoTurn) != 0 {
+				return errWrongDifficulty
+			}
+		}
+	*/
+	return nil
+}
+
+func (c *DBFT) verifyExtra(parentNextConsensus common.Hash, honestSealHash common.Hash, extra []byte) error {
 	// Resolve the authorization key and check against signers.
-	vals, sigs, err := getSignersAndSigs(c.config, header)
+	vals, sigs, err := getSignersAndSigs(c.config, extra)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve validators and signatures from header: %w", err)
 	}
 	nextConsensus := dbftutil.GetNextConsensusHash(vals)
-	if parent.NextConsensus() != nextConsensus {
-		return fmt.Errorf("invalid NextConsensus address retrieved from validators addresses: expected %s, got %s", parent.NextConsensus(), nextConsensus)
+	if parentNextConsensus != nextConsensus {
+		return fmt.Errorf("invalid NextConsensus retrieved from validators addresses: expected %s, got %s", parentNextConsensus, nextConsensus)
 	}
-	err = crypto.VerifyMultiBFT(HonestSealHash(header).Bytes(), vals, sigs)
+	err = crypto.VerifyMultiBFT(honestSealHash.Bytes(), vals, sigs)
 	if err != nil {
 		return fmt.Errorf("%w: %s", errUnauthorizedSigner, err)
-	}
-	// Ensure that the difficulty corresponds to the turn-ness of the signer
-	if !c.fakeDiff {
-		signer := vals[header.Primary()]
-		inturn := snap.inturn(header.Number.Uint64(), signer)
-		if inturn && header.Difficulty.Cmp(diffInTurn) != 0 {
-			return errWrongDifficulty
-		}
-		if !inturn && header.Difficulty.Cmp(diffNoTurn) != 0 {
-			return errWrongDifficulty
-		}
 	}
 	return nil
 }
@@ -842,31 +952,12 @@ func (c *DBFT) Initialize(chain consensus.ChainHeaderReader) {
 	c.lastIndex = currHeader.Number.Uint64()
 	c.lastTimestamp = currHeader.Time
 	c.lastBlockHash = currHeader.Hash()
+	c.lastBlockSealHash = HonestSealHash(currHeader)
+	c.lastBlockExtra = currHeader.Extra
 
 	// Do not start consensus immediately, we don't yet have sealing work.
 	// Start it once we have new sealing work in Seal.
 	c.dbft.InitializeConsensus(0, c.lastTimestamp*NsInS)
-
-	go c.eventLoop()
-}
-
-func (c *DBFT) eventLoop() {
-events:
-	for {
-		select {
-		case <-c.quit:
-			c.dbft.Timer.Stop()
-			break events
-		}
-	}
-drainLoop:
-	for {
-		select {
-		default:
-			break drainLoop
-		}
-	}
-	close(c.finished)
 }
 
 // Seal implements consensus.Engine, attempting to create a sealed block using
@@ -882,6 +973,8 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 		return fmt.Errorf("stale sealing task: invalid Number: expected %d, got %d", c.lastIndex+1, b.NumberU64())
 	}
 	if b.ParentHash().Cmp(c.lastBlockHash) != 0 {
+		// TODO: compare seal hash and check new witnesses provided by PrepareRequest then (if exists).
+		// If matches, then it's not an error.
 		c.sealingLock.Unlock()
 		return fmt.Errorf("stale sealing task: invalid ParentHash: expected %s, got %s", c.lastBlockHash, b.ParentHash())
 	}
@@ -892,7 +985,8 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 		c.sealingLock.Unlock()
 		return errors.New("no initialized pending sealing task")
 	}
-	c.sealingProposal = c.lastProposal
+	c.sealingProposal = c.lastProposal.Header()
+	c.sealingTransactions = c.lastProposal.Transactions()
 	c.sealingReceipts = c.lastReceipts
 	c.lastProposalLock.RUnlock()
 
@@ -916,6 +1010,7 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 	c.lock.RUnlock()
 
 	// Bail out if we're unauthorized to sign a block
+	// TODO: replace with validators-based check and then don't need a snapshot.
 	snap, err := c.snapshot(chain, number-1, header.ParentHash, nil)
 	if err != nil {
 		return err
@@ -939,7 +1034,8 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 
 	// Start dBFT once and afterward reinitialize it every time new block should be accepted.
 	if c.dbftStarted.CompareAndSwap(false, true) {
-		go c.dbft.Start(c.lastTimestamp * NsInS)
+		go c.dbft.Start(c.lastTimestamp * NsInS) // TODO: not in a separate loop?
+		go c.eventLoop()
 	} else {
 		c.dbft.InitializeConsensus(0, c.lastTimestamp*NsInS)
 		go func() {
@@ -988,6 +1084,159 @@ blocksLoop:
 	c.sealingLock.Unlock()
 
 	return nil
+}
+
+func (c *DBFT) eventLoop() {
+events:
+	for {
+		select {
+		case <-c.quit:
+			c.dbft.Timer.Stop()
+			// TODO: subscription and unsubscription.
+			// c.chain.UnsubscribeFromBlocks(c.blockEvents)
+			break events
+		case <-c.dbft.Timer.C():
+			hv := c.dbft.Timer.HV()
+			log.Debug("timer fired",
+				"height", hv.Height,
+				"view", uint(hv.View))
+			c.dbft.OnTimeout(hv)
+		case msg := <-c.messages:
+			fields := []any{
+				"from", msg.message.ValidatorIndex,
+				"type", msg.Type().String(),
+			}
+
+			if msg.Type() == payload.RecoveryMessageType {
+				rec := msg.GetRecoveryMessage().(*recoveryMessage)
+				if rec.preparationHash == nil {
+					req := rec.GetPrepareRequest(&msg, c.dbft.Validators, uint16(c.dbft.PrimaryIndex))
+					if req != nil {
+						h := req.Hash()
+						rec.preparationHash = &h
+					}
+				}
+
+				fields = append(fields,
+					"#preparation", len(rec.preparationPayloads),
+					"#commit", len(rec.commitPayloads),
+					"#changeview", len(rec.changeViewPayloads),
+					"#request", rec.prepareRequest != nil,
+					"#hash", rec.preparationHash != nil)
+			}
+
+			log.Debug("received message", fields...)
+			c.dbft.OnReceive(&msg)
+		case tx := <-c.transactions:
+			c.dbft.OnTransaction(&Transaction{Tx: tx})
+		case b := <-c.blockEvents:
+			c.handleChainBlock(b)
+		}
+		// Always process block event if there is any, we can add one above or external
+		// services can add several blocks during message processing.
+		var latestBlock *types.Block
+	syncLoop:
+		for {
+			select {
+			case latestBlock = <-c.blockEvents:
+			default:
+				break syncLoop
+			}
+		}
+		if latestBlock != nil {
+			c.handleChainBlock(latestBlock)
+		}
+	}
+drainLoop:
+	for {
+		select {
+		case <-c.messages:
+		case <-c.transactions:
+		case <-c.blockEvents:
+		default:
+			break drainLoop
+		}
+	}
+	close(c.messages)
+	close(c.transactions)
+	close(c.blockEvents)
+	close(c.finished)
+}
+
+// OnPayload handles Payload receive.
+func (c *DBFT) OnPayload(cp *dbftproto.Message) error {
+	p := c.payloadFromMessage(cp)
+	// decode payload data into message
+	if err := p.decodeData(); err != nil {
+		log.Info("can't decode payload data", "hash", cp.Hash(), "error", err)
+		return nil
+	}
+
+	if !c.validatePayload(p) {
+		log.Info("can't validate payload", "hash", cp.Hash())
+		return nil
+	}
+
+	if c.dbft == nil || !c.dbftStarted.Load() {
+		log.Debug("dbft is inactive or not started yet", "hash", cp.Hash())
+		return nil
+	}
+
+	c.messages <- *p
+	return nil
+}
+
+func (s *DBFT) payloadFromMessage(ep *dbftproto.Message) *Payload {
+	return &Payload{
+		Message: *ep,
+		message: message{},
+	}
+}
+
+func (c *DBFT) validatePayload(p *Payload) bool {
+	h := c.chain.CurrentHeader()
+	validators, err := c.getNextBlockValidators(h.Hash(), h.Number.Uint64(), false)
+	if err != nil {
+		return false
+	}
+	if int(p.message.ValidatorIndex) >= len(validators) {
+		return false
+	}
+
+	val := validators[p.message.ValidatorIndex]
+	return p.Sender == val
+}
+
+func (c *DBFT) newPayload(ctx *dbft.Context, t payload.MessageType, msg any) payload.ConsensusPayload {
+	cp := &Payload{}
+	cp.SetHeight(ctx.BlockIndex)
+	cp.SetValidatorIndex(uint16(ctx.MyIndex))
+	cp.SetViewNumber(ctx.ViewNumber)
+	cp.SetType(t)
+	if pr, ok := msg.(*prepareRequest); ok {
+		// TODO: take values from local context OR ensure that all dbft's context values set porperly!
+		pr.SetPrevHash(c.dbft.PrevHash)
+		pr.SetVersion(c.dbft.Version)
+	}
+	cp.SetPayload(msg)
+
+	cp.Message.ValidBlockStart = 0
+	cp.Message.ValidBlockEnd = uint64(ctx.BlockIndex)
+	cp.Message.Sender = ctx.Validators[ctx.MyIndex].(*PublicKey).Account
+
+	return cp
+}
+
+func (c *DBFT) handleChainBlock(b *types.Block) {
+	// We can get our own block here, so check for index.
+	if uint32(b.Number().Uint64()) >= c.dbft.BlockIndex {
+		log.Debug("new block in the chain",
+			"dbft index", c.dbft.BlockIndex,
+			"chain index", c.chain.CurrentHeader().Number.Uint64())
+		c.postBlock(b)
+		// No dBFT initialisation, leave this to Seal, as we don't have new proposal here anyway.
+		// c.dbft.InitializeConsensus(0, b.Timestamp*nsInMs)
+	}
 }
 
 // CalcDifficulty is the difficulty adjustment algorithm. It returns the difficulty

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -356,7 +356,7 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 				// The block might already be added via the regular network
 				// interaction.
 				if h := c.chain.GetHeaderByNumber(res.Number().Uint64()); h == nil {
-					log.Warn("error on enqueue block", zap.Error(err))
+					log.Warn("error on enqueue block", "error", err.Error())
 				}
 			}
 

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -172,7 +172,9 @@ func getSignersAndSigs(cfg *params.DBFTConfig, extra []byte) ([]common.Address, 
 		return nil, nil, errMissingSignature
 	}
 
-	// Recover Ethereum addresses of validators and their signatures.
+	// Recover Ethereum addresses of validators and their signatures, preserve
+	// the order that was specified in the source extra, because validators are
+	// sorted and NextConsensus depends on it.
 	var (
 		addrs = make([]common.Address, n)
 		sigs  = make([][]byte, m)

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -351,10 +351,17 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 			if uint64(ethBlock.Index()) <= c.lastIndex { // TODO: lock lastIndex?
 				return
 			}
-			dBFTHeader := ethBlock.Header()
+
+			// Avoid copying and may safely change the block itself, as this part
+			// of code is guaranteed to be called once thanks to condition above,
+			// c.lastIndex is updated in postBlock callback every time new block
+			// with higher index is accepted.
+			dBFTHeader := ethBlock.header
 			dBFTHeader.Extra = append(dBFTHeader.Extra, c.getBlockWitness()...) // extraVanity isn't changed, validators addresses and signatures are added.
-			// Completely replace block proposed by miner with the dBFT's one and relay it to the network.
-			res := ethBlock.WithSeal(dBFTHeader)
+
+			res := types.NewBlockWithHeader(ethBlock.header)
+			// Uncles are always nil in dBFT-like consensus.
+			res = res.WithBody(ethBlock.transactions, nil)
 
 			// Firstly, allow new sealing tasks in order to avoid race between isSealing
 			// update and incoming new task after new block persist.
@@ -370,20 +377,13 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 			}
 		}),
 		dbft.WithNewBlockFromContext(func(ctx *dbft.Context) block.Block {
-			var (
-				proposal *types.Header
-				receipts []*types.Receipt
-			)
-			c.sealingLock.RLock()
-			if c.sealingProposal == nil {
-				// Program bug.
-				panic("can't create new block from context: sealing proposal is not initialized")
+			prepareReq := ctx.PreparationPayloads[ctx.PrimaryIndex]
+			if prepareReq == nil {
+				panic("can't create new block from context: prepare request is nil")
 			}
-			proposal = c.sealingProposal
-			receipts = c.sealingReceipts
-			c.sealingLock.RUnlock()
-
-			h := types.CopyHeader(proposal)
+			proposal := prepareReq.GetPrepareRequest().(*prepareRequest)
+			// Avoid changing PrepareRequest itself.
+			h := types.CopyHeader(proposal.SealingProposal)
 
 			// BlockIndex -> Number
 			h.Number = big.NewInt(int64(ctx.BlockIndex))
@@ -398,13 +398,15 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 			}
 			h.MixDigest = dbftutil.GetNextConsensusHash(nextVals)
 
-			txs := make([]*types.Transaction, len(ctx.Transactions))
-			for i, txH := range ctx.TransactionHashes {
-				txs[i] = ctx.Transactions[txH].(*Transaction).Tx
-			}
-
+			// Do not fill block's transactions. First of all, transactions are not
+			// needed for block signing or block signature verification. Secondly, some
+			// transactions may be missing by the moment of call to NewBlockFromContext
+			// (dBFT has only the full set of their hashes). Once all transactions are
+			// fetched and the commits are collected, SetTransactions callback will be
+			// called by dBFT library to properly initialize block's transactions.
 			return &Block{
-				Block: types.NewBlock(h, txs, nil, receipts, trie.NewStackTrie(nil)),
+				header:   h,
+				receipts: proposal.SealingReceipts,
 			}
 		}),
 		dbft.WithWatchOnly(func() bool {

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -264,6 +264,11 @@ type sealingInfo struct {
 func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 	// Set any missing consensus parameters to their defaults
 	conf := *config
+	// Sort validators once to reuse the sorted list in getNextConsensus.
+	// Do not change configured committee.
+	conf.StandByCommittee = make([]common.Address, len(conf.StandByCommittee))
+	copy(conf.StandByCommittee, config.StandByCommittee)
+	slices.SortFunc(conf.StandByCommittee, common.Address.Cmp)
 	// Allocate the snapshot caches and create the engine
 	recents := lru.NewCache[common.Hash, *Snapshot](inmemorySnapshots)
 	signatures := lru.NewCache[common.Hash, common.Address](inmemorySignatures)
@@ -284,6 +289,10 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 
 		quit:     make(chan struct{}),
 		finished: make(chan struct{}),
+
+		// Temporary omit difficulty checks, as currently we don't have proper mapping from
+		// dBFT primary to difficulty calculations.
+		fakeDiff: true,
 	}
 
 	logger, _ := zap.NewDevelopment()
@@ -344,9 +353,6 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 				panic(fmt.Errorf("failed to create snapshot while retrieving Validators: %w", err))
 			}
 			res := make([]dbftCrypto.PublicKey, len(pKeys))
-			// Once signers are properly fetched from the Neo contract, we need to
-			// sort them so that dBFT can rely on the validator's index. Currently,
-			// they are sorted in ascending order.
 			for i, s := range pKeys {
 				res[i] = &PublicKey{
 					Account: s,
@@ -507,7 +513,7 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 				if savedGrandparent == nil {
 					return errors.New("failed to verify parent: failed to retrieve grandparent from storage")
 				}
-				err := c.verifyExtra(savedGrandparent.Header().NextConsensus(), req.ParentSealHash, req.ParentExtra)
+				_, err := c.verifyExtra(req.ParentSealHash, req.ParentExtra, savedGrandparent.Header().NextConsensus())
 				if err != nil {
 					return fmt.Errorf("invalid parent: parent's witness verification failed: %w", err)
 				}
@@ -570,7 +576,7 @@ func (c *DBFT) getBlockWitness() []byte {
 	dctx := c.dbft.Context
 
 	// Validators sorting order is guaranteed by governance contract, they are sorted
-	// by their vote's weight, thus, no additional sorting here.
+	// by bytes order, thus, no additional sorting here.
 	vals := make([]common.Address, len(dctx.Validators))
 	for i := range dctx.Validators {
 		vals[i] = dctx.Validators[i].(*PublicKey).Account
@@ -586,7 +592,6 @@ func (c *DBFT) getBlockWitness() []byte {
 	m := c.dbft.Context.M()
 
 	// Signatures sorting order is the same as corresponding *sorted* validators order.
-	slices.SortFunc(vals, common.Address.Cmp)
 	for i, j := 0, 0; i < len(vals) && j < m; i++ {
 		if sig, ok := sigs[vals[i]]; ok {
 			res = append(res, sig...)
@@ -886,42 +891,39 @@ func (c *DBFT) verifySeal(snap *Snapshot, header *types.Header, parents []*types
 	if number == 0 {
 		return errUnknownBlock
 	}
-	err := c.verifyExtra(parent.NextConsensus(), HonestSealHash(header), header.Extra)
+	vals, err := c.verifyExtra(HonestSealHash(header), header.Extra, parent.NextConsensus())
 	if err != nil {
 		return fmt.Errorf("invalid Extra: %w", err)
 	}
-	/*
-		// TODO: get rid of difficulty?
-		// Ensure that the difficulty corresponds to the turn-ness of the signer
-		if !c.fakeDiff {
-			signer := vals[header.Primary()]
-			inturn := snap.inturn(header.Number.Uint64(), signer)
-			if inturn && header.Difficulty.Cmp(diffInTurn) != 0 {
-				return errWrongDifficulty
-			}
-			if !inturn && header.Difficulty.Cmp(diffNoTurn) != 0 {
-				return errWrongDifficulty
-			}
+	// Ensure that the difficulty corresponds to the turn-ness of the signer
+	if !c.fakeDiff {
+		signer := vals[header.Primary()]
+		inturn := snap.inturn(header.Number.Uint64(), signer)
+		if inturn && header.Difficulty.Cmp(diffInTurn) != 0 {
+			return errWrongDifficulty
 		}
-	*/
+		if !inturn && header.Difficulty.Cmp(diffNoTurn) != 0 {
+			return errWrongDifficulty
+		}
+	}
 	return nil
 }
 
-func (c *DBFT) verifyExtra(parentNextConsensus common.Hash, honestSealHash common.Hash, extra []byte) error {
+func (c *DBFT) verifyExtra(sealHash common.Hash, extra []byte, parentNextConsensus common.Hash) ([]common.Address, error) {
 	// Resolve the authorization key and check against signers.
 	vals, sigs, err := getSignersAndSigs(c.config, extra)
 	if err != nil {
-		return fmt.Errorf("failed to retrieve validators and signatures from header: %w", err)
+		return nil, fmt.Errorf("failed to retrieve validators and signatures from header: %w", err)
 	}
 	nextConsensus := dbftutil.GetNextConsensusHash(vals)
 	if parentNextConsensus != nextConsensus {
-		return fmt.Errorf("invalid NextConsensus retrieved from validators addresses: expected %s, got %s", parentNextConsensus, nextConsensus)
+		return nil, fmt.Errorf("invalid NextConsensus retrieved from validators addresses: expected %s, got %s", parentNextConsensus, nextConsensus)
 	}
-	err = crypto.VerifyMultiBFT(honestSealHash.Bytes(), vals, sigs)
+	err = crypto.VerifyMultiBFT(sealHash.Bytes(), vals, sigs)
 	if err != nil {
-		return fmt.Errorf("%w: %s", errUnauthorizedSigner, err)
+		return nil, fmt.Errorf("%w: %s", errUnauthorizedSigner, err)
 	}
-	return nil
+	return vals, nil
 }
 
 // Prepare implements consensus.Engine, preparing all the consensus fields of the
@@ -1460,7 +1462,8 @@ func (c *DBFT) APIs(chain consensus.ChainHeaderReader) []rpc.API {
 // a NextConsensus address for the next block accepted after block with blockHash
 // hash and blockNum height (if compute is true). It also returns validators of
 // the currently processing blocks to properly initialize dBFT context's Validators
-// field (if compute is false).
+// field (if compute is false). Validators returned from this method are always expected
+// to be sorted by bytes order (even if returned from governance contract).
 func (c *DBFT) getNextBlockValidators(blockHash common.Hash, blockNum uint64, compute bool) ([]common.Address, error) {
 	// Currently we don't have governance contract, thus, always return standby set.
 	if true {

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1187,7 +1187,7 @@ func (c *DBFT) OnPayload(cp *dbftproto.Message) error {
 	}
 
 	if c.dbft == nil || !c.dbftStarted.Load() {
-		log.Debug("dbft is inactive or not started yet", "hash", cp.Hash())
+		log.Info("dbft is inactive or not started yet", "hash", cp.Hash())
 		return nil
 	}
 

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -212,7 +212,7 @@ type DBFT struct {
 
 	dbft        *dbft.DBFT
 	dbftStarted atomic.Bool
-	blockQueue  chan *Block
+	blockQueue  *blockQueue
 
 	// lastTimestamp, lastIndex and lastBlockHash are updated on every new header
 	// received from dBFT or from chain. These fields have exactly those type
@@ -262,12 +262,12 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 		recents:    recents,
 		signatures: signatures,
 		proposals:  make(map[common.Address]bool),
+		blockQueue: newBlockQueue(),
 		quit:       make(chan struct{}),
 		finished:   make(chan struct{}),
 	}
 
 	logger, _ := zap.NewDevelopment()
-	c.blockQueue = make(chan *Block)
 	c.messages = make(chan Payload, 100)
 	c.dbft = dbft.New(
 		dbft.WithLogger(logger),
@@ -338,11 +338,23 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 		}),
 		dbft.WithProcessBlock(func(b block.Block) {
 			ethBlock := b.(*Block)
-			ethBlock.changeableExtra = c.getBlockWitness()
+			if uint64(ethBlock.Index()) <= c.lastIndex { // TODO: lock lastIndex?
+				return
+			}
+			dBFTHeader := ethBlock.Header()
+			dBFTHeader.Extra = append(dBFTHeader.Extra, c.getBlockWitness()...) // extraVanity isn't changed, validators addresses and signatures are added.
+			// Completely replace block proposed by miner with the dBFT's one and relay it to the network.
+			res := ethBlock.WithSeal(dBFTHeader)
 
-			c.blockQueue <- ethBlock
-			// Do not call postBlock here to avoid race between the next pending sealing request that
-			// wants to update the same values as postBlock. Call postBlock in Seal instead.
+			if err := c.blockQueue.PutBlock(res); err != nil {
+				// The block might already be added via the regular network
+				// interaction.
+				if h := c.chain.GetHeaderByNumber(res.Number().Uint64()); h == nil {
+					log.Warn("error on enqueue block", zap.Error(err))
+				}
+			}
+
+			c.postBlock(res)
 		}),
 		dbft.WithNewBlockFromContext(func(ctx *dbft.Context) block.Block {
 			var (
@@ -545,6 +557,7 @@ func (c *DBFT) postBlock(b *types.Block) {
 		c.lastBlockExtra = h.Extra
 
 		c.sealingLock.Lock()
+		c.isSealing = false
 		c.sealingProposal = nil
 		c.sealingReceipts = nil
 		c.sealingTransactions = nil
@@ -957,7 +970,7 @@ func (c *DBFT) Initialize(chain consensus.ChainHeaderReader) {
 
 	// Do not start consensus immediately, we don't yet have sealing work.
 	// Start it once we have new sealing work in Seal.
-	c.dbft.InitializeConsensus(0, c.lastTimestamp*NsInS)
+	// c.dbft.InitializeConsensus(0, c.lastTimestamp*NsInS)
 }
 
 // Seal implements consensus.Engine, attempting to create a sealed block using
@@ -1040,56 +1053,19 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 		}
 	}
 
+	err = c.blockQueue.SubmitTask(sealingHash, results, stop)
+	if err != nil {
+		return fmt.Errorf("failed to submit sealing task to dBFT: %w", err)
+	}
+
 	// Start dBFT once and afterward reinitialize it every time new block should be accepted.
 	if c.dbftStarted.CompareAndSwap(false, true) {
-		go c.dbft.Start(c.lastTimestamp * NsInS) // TODO: not in a separate loop?
+		c.dbft.Start(c.lastTimestamp * NsInS)
+
 		go c.eventLoop()
 	} else {
 		c.dbft.InitializeConsensus(0, c.lastTimestamp*NsInS)
-		go func() {
-			<-c.dbft.Timer.C()
-			hv := c.dbft.Timer.HV()
-			log.Info("dBFT timer fired",
-				"height", hv.Height,
-				"view", uint(hv.View))
-			c.dbft.OnTimeout(hv)
-		}()
 	}
-
-	var (
-		sigBytes  []byte
-		dBFTBlock *types.Block
-	)
-blocksLoop:
-	for {
-		select {
-		case n3B := <-c.blockQueue:
-			if uint64(n3B.Index()) <= c.lastIndex {
-				continue blocksLoop
-			}
-			sigBytes = n3B.changeableExtra
-			dBFTBlock = n3B.Block // this block is completely different from the one that FinalizeAndAssemble proposed.
-			break blocksLoop
-		}
-	}
-	dBFTHeader := dBFTBlock.Header()
-	dBFTHeader.Extra = append(dBFTHeader.Extra, sigBytes...) // extraVanity isn't changed, validators addresses and signatures are added.
-
-	// Completely replace proposed block with dBFT's one and relay it to the network.
-	res := dBFTBlock.WithSeal(dBFTHeader)
-	c.postBlock(res)
-
-	// Seal interrupt is not possible with dBFT, thus, ignore stop channel and don't
-	// wait for any delay, because dBFT provides proper block timing.
-	select {
-	case results <- res:
-	default:
-		log.Warn("Sealing result is not read by miner", "sealhash", WorkerSealHash(dBFTHeader))
-	}
-
-	c.sealingLock.Lock()
-	c.isSealing = false
-	c.sealingLock.Unlock()
 
 	return nil
 }

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -192,7 +192,7 @@ type DBFT struct {
 	messages chan Payload
 
 	// various chain/mempool events and subscription management:
-	blockEvents  chan core.ChainHeadEvent
+	blockEvents  chan core.ChainHeadEvent // TODO: review the subscription type, maybe we need to subscribe not to Head, but to some other event. It depends on forks.
 	txpool       txPool
 	txsSub       event.Subscription
 	transactions chan core.NewTxsEvent
@@ -267,7 +267,7 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 
 		messages:     make(chan Payload, 100),
 		transactions: make(chan core.NewTxsEvent, 100),
-		blockEvents:  make(chan core.ChainHeadEvent),
+		blockEvents:  make(chan core.ChainHeadEvent, 1),
 		newtask:      make(chan struct{}),
 
 		quit:     make(chan struct{}),

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1068,7 +1068,7 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 		return errUnauthorizedSigner
 	}
 
-	err = c.blockQueue.SubmitTask(sealingHash, results, stop)
+	err = c.blockQueue.SubmitTask(sealingHash, b.NumberU64(), results, stop)
 	if err != nil {
 		return fmt.Errorf("failed to submit sealing task to dBFT: %w", err)
 	}

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1312,7 +1312,6 @@ func (c *DBFT) handleChainBlock(b *types.Block) {
 			"chain index", c.chain.CurrentHeader().Number.Uint64())
 		c.postBlock(b)
 		// No dBFT initialisation, leave this to Seal, as we don't have new proposal here anyway.
-		// c.dbft.InitializeConsensus(0, b.Timestamp*nsInMs)
 	}
 }
 

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -86,7 +86,11 @@ var (
 	diffNoTurn = big.NewInt(1) // Block difficulty for out-of-turn signatures
 )
 
-const extraSeal = crypto.SignatureLength // Fixed number of extra-data suffix bytes reserved for a single signer seal
+const (
+	extraSeal = crypto.SignatureLength // Fixed number of extra-data suffix bytes reserved for a single signer seal
+	// txSubCap is the capacity of channel that receives transaction notifications from mempool.
+	txSubCap = 100
+)
 
 // Various error messages to mark blocks invalid. These should be private to
 // prevent engine specific errors from being referenced in the remainder of the
@@ -266,7 +270,7 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 		blockQueue: newBlockQueue(),
 
 		messages:     make(chan Payload, 100),
-		transactions: make(chan core.NewTxsEvent, 100),
+		transactions: make(chan core.NewTxsEvent, txSubCap),
 		blockEvents:  make(chan core.ChainHeadEvent, 1),
 		newtask:      make(chan struct{}),
 
@@ -410,10 +414,27 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 		dbft.WithWatchOnly(func() bool {
 			return false
 		}),
+		dbft.WithGetTx(func(h util.Uint256) block.Transaction {
+			var hash common.Hash
+			hash.SetUint256(h)
+			tx := c.txpool.Get(hash)
+			// This check is needed, because in case of missing transaction dBFT
+			// expects a pure nil.
+			if tx != nil {
+				return &Transaction{
+					Tx: tx,
+				}
+			}
+
+			// Do not try to retrieve on-chain transaction.
+			return nil
+		}),
 		dbft.WithGetVerified(func() []block.Transaction {
 			var txs types.Transactions
 			c.sealingLock.RLock()
-			if c.sealingProposal == nil { // check the proposal, because c.sealingTransactions may be nil in case of empty transactions list.
+			// Check the sealing proposal, because c.sealingTransactions may be nil
+			// in case of missing pending transactions, and it's OK.
+			if c.sealingProposal == nil {
 				// Program bug.
 				panic("missing pending sealing work")
 			}
@@ -428,6 +449,9 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 			}
 			return res
 		}),
+		dbft.WithRequestTx(func(h ...util.Uint256) {
+			// TODO: integrate with transaction fetcher.
+		}),
 		dbft.WithGetConsensusAddress(func(keys ...dbftCrypto.PublicKey) util.Uint160 {
 			// NextConsensus is filled manually in NewBlockFromContext.
 			return util.Uint160{}
@@ -439,13 +463,15 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 			if c.sealingProposal == nil {
 				panic("bug: sealing proposal is not initialized")
 			}
+			// Fill in only proposal and receipts, transactions will be properly
+			// set from context later in SetTransactionHashes callback.
 			req.SealingProposal = c.sealingProposal
 			req.SealingReceipts = c.sealingReceipts
 			c.sealingLock.RUnlock()
 
 			req.ParentSealHash = c.lastBlockSealHash
 			req.ParentExtra = c.lastBlockExtra
-			req.TxHashes = make([]util.Uint256, 0)
+
 			return req
 		}),
 		dbft.WithNewCommit(func() payload.Commit { return new(commit) }),

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -398,10 +398,6 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 			}
 			h.MixDigest = dbftutil.GetNextConsensusHash(nextVals)
 
-			// PrevHash -> ParentHash
-			// TODO: don't pay attention to context's hash, we have it in the sealing proposal.
-			// h.ParentHash.SetBytes(ctx.PrevHash.BytesBE())
-
 			txs := make([]*types.Transaction, len(ctx.Transactions))
 			for i, txH := range ctx.TransactionHashes {
 				txs[i] = ctx.Transactions[txH].(*Transaction).Tx

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -277,7 +277,7 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 
 		messages:     make(chan Payload, 100),
 		transactions: make(chan core.NewTxsEvent, txSubCap),
-		blockEvents:  make(chan core.ChainHeadEvent, 1),
+		blockEvents:  make(chan core.ChainHeadEvent, 2),
 		sealingTask:  make(chan sealingInfo),
 
 		quit:     make(chan struct{}),

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -39,12 +39,14 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/dbft/dbftutil"
 	"github.com/ethereum/go-ethereum/consensus/misc"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/systemcontracts"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	dbftproto "github.com/ethereum/go-ethereum/eth/protocols/dbft"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -193,9 +195,11 @@ type DBFT struct {
 	service  *dbftproto.Service
 	messages chan Payload
 
-	// TODO: properly integrate chain.
-	transactions chan *types.Transaction
-	blockEvents  chan *types.Block
+	// various chain/mempool events and subscription management:
+	blockEvents  chan core.ChainHeadEvent
+	txpool       txPool
+	txsSub       event.Subscription
+	transactions chan core.NewTxsEvent
 
 	config *params.DBFTConfig // Consensus engine configuration parameters
 	epoch  uint64             // Epoch duration left for backwards compatibility.
@@ -234,7 +238,7 @@ type DBFT struct {
 	sealingTransactions types.Transactions
 
 	// chain instance needed for proper dBFT callbacks functioning.
-	chain    consensus.ChainHeaderReader
+	chain    ChainHeaderReader
 	quit     chan struct{}
 	finished chan struct{}
 
@@ -263,12 +267,16 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 		signatures: signatures,
 		proposals:  make(map[common.Address]bool),
 		blockQueue: newBlockQueue(),
-		quit:       make(chan struct{}),
-		finished:   make(chan struct{}),
+
+		messages:     make(chan Payload, 100),
+		transactions: make(chan core.NewTxsEvent, 100),
+		blockEvents:  make(chan core.ChainHeadEvent),
+
+		quit:     make(chan struct{}),
+		finished: make(chan struct{}),
 	}
 
 	logger, _ := zap.NewDevelopment()
-	c.messages = make(chan Payload, 100)
 	c.dbft = dbft.New(
 		dbft.WithLogger(logger),
 		dbft.WithSecondsPerBlock(time.Duration(conf.SecondsPerBlock)*time.Second),
@@ -542,6 +550,10 @@ func (c *DBFT) SetEthAPI(api *ethapi.BlockChainAPI) {
 
 func (c *DBFT) SetService(srv *dbftproto.Service) {
 	c.service = srv
+}
+
+func (c *DBFT) SetTxPool(pool txPool) {
+	c.txpool = pool
 }
 
 // postBlock is a callback that updates latest accepted block data and resets
@@ -958,7 +970,7 @@ func (c *DBFT) Authorize(signer common.Address, signFn SignerFn) {
 	c.signFn = signFn
 }
 
-func (c *DBFT) Initialize(chain consensus.ChainHeaderReader) {
+func (c *DBFT) Initialize(chain ChainHeaderReader) {
 	c.chain = chain
 
 	currHeader := chain.CurrentHeader()
@@ -1062,6 +1074,10 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 	if c.dbftStarted.CompareAndSwap(false, true) {
 		c.dbft.Start(c.lastTimestamp * NsInS)
 
+		// Subscribe for minted blocks and transactions from mempool.
+		c.txsSub = c.txpool.SubscribeNewTxsEvent(c.transactions)
+		c.chain.SubscribeChainHeadEvent(c.blockEvents)
+
 		go c.eventLoop()
 	} else {
 		c.dbft.InitializeConsensus(0, c.lastTimestamp*NsInS)
@@ -1111,14 +1127,17 @@ events:
 
 			log.Debug("received message", fields...)
 			c.dbft.OnReceive(&msg)
-		case tx := <-c.transactions:
-			c.dbft.OnTransaction(&Transaction{Tx: tx})
+		case txs := <-c.transactions:
+			// TODO: we likely need to filter some of them out.
+			for _, tx := range txs.Txs {
+				c.dbft.OnTransaction(&Transaction{Tx: tx})
+			}
 		case b := <-c.blockEvents:
-			c.handleChainBlock(b)
+			c.handleChainBlock(b.Block)
 		}
 		// Always process block event if there is any, we can add one above or external
 		// services can add several blocks during message processing.
-		var latestBlock *types.Block
+		var latestBlock core.ChainHeadEvent
 	syncLoop:
 		for {
 			select {
@@ -1127,8 +1146,8 @@ events:
 				break syncLoop
 			}
 		}
-		if latestBlock != nil {
-			c.handleChainBlock(latestBlock)
+		if latestBlock.Block != nil {
+			c.handleChainBlock(latestBlock.Block)
 		}
 	}
 drainLoop:

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1222,11 +1222,6 @@ func (c *DBFT) newPayload(ctx *dbft.Context, t payload.MessageType, msg any) pay
 	cp.SetValidatorIndex(uint16(ctx.MyIndex))
 	cp.SetViewNumber(ctx.ViewNumber)
 	cp.SetType(t)
-	if pr, ok := msg.(*prepareRequest); ok {
-		// TODO: take values from local context OR ensure that all dbft's context values set porperly!
-		pr.SetPrevHash(c.dbft.PrevHash)
-		pr.SetVersion(c.dbft.Version)
-	}
 	cp.SetPayload(msg)
 
 	cp.Message.ValidBlockStart = 0

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -354,7 +354,7 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 		}),
 		dbft.WithProcessBlock(func(b block.Block) {
 			ethBlock := b.(*Block)
-			if uint64(ethBlock.Index()) <= c.lastIndex { // TODO: lock lastIndex?
+			if uint64(ethBlock.Index()) <= c.lastIndex {
 				return
 			}
 
@@ -520,9 +520,8 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 					}
 				}
 
-				// TODO: lock it?
 				c.lastBlockHash = req.SealingProposal.ParentHash
-				c.dbft.PrevHash = req.SealingProposal.ParentHash.Uint256() // this may be skipped, we don't use context's prevHash.
+				c.dbft.PrevHash = req.SealingProposal.ParentHash.Uint256()
 			}
 			// Save lastProposal for getVerified().
 			// c.lastProposal = req.TxHashes

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -217,7 +217,7 @@ type DBFT struct {
 	dbft        *dbft.DBFT
 	dbftStarted atomic.Bool
 	blockQueue  *blockQueue
-	newtask     chan struct{}
+	sealingTask chan sealingInfo
 
 	// lastTimestamp, lastIndex and lastBlockHash are updated on every new header
 	// received from dBFT or from chain. These fields have exactly those type
@@ -251,6 +251,12 @@ type DBFT struct {
 	fakeDiff bool // Skip difficulty verifications
 }
 
+type sealingInfo struct {
+	number      uint64
+	sealingHash common.Hash
+	parentHash  common.Hash
+}
+
 // New creates a DBFT proof-of-authority consensus engine with the initial
 // signers set to the ones provided by the user.
 func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
@@ -272,7 +278,7 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 		messages:     make(chan Payload, 100),
 		transactions: make(chan core.NewTxsEvent, txSubCap),
 		blockEvents:  make(chan core.ChainHeadEvent, 1),
-		newtask:      make(chan struct{}),
+		sealingTask:  make(chan sealingInfo),
 
 		quit:     make(chan struct{}),
 		finished: make(chan struct{}),
@@ -1035,8 +1041,8 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 		return fmt.Errorf("stale sealing task: invalid Number: expected %d, got %d", c.lastIndex+1, b.NumberU64())
 	}
 	if b.ParentHash().Cmp(c.lastBlockHash) != 0 {
-		// TODO: compare seal hash and check new witnesses provided by PrepareRequest then (if exists).
-		// If matches, then it's not an error.
+		// Deviation from latest saved lastBlockHash is not allowed, otherwise it may lead
+		// to multiple dBFT proposals for the same height, which will break the consensus.
 		c.sealingLock.Unlock()
 		return fmt.Errorf("stale sealing task: invalid ParentHash: expected %s, got %s", c.lastBlockHash, b.ParentHash())
 	}
@@ -1110,7 +1116,11 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 		c.dbft.InitializeConsensus(0, c.lastTimestamp*NsInS)
 	}
 
-	c.newtask <- struct{}{}
+	c.sealingTask <- sealingInfo{
+		number:      b.NumberU64(),
+		sealingHash: sealingHash,
+		parentHash:  b.ParentHash(),
+	}
 	return nil
 }
 
@@ -1129,8 +1139,12 @@ events:
 				"height", hv.Height,
 				"view", uint(hv.View))
 			c.dbft.OnTimeout(hv)
-		case <-c.newtask:
-
+		case t := <-c.sealingTask:
+			log.Info("Start dBFT process for new sealing work",
+				"number", t.number,
+				"sealhash", t.sealingHash,
+				"prev", t.parentHash,
+			)
 		case msg := <-c.messages:
 			fields := []any{
 				"from", msg.message.ValidatorIndex,

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -217,6 +217,7 @@ type DBFT struct {
 	dbft        *dbft.DBFT
 	dbftStarted atomic.Bool
 	blockQueue  *blockQueue
+	newtask     chan struct{}
 
 	// lastTimestamp, lastIndex and lastBlockHash are updated on every new header
 	// received from dBFT or from chain. These fields have exactly those type
@@ -271,6 +272,7 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 		messages:     make(chan Payload, 100),
 		transactions: make(chan core.NewTxsEvent, 100),
 		blockEvents:  make(chan core.ChainHeadEvent),
+		newtask:      make(chan struct{}),
 
 		quit:     make(chan struct{}),
 		finished: make(chan struct{}),
@@ -1083,6 +1085,7 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 		c.dbft.InitializeConsensus(0, c.lastTimestamp*NsInS)
 	}
 
+	c.newtask <- struct{}{}
 	return nil
 }
 
@@ -1101,6 +1104,8 @@ events:
 				"height", hv.Height,
 				"view", uint(hv.View))
 			c.dbft.OnTimeout(hv)
+		case <-c.newtask:
+
 		case msg := <-c.messages:
 			fields := []any{
 				"from", msg.message.ValidatorIndex,

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -90,6 +90,9 @@ const (
 	extraSeal = crypto.SignatureLength // Fixed number of extra-data suffix bytes reserved for a single signer seal
 	// txSubCap is the capacity of channel that receives transaction notifications from mempool.
 	txSubCap = 100
+	// msgsChCap is a capacity of channel that accepts consensus messages from
+	// dBFT protocol.
+	msgsChCap = 100
 )
 
 // Various error messages to mark blocks invalid. These should be private to
@@ -284,7 +287,7 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 		proposals:  make(map[common.Address]bool),
 		blockQueue: newBlockQueue(),
 
-		messages:        make(chan Payload, 100),
+		messages:        make(chan Payload, msgsChCap),
 		txEvents:        make(chan core.NewTxsEvent, txSubCap),
 		chainHeadEvents: make(chan core.ChainHeadEvent, 2),
 		sealingTask:     make(chan sealingInfo),

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -596,8 +596,8 @@ func (c *DBFT) getBlockWitness() []byte {
 	return res
 }
 
-// SetEthAPI initializes Eth blockchain API for proper consensus module work.
-func (c *DBFT) SetEthAPI(api *ethapi.BlockChainAPI) {
+// WithEthAPI initializes Eth blockchain API for proper consensus module work.
+func (c *DBFT) WithEthAPI(api *ethapi.BlockChainAPI) {
 	c.ethAPI = api
 }
 
@@ -606,7 +606,9 @@ func (c *DBFT) WithBroadcast(f func(m *dbftproto.Message) error) {
 	c.broadcast = f
 }
 
-func (c *DBFT) SetTxPool(pool txPool) {
+// WithTxPool initializes transaction pool API for DBFT interactions with memory pool
+// (fetching unknown transactions).
+func (c *DBFT) WithTxPool(pool txPool) {
 	c.txpool = pool
 }
 

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -352,6 +352,11 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 			// Completely replace block proposed by miner with the dBFT's one and relay it to the network.
 			res := ethBlock.WithSeal(dBFTHeader)
 
+			// Firstly, allow new sealing tasks in order to avoid race between isSealing
+			// update and incoming new task after new block persist.
+			c.postBlock(res)
+
+			// After that notify chain about new block.
 			if err := c.blockQueue.PutBlock(res); err != nil {
 				// The block might already be added via the regular network
 				// interaction.
@@ -359,8 +364,6 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 					log.Warn("error on enqueue block", "error", err.Error())
 				}
 			}
-
-			c.postBlock(res)
 		}),
 		dbft.WithNewBlockFromContext(func(ctx *dbft.Context) block.Block {
 			var (

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -969,8 +969,9 @@ func (c *DBFT) Authorize(signer common.Address, signFn SignerFn) {
 	c.signFn = signFn
 }
 
-func (c *DBFT) Initialize(chain ChainHeaderReader) {
+func (c *DBFT) Initialize(chain ChainHeaderWriter) {
 	c.chain = chain
+	c.blockQueue.chain = chain
 
 	currHeader := chain.CurrentHeader()
 	c.lastIndex = currHeader.Number.Uint64()

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1058,16 +1058,6 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 		return errUnauthorizedSigner
 	}
 
-	// If we're amongst the recent signers, wait for the next block
-	for seen, recent := range snap.Recents {
-		if recent == signer {
-			// Signer is among recents, only wait if the current block doesn't shift it out
-			if limit := uint64(len(snap.Signers)/2 + 1); number < limit || seen > number-limit {
-				return errors.New("signed recently, must wait for others")
-			}
-		}
-	}
-
 	err = c.blockQueue.SubmitTask(sealingHash, results, stop)
 	if err != nil {
 		return fmt.Errorf("failed to submit sealing task to dBFT: %w", err)

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1093,18 +1093,22 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 	signer, _ := c.signer, c.signFn
 	c.lock.RUnlock()
 
-	// Bail out if we're unauthorized to sign a block
-	// TODO: replace with validators-based check and then don't need a snapshot.
-	snap, err := c.snapshot(chain, number-1, header.ParentHash, nil)
+	// Check that the signer is included into validators of the currently accepting block.
+	// Do not run consensus for this block if we're not a consensus node.
+	vals, err := c.getNextBlockValidators(header.ParentHash, number-1, true)
 	if err != nil {
 		c.lastProposalLock.RUnlock()
 		c.sealingLock.Unlock()
-		return err
+		return fmt.Errorf("faield to retrieve next block validators: %w", err)
 	}
-
-	// This check is duplicated in dBFT.WithGetKeyPair, but here we still need to
-	// keep it in order not to run the consensus if we're not the consensus node.
-	if _, authorized := snap.Signers[signer]; !authorized {
+	var isAuthorized bool
+	for _, v := range vals {
+		if signer == v {
+			isAuthorized = true
+			break
+		}
+	}
+	if !isAuthorized {
 		c.lastProposalLock.RUnlock()
 		c.sealingLock.Unlock()
 		return errUnauthorizedSigner

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1043,7 +1043,6 @@ func (c *DBFT) Initialize(chain ChainHeaderWriter) {
 
 	// Do not start consensus immediately, we don't yet have sealing work.
 	// Start it once we have new sealing work in Seal.
-	// c.dbft.InitializeConsensus(0, c.lastTimestamp*NsInS)
 }
 
 // Seal implements consensus.Engine, attempting to create a sealed block using

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -419,8 +419,7 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 			// fetched and the commits are collected, SetTransactions callback will be
 			// called by dBFT library to properly initialize block's transactions.
 			return &Block{
-				header:   h,
-				receipts: proposal.SealingReceipts,
+				header: h,
 			}
 		}),
 		dbft.WithWatchOnly(func() bool {
@@ -477,7 +476,6 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 			// Fill in only proposal and receipts, transactions will be properly
 			// set from context later in SetTransactionHashes callback.
 			req.SealingProposal = c.sealingProposal
-			req.SealingReceipts = c.sealingReceipts
 			c.sealingLock.RUnlock()
 
 			req.ParentSealHash = c.lastBlockSealHash
@@ -544,7 +542,6 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 
 			c.isSealing = true
 			c.sealingProposal = req.SealingProposal
-			c.sealingReceipts = req.SealingReceipts
 
 			// Do not fill c.sealingTransactions. If the node is primary, then sealing txs must be
 			// properly filled by this moment from the new miner proposal in Seal (it happens even

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -440,12 +440,13 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 			if c.sealingProposal == nil {
 				panic("bug: sealing proposal is not initialized")
 			}
-			req.sealingProposal = c.sealingProposal
-			req.sealingReceipts = c.sealingReceipts
+			req.SealingProposal = c.sealingProposal
+			req.SealingReceipts = c.sealingReceipts
 			c.sealingLock.RUnlock()
 
-			req.parentSealHash = c.lastBlockSealHash
-			req.parentExtra = c.lastBlockExtra
+			req.ParentSealHash = c.lastBlockSealHash
+			req.ParentExtra = c.lastBlockExtra
+			req.TxHashes = make([]util.Uint256, 0)
 			return req
 		}),
 		dbft.WithNewCommit(func() payload.Commit { return new(commit) }),
@@ -456,22 +457,22 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 		dbft.WithVerifyPrepareResponse(func(_ payload.ConsensusPayload) error { return nil }),
 		dbft.WithVerifyPrepareRequest(func(p payload.ConsensusPayload) error {
 			req := p.GetPrepareRequest().(*prepareRequest)
-			if req.sealingProposal == nil {
+			if req.SealingProposal == nil {
 				return errors.New("invalid PrepareRequest: sealing proposal is nil")
 			}
-			if req.sealingProposal.ParentHash.Uint256() != c.dbft.PrevHash {
+			if req.SealingProposal.ParentHash.Uint256() != c.dbft.PrevHash {
 				if c.dbft.BlockIndex <= 1 { // genesis block  is hard-coded, thus its hash (as a parent hash) must match the one that prepareRequest declares as a parent hash.
-					return fmt.Errorf("invalid parent: expected %s, got %s", c.dbft.PrevHash, req.sealingProposal.ParentHash)
+					return fmt.Errorf("invalid parent: expected %s, got %s", c.dbft.PrevHash, req.SealingProposal.ParentHash)
 				}
-				if req.parentSealHash != c.lastBlockSealHash {
-					return fmt.Errorf("parent seal hash doesn't match the last block seal hash: expected %s, got %s", c.lastBlockSealHash, req.parentSealHash)
+				if req.ParentSealHash != c.lastBlockSealHash {
+					return fmt.Errorf("parent seal hash doesn't match the last block seal hash: expected %s, got %s", c.lastBlockSealHash, req.ParentSealHash)
 				}
 				// TODO: to properly verify newly-provided witness of the parent block we need to
 				// fetch parent's parent NextConsensus. Or instead (if supported) just push the newly-constructed
 				// block to the chain and it will deal with the verification by itself.
 				// For simplicity, consider it as valid.
 				/*
-					err := c.verifyExtra(parentParentNextConsensus, req.parentSealHash, req.parentExtra)
+					err := c.verifyExtra(parentParentNextConsensus, req.ParentSealHash, req.ParentExtra)
 					if err != nil {
 						return err
 					}
@@ -481,19 +482,19 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 				// choose the right chain.
 
 				// TODO: lock it?
-				c.lastBlockHash = req.sealingProposal.ParentHash
-				c.dbft.PrevHash = req.sealingProposal.ParentHash.Uint256() // this may be skipped, we don't use context's prevHash.
+				c.lastBlockHash = req.SealingProposal.ParentHash
+				c.dbft.PrevHash = req.SealingProposal.ParentHash.Uint256() // this may be skipped, we don't use context's prevHash.
 			}
 			// Save lastProposal for getVerified().
-			// c.lastProposal = req.transactionHashes
+			// c.lastProposal = req.TxHashes
 
 			// TODO: properly initialize the rest of dBFT context from prepareRequest
 			//  to be able to properly create commit.
 
 			c.sealingLock.Lock()
 			c.isSealing = true // TODO: get rid of this after moving dbft timer to a separate routine.
-			c.sealingProposal = req.sealingProposal
-			c.sealingReceipts = req.sealingReceipts
+			c.sealingProposal = req.SealingProposal
+			c.sealingReceipts = req.SealingReceipts
 			// c.sealingTransactions? we can't get them directly from prepare request, need to store hashes and then provide callback to mempool
 			c.sealingLock.Unlock()
 			return nil

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -152,10 +152,6 @@ var (
 
 	// errUnauthorizedSigner is returned if a header is signed by a non-authorized entity.
 	errUnauthorizedSigner = errors.New("unauthorized signer")
-
-	// errRecentlySigned is returned if a header is signed by an authorized entity
-	// that already signed a header recently, thus is temporarily not allowed to.
-	errRecentlySigned = errors.New("recently signed")
 )
 
 // getSignersAndSigs extracts the set of validators addresses (ValidatorsCount number of them)

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -197,10 +197,10 @@ type DBFT struct {
 	broadcast func(m *dbftproto.Message) error
 
 	// various chain/mempool events and subscription management:
-	blockEvents  chan core.ChainHeadEvent // TODO: review the subscription type, maybe we need to subscribe not to Head, but to some other event. It depends on forks.
-	txpool       txPool
-	txsSub       event.Subscription
-	transactions chan core.NewTxsEvent
+	chainHeadSub    event.Subscription
+	chainHeadEvents chan core.ChainHeadEvent
+	txSub           event.Subscription
+	txEvents        chan core.NewTxsEvent
 
 	config *params.DBFTConfig // Consensus engine configuration parameters
 	epoch  uint64             // Epoch duration left for backwards compatibility.
@@ -239,8 +239,9 @@ type DBFT struct {
 	sealingReceipts     []*types.Receipt
 	sealingTransactions types.Transactions
 
-	// chain instance needed for proper dBFT callbacks functioning.
+	// chain and mempool instances needed for proper dBFT callbacks functioning.
 	chain    ChainHeaderReader
+	txpool   txPool
 	quit     chan struct{}
 	finished chan struct{}
 
@@ -276,10 +277,10 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 		proposals:  make(map[common.Address]bool),
 		blockQueue: newBlockQueue(),
 
-		messages:     make(chan Payload, 100),
-		transactions: make(chan core.NewTxsEvent, txSubCap),
-		blockEvents:  make(chan core.ChainHeadEvent, 2),
-		sealingTask:  make(chan sealingInfo),
+		messages:        make(chan Payload, 100),
+		txEvents:        make(chan core.NewTxsEvent, txSubCap),
+		chainHeadEvents: make(chan core.ChainHeadEvent, 2),
+		sealingTask:     make(chan sealingInfo),
 
 		quit:     make(chan struct{}),
 		finished: make(chan struct{}),
@@ -1136,8 +1137,8 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 		c.dbft.Start(c.lastTimestamp * NsInS)
 
 		// Subscribe for minted blocks and transactions from mempool.
-		c.txsSub = c.txpool.SubscribeNewTxsEvent(c.transactions)
-		c.chain.SubscribeChainHeadEvent(c.blockEvents)
+		c.txSub = c.txpool.SubscribeNewTxsEvent(c.txEvents)
+		c.chainHeadSub = c.chain.SubscribeChainHeadEvent(c.chainHeadEvents)
 
 		go c.eventLoop()
 	} else {
@@ -1158,8 +1159,9 @@ events:
 		select {
 		case <-c.quit:
 			c.dbft.Timer.Stop()
-			// TODO: subscription and unsubscription.
-			// c.chain.UnsubscribeFromBlocks(c.blockEvents)
+
+			c.chainHeadSub.Unsubscribe()
+			c.txSub.Unsubscribe()
 			break events
 		case <-c.dbft.Timer.C():
 			hv := c.dbft.Timer.HV()
@@ -1199,12 +1201,18 @@ events:
 
 			log.Debug("received message", fields...)
 			c.dbft.OnReceive(&msg)
-		case txs := <-c.transactions:
+		case txs := <-c.txEvents:
 			for _, tx := range txs.Txs {
 				c.dbft.OnTransaction(&Transaction{Tx: tx})
 			}
-		case b := <-c.blockEvents:
+		case b := <-c.chainHeadEvents:
 			c.handleChainBlock(b.Block)
+		case <-c.txSub.Err():
+			// System has stopped.
+			break events
+		case <-c.chainHeadSub.Err():
+			// System has stopped.
+			break events
 		}
 		// Always process block event if there is any, we can add one above or external
 		// services can add several blocks during message processing.
@@ -1212,7 +1220,7 @@ events:
 	syncLoop:
 		for {
 			select {
-			case latestBlock = <-c.blockEvents:
+			case latestBlock = <-c.chainHeadEvents:
 			default:
 				break syncLoop
 			}
@@ -1225,15 +1233,15 @@ drainLoop:
 	for {
 		select {
 		case <-c.messages:
-		case <-c.transactions:
-		case <-c.blockEvents:
+		case <-c.txEvents:
+		case <-c.chainHeadEvents:
 		default:
 			break drainLoop
 		}
 	}
 	close(c.messages)
-	close(c.transactions)
-	close(c.blockEvents)
+	close(c.txEvents)
+	close(c.chainHeadEvents)
 	close(c.finished)
 }
 

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1173,7 +1173,7 @@ drainLoop:
 
 // OnPayload handles Payload receive.
 func (c *DBFT) OnPayload(cp *dbftproto.Message) error {
-	p := c.payloadFromMessage(cp)
+	p := payloadFromMessage(cp)
 	// decode payload data into message
 	if err := p.decodeData(); err != nil {
 		log.Info("can't decode payload data", "hash", cp.Hash(), "error", err)
@@ -1194,7 +1194,7 @@ func (c *DBFT) OnPayload(cp *dbftproto.Message) error {
 	return nil
 }
 
-func (s *DBFT) payloadFromMessage(ep *dbftproto.Message) *Payload {
+func payloadFromMessage(ep *dbftproto.Message) *Payload {
 	return &Payload{
 		Message: *ep,
 		message: message{},

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -191,9 +191,10 @@ func getSignersAndSigs(cfg *params.DBFTConfig, extra []byte) ([]common.Address, 
 
 // DBFT is the proof-of-authority consensus engine.
 type DBFT struct {
-	// TODO: we use only BroadcastMessage, need to replace with callback like in NeoGo.
-	service  *dbftproto.Service
 	messages chan Payload
+	// Broadcast is a callback which is called to notify the dBFT service
+	// about a new consensus payload to be sent.
+	broadcast func(m *dbftproto.Message) error
 
 	// various chain/mempool events and subscription management:
 	blockEvents  chan core.ChainHeadEvent // TODO: review the subscription type, maybe we need to subscribe not to Head, but to some other event. It depends on forks.
@@ -554,7 +555,7 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 			}
 
 			ep := &p.(*Payload).Message
-			err := c.service.BroadcastMessage(ep)
+			err := c.broadcast(ep)
 			if err != nil {
 				log.Warn("can't broadcast consensus message", "error", err)
 			}
@@ -600,8 +601,9 @@ func (c *DBFT) SetEthAPI(api *ethapi.BlockChainAPI) {
 	c.ethAPI = api
 }
 
-func (c *DBFT) SetService(srv *dbftproto.Service) {
-	c.service = srv
+// WithBroadcast sets callback to notify the caller about new consensus message.
+func (c *DBFT) WithBroadcast(f func(m *dbftproto.Message) error) {
+	c.broadcast = f
 }
 
 func (c *DBFT) SetTxPool(pool txPool) {

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1198,7 +1198,6 @@ events:
 			log.Debug("received message", fields...)
 			c.dbft.OnReceive(&msg)
 		case txs := <-c.transactions:
-			// TODO: we likely need to filter some of them out.
 			for _, tx := range txs.Txs {
 				c.dbft.OnTransaction(&Transaction{Tx: tx})
 			}

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -476,6 +476,16 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 				// After that we assume that parent block is valid and it can be sent to chain.
 				// For now, we'll hope that parent block will be fetched automatically and internal forks resolving mechanism will
 				// choose the right chain.
+				savedParent := c.chain.GetBlockByNumber(req.SealingProposal.Number.Uint64() - 1)
+				if savedParent != nil { // TODO: what if it's nil? Is it ever possible?
+					newHeader := savedParent.Header()
+					newHeader.Extra = req.ParentExtra
+					err := c.blockQueue.PutBlock(savedParent.WithSeal(newHeader)) // TODO: maybe send to a separate routine.
+					if err != nil {
+						// TODO: this error is very critical for further block processing.
+						log.Warn("failed to enqueue parent with updated extra: %w", err)
+					}
+				}
 
 				// TODO: lock it?
 				c.lastBlockHash = req.SealingProposal.ParentHash

--- a/consensus/dbft/payload.go
+++ b/consensus/dbft/payload.go
@@ -107,7 +107,6 @@ func (p *Payload) SetValidatorIndex(i uint16) {
 
 // Height implements the payload.ConsensusPayload interface.
 func (p Payload) Height() uint32 {
-	// TODO: uint32 is dBFT restriction, maybe extend dBFT interface?
 	return uint32(p.message.BlockIndex)
 }
 

--- a/consensus/dbft/payload.go
+++ b/consensus/dbft/payload.go
@@ -116,14 +116,6 @@ func (p *Payload) SetHeight(h uint32) {
 	p.message.BlockIndex = uint64(h)
 }
 
-/*
-// EncodeBinary implements the io.Serializable interface.
-func (p *Payload) EncodeBinary(w *io.BinWriter) {
-	p.encodeData()
-	p.Message.EncodeBinary(w)
-}
-*/
-
 // Sign signs payload using the private key.
 // It also sets corresponding sender and witness.
 func (p *Payload) Sign(key *Signer) error {
@@ -164,16 +156,6 @@ func (p *Payload) Hash() util.Uint256 {
 	}
 	return p.Message.Hash().Uint256()
 }
-
-/*
-// DecodeBinary implements the io.Serializable interface.
-func (p *Payload) DecodeBinary(r *io.BinReader) {
-	p.Extensible.DecodeBinary(r)
-	if r.Err == nil {
-		r.Err = p.decodeData()
-	}
-}
-*/
 
 // EncodeBinary implements the io.Serializable interface.
 func (m *message) EncodeBinary(w *io.BinWriter) {
@@ -240,6 +222,9 @@ func (p *Payload) encodeData() {
 		p.Message.ValidBlockEnd = p.BlockIndex
 		bw := io.NewBufBinWriter()
 		p.message.EncodeBinary(bw.BinWriter)
+		if bw.Err != nil {
+			panic(fmt.Errorf("failed to encode payload: %w", bw.Err))
+		}
 		p.Message.Data = bw.Bytes()
 	}
 }

--- a/consensus/dbft/payload.go
+++ b/consensus/dbft/payload.go
@@ -1,0 +1,255 @@
+package dbft
+
+import (
+	"bytes"
+	"fmt"
+
+	dbftproto "github.com/ethereum/go-ethereum/eth/protocols/dbft"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/nspcc-dev/dbft/payload"
+	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+)
+
+type (
+	messageType byte
+
+	message struct {
+		Type           messageType
+		BlockIndex     uint64
+		ValidatorIndex byte
+		ViewNumber     byte
+
+		payload io.Serializable
+	}
+
+	// Payload is a type for consensus-related messages.
+	Payload struct {
+		dbftproto.Message
+		message
+	}
+)
+
+const (
+	changeViewType      messageType = 0x00
+	prepareRequestType  messageType = 0x20
+	prepareResponseType messageType = 0x21
+	commitType          messageType = 0x30
+	recoveryRequestType messageType = 0x40
+	recoveryMessageType messageType = 0x41
+)
+
+// ViewNumber implements the payload.ConsensusPayload interface.
+func (p Payload) ViewNumber() byte {
+	return p.message.ViewNumber
+}
+
+// SetViewNumber implements the payload.ConsensusPayload interface.
+func (p *Payload) SetViewNumber(view byte) {
+	p.message.ViewNumber = view
+}
+
+// Type implements the payload.ConsensusPayload interface.
+func (p Payload) Type() payload.MessageType {
+	return payload.MessageType(p.message.Type)
+}
+
+// SetType implements the payload.ConsensusPayload interface.
+func (p *Payload) SetType(t payload.MessageType) {
+	p.message.Type = messageType(t)
+}
+
+// Payload implements the payload.ConsensusPayload interface.
+func (p Payload) Payload() any {
+	return p.payload
+}
+
+// SetPayload implements the payload.ConsensusPayload interface.
+func (p *Payload) SetPayload(pl any) {
+	p.payload = pl.(io.Serializable)
+}
+
+// GetChangeView implements the payload.ConsensusPayload interface.
+func (p Payload) GetChangeView() payload.ChangeView { return p.payload.(payload.ChangeView) }
+
+// GetPrepareRequest implements the payload.ConsensusPayload interface.
+func (p Payload) GetPrepareRequest() payload.PrepareRequest {
+	return p.payload.(payload.PrepareRequest)
+}
+
+// GetPrepareResponse implements the payload.ConsensusPayload interface.
+func (p Payload) GetPrepareResponse() payload.PrepareResponse {
+	return p.payload.(payload.PrepareResponse)
+}
+
+// GetCommit implements the payload.ConsensusPayload interface.
+func (p Payload) GetCommit() payload.Commit { return p.payload.(payload.Commit) }
+
+// GetRecoveryRequest implements the payload.ConsensusPayload interface.
+func (p Payload) GetRecoveryRequest() payload.RecoveryRequest {
+	return p.payload.(payload.RecoveryRequest)
+}
+
+// GetRecoveryMessage implements the payload.ConsensusPayload interface.
+func (p Payload) GetRecoveryMessage() payload.RecoveryMessage {
+	return p.payload.(payload.RecoveryMessage)
+}
+
+// ValidatorIndex implements the payload.ConsensusPayload interface.
+func (p Payload) ValidatorIndex() uint16 {
+	return uint16(p.message.ValidatorIndex)
+}
+
+// SetValidatorIndex implements the payload.ConsensusPayload interface.
+func (p *Payload) SetValidatorIndex(i uint16) {
+	p.message.ValidatorIndex = byte(i)
+}
+
+// Height implements the payload.ConsensusPayload interface.
+func (p Payload) Height() uint32 {
+	// TODO: uint32 is dBFT restriction, maybe extend dBFT interface?
+	return uint32(p.message.BlockIndex)
+}
+
+// SetHeight implements the payload.ConsensusPayload interface.
+func (p *Payload) SetHeight(h uint32) {
+	p.message.BlockIndex = uint64(h)
+}
+
+/*
+// EncodeBinary implements the io.Serializable interface.
+func (p *Payload) EncodeBinary(w *io.BinWriter) {
+	p.encodeData()
+	p.Message.EncodeBinary(w)
+}
+*/
+
+// Sign signs payload using the private key.
+// It also sets corresponding sender and witness.
+func (p *Payload) Sign(key *Signer) error {
+	if key.Signer != p.Sender {
+		return fmt.Errorf("can't sign payload with invalid sender: payload sender must be %s, address for signing is %s", p.Sender, key.Signer)
+	}
+	p.encodeData()
+
+	b, err := p.rlp()
+	if err != nil {
+		return fmt.Errorf("failed to calculate RLP: %w", err)
+	}
+	sig, err := key.Sign(b)
+	if err != nil {
+		return err
+	}
+
+	p.Witness = sig
+	return nil
+}
+
+// rlp returns serialized hashable payload fields that should be signed.
+func (p *Payload) rlp() ([]byte, error) {
+	cp := p.Message
+	cp.Witness = nil // cp is a copy and witness is not included into hash.
+
+	b := new(bytes.Buffer)
+	if err := rlp.Encode(b, cp); err != nil {
+		return nil, fmt.Errorf("failed to encode message: %w", err)
+	}
+	return b.Bytes(), nil
+}
+
+// Hash implements the payload.ConsensusPayload interface.
+func (p *Payload) Hash() util.Uint256 {
+	if p.Message.Data == nil {
+		p.encodeData()
+	}
+	return p.Message.Hash().Uint256()
+}
+
+/*
+// DecodeBinary implements the io.Serializable interface.
+func (p *Payload) DecodeBinary(r *io.BinReader) {
+	p.Extensible.DecodeBinary(r)
+	if r.Err == nil {
+		r.Err = p.decodeData()
+	}
+}
+*/
+
+// EncodeBinary implements the io.Serializable interface.
+func (m *message) EncodeBinary(w *io.BinWriter) {
+	w.WriteB(byte(m.Type))
+	w.WriteU64LE(m.BlockIndex)
+	w.WriteB(m.ValidatorIndex)
+	w.WriteB(m.ViewNumber)
+	m.payload.EncodeBinary(w)
+}
+
+// DecodeBinary implements the io.Serializable interface.
+func (m *message) DecodeBinary(r *io.BinReader) {
+	m.Type = messageType(r.ReadB())
+	m.BlockIndex = r.ReadU64LE()
+	m.ValidatorIndex = r.ReadB()
+	m.ViewNumber = r.ReadB()
+
+	switch m.Type {
+	case changeViewType:
+		cv := new(changeView)
+		// newViewNumber is not marshaled
+		cv.newViewNumber = m.ViewNumber + 1
+		m.payload = cv
+	case prepareRequestType:
+		m.payload = new(prepareRequest)
+	case prepareResponseType:
+		m.payload = new(prepareResponse)
+	case commitType:
+		m.payload = new(commit)
+	case recoveryRequestType:
+		m.payload = new(recoveryRequest)
+	case recoveryMessageType:
+		m.payload = new(recoveryMessage)
+	default:
+		r.Err = fmt.Errorf("invalid type: 0x%02x", byte(m.Type))
+		return
+	}
+	m.payload.DecodeBinary(r)
+}
+
+// String implements fmt.Stringer interface.
+func (t messageType) String() string {
+	switch t {
+	case changeViewType:
+		return "ChangeView"
+	case prepareRequestType:
+		return "PrepareRequest"
+	case prepareResponseType:
+		return "PrepareResponse"
+	case commitType:
+		return "Commit"
+	case recoveryRequestType:
+		return "RecoveryRequest"
+	case recoveryMessageType:
+		return "RecoveryMessage"
+	default:
+		return fmt.Sprintf("UNKNOWN(0x%02x)", byte(t))
+	}
+}
+
+func (p *Payload) encodeData() {
+	if p.Message.Data == nil {
+		p.Message.ValidBlockStart = 0
+		p.Message.ValidBlockEnd = p.BlockIndex
+		bw := io.NewBufBinWriter()
+		p.message.EncodeBinary(bw.BinWriter)
+		p.Message.Data = bw.Bytes()
+	}
+}
+
+// decode data of payload into its message.
+func (p *Payload) decodeData() error {
+	br := io.NewBinReaderFromBuf(p.Message.Data)
+	p.message.DecodeBinary(br)
+	if br.Err != nil {
+		return fmt.Errorf("can't decode message: %w", br.Err)
+	}
+	return nil
+}

--- a/consensus/dbft/payload_test.go
+++ b/consensus/dbft/payload_test.go
@@ -53,10 +53,9 @@ func TestPayloadSerializable(t *testing.T) {
 					ExcessBlobGas:    nil,
 					ParentBeaconRoot: nil,
 				},
-				SealingReceipts: []*types.Receipt{},
-				TxHashes:        []util.Uint256{},
-				ParentSealHash:  common.Hash{1, 2, 3},
-				ParentExtra:     []byte{1, 2, 3},
+				TxHashes:       []util.Uint256{},
+				ParentSealHash: common.Hash{1, 2, 3},
+				ParentExtra:    []byte{1, 2, 3},
 			},
 		},
 	}

--- a/consensus/dbft/payload_test.go
+++ b/consensus/dbft/payload_test.go
@@ -1,0 +1,89 @@
+package dbft
+
+import (
+	"crypto/rand"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	dbftproto "github.com/ethereum/go-ethereum/eth/protocols/dbft"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPayloadSerializable(t *testing.T) {
+	gk, _ := crypto.GenerateKey()
+	expected := &Payload{
+		Message: dbftproto.Message{
+			ValidBlockStart: 0,
+			ValidBlockEnd:   1,
+			Sender:          crypto.PubkeyToAddress(gk.PublicKey),
+			Data:            nil,
+			Witness:         nil,
+		},
+		message: message{
+			Type:           prepareRequestType,
+			BlockIndex:     1,
+			ValidatorIndex: 2,
+			ViewNumber:     3,
+			payload: &prepareRequest{
+				SealingProposal: &types.Header{
+					ParentHash:       common.Hash{1, 2, 3},
+					UncleHash:        common.Hash{1, 2, 3},
+					Coinbase:         common.Address{1, 2, 3},
+					Root:             common.Hash{1, 2, 3},
+					TxHash:           common.Hash{1, 2, 3},
+					ReceiptHash:      common.Hash{1, 2, 3},
+					Bloom:            types.Bloom{1, 2, 3},
+					Difficulty:       big.NewInt(0),
+					Number:           big.NewInt(1),
+					GasLimit:         0,
+					GasUsed:          0,
+					Time:             0,
+					Extra:            []byte{1, 2, 3},
+					MixDigest:        common.Hash{1, 2, 3},
+					Nonce:            types.BlockNonce{},
+					BaseFee:          nil,
+					WithdrawalsHash:  nil,
+					BlobGasUsed:      nil,
+					ExcessBlobGas:    nil,
+					ParentBeaconRoot: nil,
+				},
+				SealingReceipts: []*types.Receipt{},
+				TxHashes:        []util.Uint256{},
+				ParentSealHash:  common.Hash{1, 2, 3},
+				ParentExtra:     []byte{1, 2, 3},
+			},
+		},
+	}
+
+	err := expected.Sign(&Signer{
+		Signer: crypto.PubkeyToAddress(gk.PublicKey),
+		SignFn: func(signer accounts.Account, mimeType string, message []byte) ([]byte, error) {
+			return gk.Sign(rand.Reader, crypto.Keccak256(message), nil)
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, expected.Data)
+	require.NotNil(t, expected.Witness)
+
+	m := expected.Message
+	h := m.Hash()
+	require.NotNil(t, h)
+
+	b, err := rlp.EncodeToBytes(m)
+	require.NoError(t, err)
+
+	var actual = new(dbftproto.Message)
+	require.NoError(t, rlp.DecodeBytes(b, actual))
+	require.Equal(t, expected.Message, *actual)
+
+	actualP := payloadFromMessage(actual)
+	require.NoError(t, actualP.decodeData())
+
+	require.Equal(t, expected, actualP)
+}

--- a/consensus/dbft/prepare_request.go
+++ b/consensus/dbft/prepare_request.go
@@ -1,0 +1,96 @@
+package dbft
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/nspcc-dev/dbft/payload"
+	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+)
+
+// prepareRequest represents dBFT prepareRequest message.
+type prepareRequest struct {
+	// TODO: we don't need the whole structures, in future we need to exclude those
+	// that are not used for consensus agreement.
+	sealingProposal   *types.Header
+	sealingReceipts   []*types.Receipt
+	transactionHashes []util.Uint256
+
+	// Fields that should be included into PrepareRequest for its verification:
+	parentSealHash common.Hash
+	parentExtra    []byte // TODO: optimize to exclude hashable part.
+}
+
+var _ payload.PrepareRequest = (*prepareRequest)(nil)
+
+// Version implements the payload.PrepareRequest interface.
+func (p prepareRequest) Version() uint32 {
+	return 0
+}
+
+// SetVersion implements the payload.PrepareRequest interface.
+func (p *prepareRequest) SetVersion(v uint32) {
+	return
+}
+
+// PrevHash implements the payload.PrepareRequest interface.
+func (p prepareRequest) PrevHash() util.Uint256 {
+	return p.sealingProposal.ParentHash.Uint256()
+}
+
+// SetPrevHash implements the payload.PrepareRequest interface.
+func (p *prepareRequest) SetPrevHash(h util.Uint256) {
+	// No setter, the proposal must be kept as is.
+	return
+}
+
+// Timestamp implements the payload.PrepareRequest interface.
+func (p *prepareRequest) Timestamp() uint64 { return p.sealingProposal.Time * NsInS }
+
+// SetTimestamp implements the payload.PrepareRequest interface.
+func (p *prepareRequest) SetTimestamp(ts uint64) {
+	// @roman, we don't explicitly set timestamp in prepare request, instead we use
+	// exactly those timestamp that was provided via latest sealing proposal.
+	// TODO: we need to inspect how it may affect dBFT, on the server side this
+	// leads to subsequent deviations in blocks timestamps (need to check).
+}
+
+// Nonce implements the payload.PrepareRequest interface.
+func (p *prepareRequest) Nonce() uint64 { return 0 }
+
+// SetNonce implements the payload.PrepareRequest interface.
+func (p *prepareRequest) SetNonce(nonce uint64) {}
+
+// TransactionHashes implements the payload.PrepareRequest interface.
+func (p *prepareRequest) TransactionHashes() []util.Uint256 { return p.transactionHashes }
+
+// SetTransactionHashes implements the payload.PrepareRequest interface.
+func (p *prepareRequest) SetTransactionHashes(hs []util.Uint256) { p.transactionHashes = hs }
+
+// NextConsensus implements the payload.PrepareRequest interface.
+func (p *prepareRequest) NextConsensus() util.Uint160 { return util.Uint160{} }
+
+// SetNextConsensus implements the payload.PrepareRequest interface.
+func (p *prepareRequest) SetNextConsensus(_ util.Uint160) {}
+
+// EncodeBinary implements the io.Serializable interface.
+func (p *prepareRequest) EncodeBinary(w *io.BinWriter) {
+	b, err := rlp.EncodeToBytes(p)
+	if err != nil {
+		w.Err = fmt.Errorf("failed to encode PrepareRequest to RLP: %w", err)
+		return
+	}
+	w.WriteVarBytes(b)
+}
+
+// DecodeBinary implements the io.Serializable interface.
+func (p *prepareRequest) DecodeBinary(r *io.BinReader) {
+	err := rlp.DecodeBytes(r.ReadVarBytes(), p)
+	if err != nil {
+		r.Err = fmt.Errorf("failed to decode PrepareRequest RLP: %w", err)
+	}
+	// TODO: restrict MaxTransactionsPerBlock.
+}

--- a/consensus/dbft/prepare_request.go
+++ b/consensus/dbft/prepare_request.go
@@ -48,12 +48,7 @@ func (p *prepareRequest) SetPrevHash(h util.Uint256) {
 func (p *prepareRequest) Timestamp() uint64 { return p.SealingProposal.Time * NsInS }
 
 // SetTimestamp implements the payload.PrepareRequest interface.
-func (p *prepareRequest) SetTimestamp(ts uint64) {
-	// @roman, we don't explicitly set timestamp in prepare request, instead we use
-	// exactly those timestamp that was provided via latest sealing proposal.
-	// TODO: we need to inspect how it may affect dBFT, on the server side this
-	// leads to subsequent deviations in blocks timestamps (need to check).
-}
+func (p *prepareRequest) SetTimestamp(ts uint64) {}
 
 // Nonce implements the payload.PrepareRequest interface.
 func (p *prepareRequest) Nonce() uint64 { return 0 }

--- a/consensus/dbft/prepare_request.go
+++ b/consensus/dbft/prepare_request.go
@@ -15,13 +15,13 @@ import (
 type prepareRequest struct {
 	// TODO: we don't need the whole structures, in future we need to exclude those
 	// that are not used for consensus agreement.
-	sealingProposal   *types.Header
-	sealingReceipts   []*types.Receipt
-	transactionHashes []util.Uint256
+	SealingProposal *types.Header
+	SealingReceipts []*types.Receipt
+	TxHashes        []util.Uint256
 
 	// Fields that should be included into PrepareRequest for its verification:
-	parentSealHash common.Hash
-	parentExtra    []byte // TODO: optimize to exclude hashable part.
+	ParentSealHash common.Hash
+	ParentExtra    []byte // TODO: optimize to exclude hashable part.
 }
 
 var _ payload.PrepareRequest = (*prepareRequest)(nil)
@@ -38,7 +38,7 @@ func (p *prepareRequest) SetVersion(v uint32) {
 
 // PrevHash implements the payload.PrepareRequest interface.
 func (p prepareRequest) PrevHash() util.Uint256 {
-	return p.sealingProposal.ParentHash.Uint256()
+	return p.SealingProposal.ParentHash.Uint256()
 }
 
 // SetPrevHash implements the payload.PrepareRequest interface.
@@ -48,7 +48,7 @@ func (p *prepareRequest) SetPrevHash(h util.Uint256) {
 }
 
 // Timestamp implements the payload.PrepareRequest interface.
-func (p *prepareRequest) Timestamp() uint64 { return p.sealingProposal.Time * NsInS }
+func (p *prepareRequest) Timestamp() uint64 { return p.SealingProposal.Time * NsInS }
 
 // SetTimestamp implements the payload.PrepareRequest interface.
 func (p *prepareRequest) SetTimestamp(ts uint64) {
@@ -65,10 +65,10 @@ func (p *prepareRequest) Nonce() uint64 { return 0 }
 func (p *prepareRequest) SetNonce(nonce uint64) {}
 
 // TransactionHashes implements the payload.PrepareRequest interface.
-func (p *prepareRequest) TransactionHashes() []util.Uint256 { return p.transactionHashes }
+func (p *prepareRequest) TransactionHashes() []util.Uint256 { return p.TxHashes }
 
 // SetTransactionHashes implements the payload.PrepareRequest interface.
-func (p *prepareRequest) SetTransactionHashes(hs []util.Uint256) { p.transactionHashes = hs }
+func (p *prepareRequest) SetTransactionHashes(hs []util.Uint256) { p.TxHashes = hs }
 
 // NextConsensus implements the payload.PrepareRequest interface.
 func (p *prepareRequest) NextConsensus() util.Uint160 { return util.Uint160{} }
@@ -88,7 +88,11 @@ func (p *prepareRequest) EncodeBinary(w *io.BinWriter) {
 
 // DecodeBinary implements the io.Serializable interface.
 func (p *prepareRequest) DecodeBinary(r *io.BinReader) {
-	err := rlp.DecodeBytes(r.ReadVarBytes(), p)
+	b := r.ReadVarBytes()
+	if r.Err != nil {
+		return
+	}
+	err := rlp.DecodeBytes(b, p)
 	if err != nil {
 		r.Err = fmt.Errorf("failed to decode PrepareRequest RLP: %w", err)
 	}

--- a/consensus/dbft/prepare_request.go
+++ b/consensus/dbft/prepare_request.go
@@ -88,5 +88,4 @@ func (p *prepareRequest) DecodeBinary(r *io.BinReader) {
 	if err != nil {
 		r.Err = fmt.Errorf("failed to decode PrepareRequest RLP: %w", err)
 	}
-	// TODO: restrict MaxTransactionsPerBlock.
 }

--- a/consensus/dbft/prepare_request.go
+++ b/consensus/dbft/prepare_request.go
@@ -18,7 +18,7 @@ type prepareRequest struct {
 
 	// Fields that should be included into PrepareRequest for its verification:
 	ParentSealHash common.Hash
-	ParentExtra    []byte // TODO: optimize to exclude hashable part.
+	ParentExtra    []byte
 }
 
 var _ payload.PrepareRequest = (*prepareRequest)(nil)

--- a/consensus/dbft/prepare_request.go
+++ b/consensus/dbft/prepare_request.go
@@ -13,10 +13,7 @@ import (
 
 // prepareRequest represents dBFT prepareRequest message.
 type prepareRequest struct {
-	// TODO: we don't need the whole structures, in future we need to exclude those
-	// that are not used for consensus agreement.
 	SealingProposal *types.Header
-	SealingReceipts []*types.Receipt
 	TxHashes        []util.Uint256
 
 	// Fields that should be included into PrepareRequest for its verification:

--- a/consensus/dbft/prepare_response.go
+++ b/consensus/dbft/prepare_response.go
@@ -1,0 +1,30 @@
+package dbft
+
+import (
+	"github.com/nspcc-dev/dbft/payload"
+	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+)
+
+// prepareResponse represents dBFT PrepareResponse message.
+type prepareResponse struct {
+	preparationHash util.Uint256
+}
+
+var _ payload.PrepareResponse = (*prepareResponse)(nil)
+
+// EncodeBinary implements the io.Serializable interface.
+func (p *prepareResponse) EncodeBinary(w *io.BinWriter) {
+	w.WriteBytes(p.preparationHash[:])
+}
+
+// DecodeBinary implements the io.Serializable interface.
+func (p *prepareResponse) DecodeBinary(r *io.BinReader) {
+	r.ReadBytes(p.preparationHash[:])
+}
+
+// PreparationHash implements the payload.PrepareResponse interface.
+func (p *prepareResponse) PreparationHash() util.Uint256 { return p.preparationHash }
+
+// SetPreparationHash implements the payload.PrepareResponse interface.
+func (p *prepareResponse) SetPreparationHash(h util.Uint256) { p.preparationHash = h }

--- a/consensus/dbft/prepare_response_test.go
+++ b/consensus/dbft/prepare_response_test.go
@@ -1,0 +1,15 @@
+package dbft
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareResponse_Setters(t *testing.T) {
+	var p prepareResponse
+
+	p.SetPreparationHash(util.Uint256{1, 2, 3})
+	require.Equal(t, util.Uint256{1, 2, 3}, p.PreparationHash())
+}

--- a/consensus/dbft/recovery_message.go
+++ b/consensus/dbft/recovery_message.go
@@ -1,0 +1,292 @@
+package dbft
+
+import (
+	"errors"
+
+	dbftproto "github.com/ethereum/go-ethereum/eth/protocols/dbft"
+	"github.com/nspcc-dev/dbft/crypto"
+	"github.com/nspcc-dev/dbft/payload"
+	"github.com/nspcc-dev/neo-go/pkg/io"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+)
+
+type (
+	// recoveryMessage represents dBFT Recovery message.
+	recoveryMessage struct {
+		preparationHash     *util.Uint256
+		preparationPayloads []*preparationCompact
+		commitPayloads      []*commitCompact
+		changeViewPayloads  []*changeViewCompact
+		stateRootEnabled    bool
+		prepareRequest      *message
+	}
+
+	changeViewCompact struct {
+		ValidatorIndex     uint8
+		OriginalViewNumber byte
+		Timestamp          uint64
+		InvocationScript   []byte
+	}
+
+	commitCompact struct {
+		ViewNumber       byte
+		ValidatorIndex   uint8
+		Signature        [extraSeal]byte
+		InvocationScript []byte
+	}
+
+	preparationCompact struct {
+		ValidatorIndex   uint8
+		InvocationScript []byte
+	}
+)
+
+var _ payload.RecoveryMessage = (*recoveryMessage)(nil)
+
+// DecodeBinary implements the io.Serializable interface.
+func (m *recoveryMessage) DecodeBinary(r *io.BinReader) {
+	r.ReadArray(&m.changeViewPayloads)
+
+	var hasReq = r.ReadBool()
+	if hasReq {
+		m.prepareRequest = &message{}
+		m.prepareRequest.DecodeBinary(r)
+		if r.Err == nil && m.prepareRequest.Type != prepareRequestType {
+			r.Err = errors.New("recovery message PrepareRequest has wrong type")
+			return
+		}
+	} else {
+		l := r.ReadVarUint()
+		if l != 0 {
+			if l == util.Uint256Size {
+				m.preparationHash = new(util.Uint256)
+				r.ReadBytes(m.preparationHash[:])
+			} else {
+				r.Err = errors.New("invalid data")
+			}
+		} else {
+			m.preparationHash = nil
+		}
+	}
+
+	r.ReadArray(&m.preparationPayloads)
+	r.ReadArray(&m.commitPayloads)
+}
+
+// EncodeBinary implements the io.Serializable interface.
+func (m *recoveryMessage) EncodeBinary(w *io.BinWriter) {
+	w.WriteArray(m.changeViewPayloads)
+
+	hasReq := m.prepareRequest != nil
+	w.WriteBool(hasReq)
+	if hasReq {
+		m.prepareRequest.EncodeBinary(w)
+	} else {
+		if m.preparationHash == nil {
+			w.WriteVarUint(0)
+		} else {
+			w.WriteVarUint(util.Uint256Size)
+			w.WriteBytes(m.preparationHash[:])
+		}
+	}
+
+	w.WriteArray(m.preparationPayloads)
+	w.WriteArray(m.commitPayloads)
+}
+
+// DecodeBinary implements the io.Serializable interface.
+func (p *changeViewCompact) DecodeBinary(r *io.BinReader) {
+	p.ValidatorIndex = r.ReadB()
+	p.OriginalViewNumber = r.ReadB()
+	p.Timestamp = r.ReadU64LE()
+	p.InvocationScript = r.ReadVarBytes(1024)
+}
+
+// EncodeBinary implements the io.Serializable interface.
+func (p *changeViewCompact) EncodeBinary(w *io.BinWriter) {
+	w.WriteB(p.ValidatorIndex)
+	w.WriteB(p.OriginalViewNumber)
+	w.WriteU64LE(p.Timestamp)
+	w.WriteVarBytes(p.InvocationScript)
+}
+
+// DecodeBinary implements the io.Serializable interface.
+func (p *commitCompact) DecodeBinary(r *io.BinReader) {
+	p.ViewNumber = r.ReadB()
+	p.ValidatorIndex = r.ReadB()
+	r.ReadBytes(p.Signature[:])
+	p.InvocationScript = r.ReadVarBytes(1024)
+}
+
+// EncodeBinary implements the io.Serializable interface.
+func (p *commitCompact) EncodeBinary(w *io.BinWriter) {
+	w.WriteB(p.ViewNumber)
+	w.WriteB(p.ValidatorIndex)
+	w.WriteBytes(p.Signature[:])
+	w.WriteVarBytes(p.InvocationScript)
+}
+
+// DecodeBinary implements the io.Serializable interface.
+func (p *preparationCompact) DecodeBinary(r *io.BinReader) {
+	p.ValidatorIndex = r.ReadB()
+	p.InvocationScript = r.ReadVarBytes(1024)
+}
+
+// EncodeBinary implements the io.Serializable interface.
+func (p *preparationCompact) EncodeBinary(w *io.BinWriter) {
+	w.WriteB(p.ValidatorIndex)
+	w.WriteVarBytes(p.InvocationScript)
+}
+
+// AddPayload implements the payload.RecoveryMessage interface.
+func (m *recoveryMessage) AddPayload(p payload.ConsensusPayload) {
+	validator := uint8(p.ValidatorIndex())
+
+	switch p.Type() {
+	case payload.PrepareRequestType:
+		m.prepareRequest = &message{
+			Type:       prepareRequestType,
+			ViewNumber: p.ViewNumber(),
+			payload:    p.GetPrepareRequest().(*prepareRequest),
+		}
+		h := p.Hash()
+		m.preparationHash = &h
+		m.preparationPayloads = append(m.preparationPayloads, &preparationCompact{
+			ValidatorIndex:   validator,
+			InvocationScript: p.(*Payload).Witness,
+		})
+	case payload.PrepareResponseType:
+		m.preparationPayloads = append(m.preparationPayloads, &preparationCompact{
+			ValidatorIndex:   validator,
+			InvocationScript: p.(*Payload).Witness,
+		})
+
+		if m.preparationHash == nil {
+			h := p.GetPrepareResponse().PreparationHash()
+			m.preparationHash = &h
+		}
+	case payload.ChangeViewType:
+		m.changeViewPayloads = append(m.changeViewPayloads, &changeViewCompact{
+			ValidatorIndex:     validator,
+			OriginalViewNumber: p.ViewNumber(),
+			Timestamp:          p.GetChangeView().Timestamp(),
+			InvocationScript:   p.(*Payload).Witness,
+		})
+	case payload.CommitType:
+		m.commitPayloads = append(m.commitPayloads, &commitCompact{
+			ValidatorIndex:   validator,
+			ViewNumber:       p.ViewNumber(),
+			Signature:        p.GetCommit().(*commit).signature,
+			InvocationScript: p.(*Payload).Witness,
+		})
+	}
+}
+
+// GetPrepareRequest implements the payload.RecoveryMessage interface.
+func (m *recoveryMessage) GetPrepareRequest(p payload.ConsensusPayload, validators []crypto.PublicKey, primary uint16) payload.ConsensusPayload {
+	if m.prepareRequest == nil {
+		return nil
+	}
+
+	var compact *preparationCompact
+	for _, p := range m.preparationPayloads {
+		if p != nil && p.ValidatorIndex == uint8(primary) {
+			compact = p
+			break
+		}
+	}
+
+	if compact == nil {
+		return nil
+	}
+
+	req := fromPayload(prepareRequestType, p.(*Payload), m.prepareRequest.payload)
+	req.SetValidatorIndex(primary)
+	req.Sender = validators[primary].(*PublicKey).Account
+	req.Witness = compact.InvocationScript
+
+	return req
+}
+
+// GetPrepareResponses implements the payload.RecoveryMessage interface.
+func (m *recoveryMessage) GetPrepareResponses(p payload.ConsensusPayload, validators []crypto.PublicKey) []payload.ConsensusPayload {
+	if m.preparationHash == nil {
+		return nil
+	}
+
+	ps := make([]payload.ConsensusPayload, len(m.preparationPayloads))
+
+	for i, resp := range m.preparationPayloads {
+		r := fromPayload(prepareResponseType, p.(*Payload), &prepareResponse{
+			preparationHash: *m.preparationHash,
+		})
+		r.SetValidatorIndex(uint16(resp.ValidatorIndex))
+		r.Sender = validators[resp.ValidatorIndex].(*PublicKey).Account
+		r.Witness = resp.InvocationScript
+
+		ps[i] = r
+	}
+
+	return ps
+}
+
+// GetChangeViews implements the payload.RecoveryMessage interface.
+func (m *recoveryMessage) GetChangeViews(p payload.ConsensusPayload, validators []crypto.PublicKey) []payload.ConsensusPayload {
+	ps := make([]payload.ConsensusPayload, len(m.changeViewPayloads))
+
+	for i, cv := range m.changeViewPayloads {
+		c := fromPayload(changeViewType, p.(*Payload), &changeView{
+			newViewNumber: cv.OriginalViewNumber + 1,
+			timestamp:     cv.Timestamp,
+		})
+		c.message.ViewNumber = cv.OriginalViewNumber
+		c.SetValidatorIndex(uint16(cv.ValidatorIndex))
+		c.Sender = validators[cv.ValidatorIndex].(*PublicKey).Account
+		c.Witness = cv.InvocationScript
+
+		ps[i] = c
+	}
+
+	return ps
+}
+
+// GetCommits implements the payload.RecoveryMessage interface.
+func (m *recoveryMessage) GetCommits(p payload.ConsensusPayload, validators []crypto.PublicKey) []payload.ConsensusPayload {
+	ps := make([]payload.ConsensusPayload, len(m.commitPayloads))
+
+	for i, c := range m.commitPayloads {
+		cc := fromPayload(commitType, p.(*Payload), &commit{signature: c.Signature})
+		cc.SetValidatorIndex(uint16(c.ValidatorIndex))
+		cc.Sender = validators[c.ValidatorIndex].(*PublicKey).Account
+		cc.Witness = c.InvocationScript
+
+		ps[i] = cc
+	}
+
+	return ps
+}
+
+// PreparationHash implements the payload.RecoveryMessage interface.
+func (m *recoveryMessage) PreparationHash() *util.Uint256 {
+	return m.preparationHash
+}
+
+// SetPreparationHash implements the payload.RecoveryMessage interface.
+func (m *recoveryMessage) SetPreparationHash(h *util.Uint256) {
+	m.preparationHash = h
+}
+
+func fromPayload(t messageType, recovery *Payload, p io.Serializable) *Payload {
+	return &Payload{
+		Message: dbftproto.Message{
+			ValidBlockEnd: recovery.BlockIndex,
+			Sender:        recovery.Sender,
+		},
+		message: message{
+			Type:       t,
+			BlockIndex: recovery.BlockIndex,
+			ViewNumber: recovery.message.ViewNumber,
+			payload:    p,
+		},
+	}
+}

--- a/consensus/dbft/recovery_request.go
+++ b/consensus/dbft/recovery_request.go
@@ -1,0 +1,29 @@
+package dbft
+
+import (
+	"github.com/nspcc-dev/dbft/payload"
+	"github.com/nspcc-dev/neo-go/pkg/io"
+)
+
+// recoveryRequest represents dBFT RecoveryRequest message.
+type recoveryRequest struct {
+	timestamp uint64
+}
+
+var _ payload.RecoveryRequest = (*recoveryRequest)(nil)
+
+// DecodeBinary implements the io.Serializable interface.
+func (m *recoveryRequest) DecodeBinary(r *io.BinReader) {
+	m.timestamp = r.ReadU64LE()
+}
+
+// EncodeBinary implements the io.Serializable interface.
+func (m *recoveryRequest) EncodeBinary(w *io.BinWriter) {
+	w.WriteU64LE(m.timestamp)
+}
+
+// Timestamp implements the payload.RecoveryRequest interface.
+func (m *recoveryRequest) Timestamp() uint64 { return m.timestamp }
+
+// SetTimestamp implements the payload.RecoveryRequest interface.
+func (m *recoveryRequest) SetTimestamp(ts uint64) { m.timestamp = ts }

--- a/consensus/dbft/signer.go
+++ b/consensus/dbft/signer.go
@@ -22,5 +22,5 @@ type Signer struct {
 // In case of block, msg is expected to be dbftRLP(header) that must be
 // guaranteed by Block.Sign method.
 func (s *Signer) Sign(msg []byte) ([]byte, error) {
-	return s.SignFn(accounts.Account{Address: s.Signer}, accounts.MimetypeClique, msg) // TODO: replace this accounts.MimetypeClique?
+	return s.SignFn(accounts.Account{Address: s.Signer}, accounts.MimetypeClique, msg)
 }

--- a/consensus/dbft/signer.go
+++ b/consensus/dbft/signer.go
@@ -22,5 +22,5 @@ type Signer struct {
 // In case of block, msg is expected to be dbftRLP(header) that must be
 // guaranteed by Block.Sign method.
 func (s *Signer) Sign(msg []byte) ([]byte, error) {
-	return s.SignFn(accounts.Account{Address: s.Signer}, accounts.MimetypeClique, msg)
+	return s.SignFn(accounts.Account{Address: s.Signer}, accounts.MimetypeClique, msg) // TODO: replace this accounts.MimetypeClique?
 }

--- a/consensus/dbft/snapshot.go
+++ b/consensus/dbft/snapshot.go
@@ -56,7 +56,6 @@ type Snapshot struct {
 	Number  uint64                      `json:"number"`  // Block number where the snapshot was created
 	Hash    common.Hash                 `json:"hash"`    // Block hash where the snapshot was created
 	Signers map[common.Address]struct{} `json:"signers"` // Set of authorized signers at this moment
-	Recents map[uint64]common.Address   `json:"recents"` // Set of recent signers for spam protections
 	Votes   []*Vote                     `json:"votes"`   // List of votes cast in chronological order
 	Tally   map[common.Address]Tally    `json:"tally"`   // Current vote tally to avoid recalculating
 }
@@ -71,7 +70,6 @@ func newSnapshot(epoch uint64, cfg *params.DBFTConfig, number uint64, hash commo
 		Number:  number,
 		Hash:    hash,
 		Signers: make(map[common.Address]struct{}),
-		Recents: make(map[uint64]common.Address),
 		Tally:   make(map[common.Address]Tally),
 	}
 	for _, signer := range signers {
@@ -114,15 +112,11 @@ func (s *Snapshot) copy() *Snapshot {
 		Number:  s.Number,
 		Hash:    s.Hash,
 		Signers: make(map[common.Address]struct{}),
-		Recents: make(map[uint64]common.Address),
 		Votes:   make([]*Vote, len(s.Votes)),
 		Tally:   make(map[common.Address]Tally),
 	}
 	for signer := range s.Signers {
 		cpy.Signers[signer] = struct{}{}
-	}
-	for block, signer := range s.Recents {
-		cpy.Recents[block] = signer
 	}
 	for address, tally := range s.Tally {
 		cpy.Tally[address] = tally
@@ -206,10 +200,6 @@ func (s *Snapshot) apply(headers []*types.Header) (*Snapshot, error) {
 			snap.Votes = nil
 			snap.Tally = make(map[common.Address]Tally)
 		}
-		// Delete the oldest signer from the recent list to allow it signing again
-		if limit := uint64(len(snap.Signers)/2 + 1); number >= limit {
-			delete(snap.Recents, number-limit)
-		}
 		// Resolve the authorization key and check against signers
 		// TODO: this must be fixed, works incorrectly now.
 		vals, _, err := getSignersAndSigs(s.config, header.Extra)
@@ -220,12 +210,6 @@ func (s *Snapshot) apply(headers []*types.Header) (*Snapshot, error) {
 		if _, ok := snap.Signers[signer]; !ok {
 			return nil, errUnauthorizedSigner
 		}
-		for _, recent := range snap.Recents {
-			if recent == signer {
-				return nil, errRecentlySigned
-			}
-		}
-		snap.Recents[number] = signer
 
 		// Header authorized, discard any previous votes from the signer
 		for i, vote := range snap.Votes {
@@ -258,10 +242,6 @@ func (s *Snapshot) apply(headers []*types.Header) (*Snapshot, error) {
 			} else {
 				delete(snap.Signers, header.Coinbase)
 
-				// Signer list shrunk, delete any leftover recent caches
-				if limit := uint64(len(snap.Signers)/2 + 1); number >= limit {
-					delete(snap.Recents, number-limit)
-				}
 				// Discard any previous votes the deauthorized signer cast
 				for i := 0; i < len(snap.Votes); i++ {
 					if snap.Votes[i].Signer == header.Coinbase {

--- a/consensus/dbft/snapshot.go
+++ b/consensus/dbft/snapshot.go
@@ -201,7 +201,6 @@ func (s *Snapshot) apply(headers []*types.Header) (*Snapshot, error) {
 			snap.Tally = make(map[common.Address]Tally)
 		}
 		// Resolve the authorization key and check against signers
-		// TODO: this must be fixed, works incorrectly now.
 		vals, _, err := getSignersAndSigs(s.config, header.Extra)
 		if err != nil {
 			return nil, err

--- a/consensus/dbft/snapshot.go
+++ b/consensus/dbft/snapshot.go
@@ -212,7 +212,7 @@ func (s *Snapshot) apply(headers []*types.Header) (*Snapshot, error) {
 		}
 		// Resolve the authorization key and check against signers
 		// TODO: this must be fixed, works incorrectly now.
-		vals, _, err := getSignersAndSigs(s.config, header)
+		vals, _, err := getSignersAndSigs(s.config, header.Extra)
 		if err != nil {
 			return nil, err
 		}

--- a/consensus/dbft/txpool.go
+++ b/consensus/dbft/txpool.go
@@ -1,0 +1,32 @@
+package dbft
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/txpool"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// txPool defines the methods needed from a transaction pool implementation to
+// support all the operations needed by the Ethereum chain protocols.
+type txPool interface {
+	// Has returns an indicator whether txpool has a transaction
+	// cached with the given hash.
+	Has(hash common.Hash) bool
+
+	// Get retrieves the transaction from local txpool with given
+	// tx hash.
+	Get(hash common.Hash) *types.Transaction
+
+	// Add should add the given transactions to the pool.
+	Add(txs []*types.Transaction, local bool, sync bool) []error
+
+	// Pending should return pending transactions.
+	// The slice should be modifiable by the caller.
+	Pending(enforceTips bool) map[common.Address][]*txpool.LazyTransaction
+
+	// SubscribeNewTxsEvent should return an event subscription of
+	// NewTxsEvent and send events to the given channel.
+	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
+}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/trie"
+	"golang.org/x/exp/slices"
 )
 
 //go:generate go run github.com/fjl/gencodec -type Genesis -field-override genesisSpecMarshaling -out gen_genesis.go
@@ -483,6 +484,10 @@ func (g *Genesis) ToBlock() *types.Block {
 		if g.Config.DBFT.ValidatorsCount == 0 {
 			panic("ValidatorsCount is not specified in the dBFT config")
 		}
+		// Do not change configured committee.
+		sb := make([]common.Address, len(g.Config.DBFT.StandByCommittee))
+		copy(sb, g.Config.DBFT.StandByCommittee)
+		slices.SortFunc(sb, common.Address.Cmp)
 		var (
 			n           = int(g.Config.DBFT.ValidatorsCount)
 			m           = crypto.GetBFTHonestNodeCount(n)
@@ -490,14 +495,14 @@ func (g *Genesis) ToBlock() *types.Block {
 		)
 		if len(g.ExtraData) == 0 {
 			extra := make([]byte, extraVanity+n*common.AddressLength+m*crypto.SignatureLength)
-			for i, v := range g.Config.DBFT.StandByCommittee[:n] {
+			for i, v := range sb[:n] {
 				offset := extraVanity + i*common.AddressLength
 				copy(extra[offset:offset+common.AddressLength], v.Bytes())
 			}
 			head.Extra = extra
 		}
 		if g.Mixhash == (common.Hash{}) {
-			head.MixDigest = dbftutil.GetNextConsensusHash(g.Config.DBFT.StandByCommittee[:n])
+			head.MixDigest = dbftutil.GetNextConsensusHash(sb[:n])
 		}
 	}
 	var withdrawals []*types.Withdrawal

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -257,9 +257,10 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 	eth.APIBackend.gpo = gasprice.NewOracle(eth.APIBackend, gpoParams)
 
-	eth.dbftSrv = dbftproto.New(ethapi.NewBlockChainAPI(eth.APIBackend))
-	
-	var bft *dbft.DBFT
+	var (
+		bft       *dbft.DBFT
+		onPayload func(*dbftproto.Message) error
+	)
 	switch t := eth.engine.(type) {
 	case *dbft.DBFT:
 		bft = t
@@ -270,8 +271,13 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		}
 	}
 	if bft != nil {
+		onPayload = bft.OnPayload
+	}
+	eth.dbftSrv = dbftproto.New(ethapi.NewBlockChainAPI(eth.APIBackend), onPayload)
+	if bft != nil {
 		ethAPI := ethapi.NewBlockChainAPI(eth.APIBackend)
 		bft.SetEthAPI(ethAPI)
+		bft.SetService(eth.dbftSrv)
 	}
 
 	// Setup DNS discovery iterators.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -277,7 +277,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	if bft != nil {
 		ethAPI := ethapi.NewBlockChainAPI(eth.APIBackend)
 		bft.SetEthAPI(ethAPI)
-		bft.SetService(eth.dbftSrv)
+		bft.WithBroadcast(eth.dbftSrv.BroadcastMessage)
 		bft.SetTxPool(eth.txPool)
 	}
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -276,9 +276,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.dbftSrv = dbftproto.New(ethapi.NewBlockChainAPI(eth.APIBackend), onPayload)
 	if bft != nil {
 		ethAPI := ethapi.NewBlockChainAPI(eth.APIBackend)
-		bft.SetEthAPI(ethAPI)
+		bft.WithEthAPI(ethAPI)
 		bft.WithBroadcast(eth.dbftSrv.BroadcastMessage)
-		bft.SetTxPool(eth.txPool)
+		bft.WithTxPool(eth.txPool)
 	}
 
 	// Setup DNS discovery iterators.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -278,6 +278,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		ethAPI := ethapi.NewBlockChainAPI(eth.APIBackend)
 		bft.SetEthAPI(ethAPI)
 		bft.SetService(eth.dbftSrv)
+		bft.SetTxPool(eth.txPool)
 	}
 
 	// Setup DNS discovery iterators.

--- a/eth/protocols/dbft/handler.go
+++ b/eth/protocols/dbft/handler.go
@@ -101,6 +101,12 @@ func (s *Service) HandleMessage(peer *Peer) error {
 		if err := msg.Decode(&m); err != nil {
 			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 		}
+		if s.onPayload != nil {
+			err := s.onPayload(&m)
+			if err != nil {
+				return fmt.Errorf("failed to handle dBFT message: %w", err)
+			}
+		}
 		return s.BroadcastMessage(&m)
 	default:
 		return fmt.Errorf("%w: %v", errInvalidMsgCode, msg.Code)

--- a/eth/protocols/dbft/handler_test.go
+++ b/eth/protocols/dbft/handler_test.go
@@ -28,9 +28,9 @@ func TestHandling(t *testing.T) {
 		key, _         = crypto.GenerateKey()
 		addr           = crypto.PubkeyToAddress(key.PublicKey)
 		bc             = &testBC{height: 10}
-		s1             = New(bc)
-		s2             = New(bc)
-		s3             = New(bc)
+		s1             = New(bc, nil)
+		s2             = New(bc, nil)
+		s3             = New(bc, nil)
 		p1             = p2p.NewPeer(enode.ID{1}, "peer1", nil)
 		p2             = p2p.NewPeer(enode.ID{2}, "peer2", nil)
 		p3             = p2p.NewPeer(enode.ID{3}, "peer3", nil)

--- a/eth/protocols/dbft/payload.go
+++ b/eth/protocols/dbft/payload.go
@@ -6,6 +6,7 @@ package dbft
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -44,12 +45,14 @@ func (m Message) Hash() common.Hash {
 func (m Message) Verify() error {
 	var h = m.Hash()
 
-	pk, err := crypto.SigToPub(h[:], m.Witness)
+	pk, err := crypto.Ecrecover(h.Bytes(), m.Witness)
 	if err != nil {
 		return err
 	}
-	if crypto.PubkeyToAddress(*pk) != m.Sender {
-		return invalidSig
+
+	addr := crypto.PubkeyBytesToAddress(pk)
+	if addr != m.Sender {
+		return fmt.Errorf("%w: expected sender %s, recovered sender %s", invalidSig, m.Sender, addr)
 	}
 	return nil
 }

--- a/eth/protocols/dbft/service.go
+++ b/eth/protocols/dbft/service.go
@@ -82,8 +82,9 @@ func (s *Service) BroadcastMessage(m *Message) error {
 		return err
 	}
 	var peers = s.grabPeers()
+	h := m.Hash()
 	for _, p := range peers {
-		err := p.SendAnnounceMsg(m.Hash())
+		err := p.SendAnnounceMsg(h)
 		if err != nil {
 			return err
 		}

--- a/eth/protocols/dbft/service.go
+++ b/eth/protocols/dbft/service.go
@@ -30,15 +30,18 @@ type Service struct {
 	peers map[enode.ID]*Peer
 
 	pool *Pool
+
+	onPayload func(message *Message) error
 }
 
 // New creates a new instance of [Service].
-func New(bc BlockChainAPI) *Service {
+func New(bc BlockChainAPI, onPayload func(*Message) error) *Service {
 	poolLedger := newLedger(bc)
 	return &Service{
-		bc:    bc,
-		peers: make(map[enode.ID]*Peer),
-		pool:  NewPool(poolLedger, defaultSenderPoolSize),
+		bc:        bc,
+		onPayload: onPayload,
+		peers:     make(map[enode.ID]*Peer),
+		pool:      NewPool(poolLedger, defaultSenderPoolSize),
 	}
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -70,7 +70,7 @@ const (
 	intervalAdjustBias = 200 * 1000.0 * 1000.0
 
 	// staleThreshold is the maximum depth of the acceptable stale block.
-	staleThreshold = 7
+	staleThreshold = 0
 )
 
 var (


### PR DESCRIPTION
Close #13. Close #31. Implement a part of #29.

In this PR:
* Introduce custom dBFT payloads implementation;
* Integrate DBFT service with dBFT message pool;
* Integrate DBFT service with transactions mempool and chain events;
* Introduce basic dBFT verification rules;
* Make multiple consensus nodes accept blocks, accept transactions.

A set of related issues are created for further work. Several critical issues exist in the current implementation that under certain circumstances may stop consensus or kill the node, they will be resolved in separate PRs.