### PR TITLE
dbft: remove unnecessary call to computable getNextBlockValidators

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -347,12 +347,11 @@ func New(config *params.DBFTConfig, db ethdb.Database) *DBFT {
 				// block's validators, thus should return validators from the current
 				// epoch without recalculation.
 				pKeys, err = c.getNextBlockValidators(c.lastBlockHash, c.lastIndex, false)
-			} else {
-				// getValidators with non-empty args is used by dbft to fill block's
-				// NextConsensus field, ComputeNextBlockValidators will return proper
-				// value for NextConsensus wrt dBFT epoch start/end.
-				pKeys, err = c.getNextBlockValidators(c.lastBlockHash, c.lastIndex, true)
 			}
+			// getValidators with non-empty args is used by dbft to fill block's
+			// NextConsensus field, but DBFT doesn't provide WithGetConsensusAddress
+			// callback and fills NextConsensus by itself via WithNewBlockFromContext
+			// callback. Thus, leave pKeys empty if txes != nil.
 			if err != nil {
 				// Program bug.
 				panic(fmt.Errorf("failed to create snapshot while retrieving Validators: %w", err))


### PR DESCRIPTION
dBFT doesn't use validators got from this call to GetValidators callback, because DBFT service doesn't properly set WithGetConsensusAddress, and thus this call can be safely skipped. Instead, DBFT service fills NextConsensus field by itself in NewBlockFromContext callback.

This commit technically doesn't perform any functional changes. This commit is just a removal of the code that was never used by Geth library.

This commit is a direct consequence of nspcc-dev/dbft#84 and a port of https://github.com/nspcc-dev/neo-go/pull/3279.