### PR TITLE
dbft: ensure non-consensus nodes function normally

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1113,17 +1113,15 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 			break
 		}
 	}
-	if !isAuthorized {
-		c.lastProposalLock.RUnlock()
-		c.sealingLock.Unlock()
-		return errUnauthorizedSigner
-	}
-
-	err = c.blockQueue.SubmitTask(sealingHash, b.NumberU64(), results, stop)
-	if err != nil {
-		c.lastProposalLock.RUnlock()
-		c.sealingLock.Unlock()
-		return fmt.Errorf("failed to submit sealing task to dBFT: %w", err)
+	// Submit task to blockQueue only if we're a member of validators set, otherwise it's
+	// useless to expect that out proposal will be accepted for the current height.
+	if isAuthorized {
+		err = c.blockQueue.SubmitTask(sealingHash, b.NumberU64(), results, stop)
+		if err != nil {
+			c.lastProposalLock.RUnlock()
+			c.sealingLock.Unlock()
+			return fmt.Errorf("failed to submit sealing task to dBFT: %w", err)
+		}
 	}
 
 	c.sealingProposal = lastHeader

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1249,6 +1249,11 @@ drainLoop:
 
 // OnPayload handles Payload receive.
 func (c *DBFT) OnPayload(cp *dbftproto.Message) error {
+	if c.dbft == nil || !c.dbftStarted.Load() {
+		log.Debug("skip dBFT payload handling: dbft is inactive or not started yet", "hash", cp.Hash())
+		return nil
+	}
+
 	p := payloadFromMessage(cp)
 	// decode payload data into message
 	if err := p.decodeData(); err != nil {
@@ -1258,11 +1263,6 @@ func (c *DBFT) OnPayload(cp *dbftproto.Message) error {
 
 	if !c.validatePayload(p) {
 		log.Info("can't validate payload", "hash", cp.Hash())
-		return nil
-	}
-
-	if c.dbft == nil || !c.dbftStarted.Load() {
-		log.Info("dbft is inactive or not started yet", "hash", cp.Hash())
 		return nil
 	}
 


### PR DESCRIPTION
Close #63.

In this PR:
* allow dBFT payloads broadcasting for non-consensus nodes;
* allow non-consensus nodes with enabled miner to participate in consensus process with "WatchOnly" status.

The overall updated node behaviour is the following:
    
* If the node is a light node, then DBFT consensus engine is created but not started. dBFT P2P protocol is not started and not processing/shearing any consensus messages. Consensus engine in this case is used for incoming blocks verification only. Miner also can't be started for light node, it's prohibited by the current Geth implementation and we're pretty OK with it.
* If the node is a full node (archival, RPC or any full non-miner node) then DBFT service is created but not started (and not initialized by account). It is used to verify incoming blocks. dBFT P2P protocol is started and used to relay consensus messages without verification (just P2P broadcasting). Miner is not started.
* If the node is a miner node, then DBFT service is created, started and initialised by etherbase account (that is potentially a validator). dBFT P2P protocol is started and used to relay consensus messages and to route consensus messages to DBFT service with preliminary verification. Miner is started and submitting tasks to DBFT service even if etherbase authorized accoint is a validator. In case if authorized account is excluded from the validators list, then the node is still a consensus member with "WatchOnly" status until it's restarted without `--miner` flag. Once authorised acconunt is included back to the validators set, then miner is allowed to submit tasks to DBFT service and DBFT service properly starts its work with "Backup" or "Primary" status.

Thus, DBFT service event loop is directly depends on miner process start and at the same time it respects the fact whether authorized account is included into validators set for the current block. The described state of things looks good to me and thus, I consider that no additional modifications should be done in DBFT engine configuration.