### PR TITLE
dbft: always check for CV to init sealing proposal

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1162,6 +1162,7 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 func (c *DBFT) eventLoop() {
 events:
 	for {
+		oldView := c.dbft.ViewNumber
 		select {
 		case <-c.quit:
 			c.dbft.Timer.Stop()
@@ -1205,29 +1206,7 @@ events:
 					"#hash", rec.preparationHash != nil)
 			}
 			log.Debug("received message", fields...)
-			oldView := c.dbft.ViewNumber
 			c.dbft.OnReceive(&msg)
-			newView := c.dbft.ViewNumber
-			// If ChangeView has happened, we need to wait for the new proposal
-			// from miner.
-			if newView > oldView {
-				log.Info("Change view detected, waiting for new sealing task to be submitted by miner", "old view", oldView, "new view", newView)
-				c.sealingLock.Lock()
-				c.isSealing = false
-				c.sealingProposal = nil
-				c.sealingReceipts = nil
-				c.sealingTransactions = nil
-				c.sealingWaitingForNewProposal = true
-				c.sealingLock.Unlock()
-
-				t := <-c.sealingTask
-				log.Info("Start dBFT process for updated sealing work",
-					"view", newView,
-					"number", t.number,
-					"sealhash", t.sealingHash,
-					"prev", t.parentHash,
-				)
-			}
 		case txs := <-c.txEvents:
 			for _, tx := range txs.Txs {
 				c.dbft.OnTransaction(&Transaction{Tx: tx})
@@ -1240,6 +1219,27 @@ events:
 		case <-c.chainHeadSub.Err():
 			// System has stopped.
 			break events
+		}
+		newView := c.dbft.ViewNumber
+		// If ChangeView has happened, we always need to wait for the new proposal
+		// from miner.
+		if newView > oldView {
+			log.Info("Change view detected, waiting for new sealing task to be submitted by miner", "old view", oldView, "new view", newView)
+			c.sealingLock.Lock()
+			c.isSealing = false
+			c.sealingProposal = nil
+			c.sealingReceipts = nil
+			c.sealingTransactions = nil
+			c.sealingWaitingForNewProposal = true
+			c.sealingLock.Unlock()
+
+			t := <-c.sealingTask
+			log.Info("Start dBFT process for updated sealing work",
+				"view", newView,
+				"number", t.number,
+				"sealhash", t.sealingHash,
+				"prev", t.parentHash,
+			)
 		}
 		// Always process block event if there is any, we can add one above or external
 		// services can add several blocks during message processing.


### PR DESCRIPTION
CV may happen not only in `OnReceive` but also in `OnTimeout` event:
```
2023-12-22T17:13:56.937+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/dbft.go:482	received ChangeView	{"validator": 0, "reason": "Timeout", "new view": 1}
2023-12-22T17:13:57.108+0300	DEBUG	dbft@v0.0.0-20230515113611-25db6ba61d5c/dbft.go:185	timeout	{"height": 1, "view": 0}
2023-12-22T17:13:57.108+0300	DEBUG	dbft@v0.0.0-20230515113611-25db6ba61d5c/dbft.go:617	reset timer	{"h": 1, "v": 0, "delay": "20s"}
2023-12-22T17:13:57.108+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/send.go:80	request change view	{"view": 0, "height": 1, "reason": "Timeout", "new_view": 1, "nc": 0, "nf": 0}
2023-12-22T17:13:57.108+0300	DEBUG	dbft@v0.0.0-20230515113611-25db6ba61d5c/send.go:9	broadcasting message	{"type": "ChangeView", "height": 1, "view": 0}
2023-12-22T17:13:57.109+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/dbft.go:107	changing dbft view	{"height": 1, "view": 1, "index": 3, "role": "Backup"}
2023-12-22T17:13:57.109+0300	DEBUG	dbft@v0.0.0-20230515113611-25db6ba61d5c/dbft.go:617	reset timer	{"h": 1, "v": 1, "delay": "0s"}
2023-12-22T17:13:57.109+0300	DEBUG	dbft@v0.0.0-20230515113611-25db6ba61d5c/dbft.go:185	timeout	{"height": 1, "view": 1}
2023-12-22T17:13:57.109+0300	DEBUG	dbft@v0.0.0-20230515113611-25db6ba61d5c/dbft.go:617	reset timer	{"h": 1, "v": 1, "delay": "40s"}
2023-12-22T17:13:57.109+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/send.go:69	skip change view	{"nc": 0, "nf": 3}
2023-12-22T17:13:57.109+0300	DEBUG	dbft@v0.0.0-20230515113611-25db6ba61d5c/send.go:9	broadcasting message	{"type": "RecoveryRequest", "height": 1, "view": 1}
```

Thus, always check dBFT change view event. Require new view to be larger than the previous one in order not to catch initialisation at new height.

This commit should be a part of #70. Ref. #54.