### PR TITLE
Properly initialize DBFT engine context in case of CV

### DIFF
--- a/consensus/dbft/blockqueue.go
+++ b/consensus/dbft/blockqueue.go
@@ -115,7 +115,8 @@ func (bq *blockQueue) SubmitTask(sealHash common.Hash, number uint64, resCh chan
 	defer bq.tasksLock.Unlock()
 
 	// Do not check the existing task with the same hash. It could happen that new
-	// sealing task has the same hash after ChangeView sealing proposal initialisation.
+	// sealing task has the same hash after ChangeView sealing proposal initialisation,
+	// and if that's the case, then just update the result/cancel channel.
 	bq.tasks[sealHash] = task{
 		height:   number,
 		resCh:    resCh,

--- a/consensus/dbft/blockqueue.go
+++ b/consensus/dbft/blockqueue.go
@@ -10,6 +10,12 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+// blockQueueCap is the number of tasks blockQueue can fit at once. It's OK for
+// the blockQueue not to have a proper task for the newly-created block, and
+// normally a single task is expected to be present in blockQueue. But we still
+// need blockQueueCap restriction for the case of endless change views.
+const blockQueueCap = 100
+
 // blockQueue is an entity that collects sealed blocks from dBFT and routs these
 // blocks to a proper place (either to miner or directly to chain).
 type blockQueue struct {
@@ -48,7 +54,7 @@ func (bq *blockQueue) PutBlock(b *types.Block) error {
 	bq.tasksLock.Lock()
 	task, ok := bq.tasks[h]
 
-	bq.clearStaleTasks(b.NumberU64())
+	bq.clearStaleTasks(b.NumberU64(), -1)
 
 	if ok {
 		var (
@@ -101,10 +107,14 @@ func (bq *blockQueue) PutBlock(b *types.Block) error {
 
 // clearStaleTasks removes all stale tasks up to the specified height (including
 // the height itself). It doesn't hold tasksLock, so it's the caller's responsibility.
-func (bq *blockQueue) clearStaleTasks(till uint64) {
+func (bq *blockQueue) clearStaleTasks(till uint64, count int) {
 	for h, task := range bq.tasks {
 		if task.height <= till {
 			delete(bq.tasks, h)
+			count--
+			if count <= 0 {
+				break
+			}
 		}
 	}
 }
@@ -113,6 +123,13 @@ func (bq *blockQueue) clearStaleTasks(till uint64) {
 func (bq *blockQueue) SubmitTask(sealHash common.Hash, number uint64, resCh chan<- *types.Block, cancelCh <-chan struct{}) error {
 	bq.tasksLock.Lock()
 	defer bq.tasksLock.Unlock()
+
+	// We're OK with the fact that capacity is reached, remove random outdated seal
+	// task (it's likely won't be completed, and if it will, then the block will be
+	// inserted to the chain directly).
+	if len(bq.tasks) == blockQueueCap {
+		bq.clearStaleTasks(number, 1)
+	}
 
 	// Do not check the existing task with the same hash. It could happen that new
 	// sealing task has the same hash after ChangeView sealing proposal initialisation,

--- a/consensus/dbft/blockqueue.go
+++ b/consensus/dbft/blockqueue.go
@@ -114,11 +114,8 @@ func (bq *blockQueue) SubmitTask(sealHash common.Hash, number uint64, resCh chan
 	bq.tasksLock.Lock()
 	defer bq.tasksLock.Unlock()
 
-	if _, ok := bq.tasks[sealHash]; ok {
-		// Likely a program bug (incorrect Seal proposal verification), should never happen.
-		return fmt.Errorf("duplicating sealing task is not allowed for dBFT: %s", sealHash)
-	}
-
+	// Do not check the existing task with the same hash. It could happen that new
+	// sealing task has the same hash after ChangeView sealing proposal initialisation.
 	bq.tasks[sealHash] = task{
 		height:   number,
 		resCh:    resCh,

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -238,11 +238,12 @@ type DBFT struct {
 	lastProposal     *types.Block
 	lastReceipts     []*types.Receipt
 
-	sealingLock         sync.RWMutex
-	isSealing           bool
-	sealingProposal     *types.Header
-	sealingReceipts     []*types.Receipt
-	sealingTransactions types.Transactions
+	sealingLock                  sync.RWMutex
+	isSealing                    bool
+	sealingProposal              *types.Header
+	sealingReceipts              []*types.Receipt
+	sealingTransactions          types.Transactions
+	sealingWaitingForNewProposal bool
 
 	// chain and mempool instances needed for proper dBFT callbacks functioning.
 	chain    ChainHeaderReader
@@ -1129,19 +1130,25 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 	c.isSealing = true
 
 	c.lastProposalLock.RUnlock()
-	c.sealingLock.Unlock()
 
-	// Start dBFT once and afterward reinitialize it every time new block should be accepted.
-	if c.dbftStarted.CompareAndSwap(false, true) {
-		c.dbft.Start(c.lastTimestamp * NsInS)
-
-		// Subscribe for minted blocks and transactions from mempool.
-		c.txSub = c.txpool.SubscribeNewTxsEvent(c.txEvents)
-		c.chainHeadSub = c.chain.SubscribeChainHeadEvent(c.chainHeadEvents)
-
-		go c.eventLoop()
+	// If ChangeView happened, then no dBFT reinitialization is expected.
+	if c.sealingWaitingForNewProposal {
+		c.sealingWaitingForNewProposal = false
+		c.sealingLock.Unlock()
 	} else {
-		c.dbft.InitializeConsensus(0, c.lastTimestamp*NsInS)
+		c.sealingLock.Unlock()
+		// Start dBFT once and afterward reinitialize it every time new block should be accepted.
+		if c.dbftStarted.CompareAndSwap(false, true) {
+			c.dbft.Start(c.lastTimestamp * NsInS)
+
+			// Subscribe for minted blocks and transactions from mempool.
+			c.txSub = c.txpool.SubscribeNewTxsEvent(c.txEvents)
+			c.chainHeadSub = c.chain.SubscribeChainHeadEvent(c.chainHeadEvents)
+
+			go c.eventLoop()
+		} else {
+			c.dbft.InitializeConsensus(0, c.lastTimestamp*NsInS)
+		}
 	}
 
 	c.sealingTask <- sealingInfo{
@@ -1197,9 +1204,30 @@ events:
 					"#request", rec.prepareRequest != nil,
 					"#hash", rec.preparationHash != nil)
 			}
-
 			log.Debug("received message", fields...)
+			oldView := c.dbft.ViewNumber
 			c.dbft.OnReceive(&msg)
+			newView := c.dbft.ViewNumber
+			// If ChangeView has happened, we need to wait for the new proposal
+			// from miner.
+			if newView > oldView {
+				log.Info("Change view detected, waiting for new sealing task to be submitted by miner", "old view", oldView, "new view", newView)
+				c.sealingLock.Lock()
+				c.isSealing = false
+				c.sealingProposal = nil
+				c.sealingReceipts = nil
+				c.sealingTransactions = nil
+				c.sealingWaitingForNewProposal = true
+				c.sealingLock.Unlock()
+
+				t := <-c.sealingTask
+				log.Info("Start dBFT process for updated sealing work",
+					"view", newView,
+					"number", t.number,
+					"sealhash", t.sealingHash,
+					"prev", t.parentHash,
+				)
+			}
 		case txs := <-c.txEvents:
 			for _, tx := range txs.Txs {
 				c.dbft.OnTransaction(&Transaction{Tx: tx})

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1051,7 +1051,7 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 	c.sealingLock.Lock()
 	if c.isSealing {
 		c.sealingLock.Unlock()
-		return errors.New("previous sealing is not yet finished")
+		return nil
 	}
 	if b.NumberU64() != c.lastIndex+1 {
 		c.sealingLock.Unlock()

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -462,8 +462,10 @@ func (w *worker) newWorkLoop(recommit time.Duration) {
 			// If sealing is running resubmit a new work cycle periodically to pull in
 			// higher priced transactions. Disable this overhead for pending blocks.
 			if w.isRunning() && (w.chainConfig.Clique == nil || w.chainConfig.Clique.Period > 0) {
-				// Short circuit if no new transaction arrives.
-				if w.newTxs.Load() == 0 {
+				// Short circuit if no new transaction arrives except dBFT consensus. For
+				// dBFT we always need a fresh proposal with an updated block timestamp even
+				// if no new transactions received.
+				if w.newTxs.Load() == 0 && w.chainConfig.DBFT == nil {
 					timer.Reset(recommit)
 					continue
 				}


### PR DESCRIPTION
Close #54. Implement a part of #29.

Current PR contains the following major changes in the dBFT and miner logic:
1. Allow miner to submit several tasks for the same height on `--miner.recommit` timeout even if no new transactions arrived.
2. Make `DBFT` engine wait for a new sealing task every CV.
3. Do not return error from `Seal` on new sealing proposal if the previous proposal is still at work.
4. Restrict capacity of `blockQueue`.