### PR TITLE
dbft: Use RLP encoding for dBFT payloads

### DIFF
--- a/consensus/dbft/change_view.go
+++ b/consensus/dbft/change_view.go
@@ -2,31 +2,19 @@ package dbft
 
 import (
 	"github.com/nspcc-dev/dbft/payload"
-	"github.com/nspcc-dev/neo-go/pkg/io"
 )
 
 // changeView represents dBFT ChangeView message.
 type changeView struct {
+	// newViewNumber is not marshaled to rlp
 	newViewNumber byte
-	// timestamp is nanoseconds-precision payload timestamp, exactly like the one
+	// TimestampExt is nanoseconds-precision payload TimestampExt, exactly like the one
 	// that dBFT library operates internally with.
-	timestamp uint64
-	reason    payload.ChangeViewReason
+	TimestampExt uint64
+	ReasonExt    payload.ChangeViewReason
 }
 
 var _ payload.ChangeView = (*changeView)(nil)
-
-// EncodeBinary implements the io.Serializable interface.
-func (c *changeView) EncodeBinary(w *io.BinWriter) {
-	w.WriteU64LE(c.timestamp)
-	w.WriteB(byte(c.reason))
-}
-
-// DecodeBinary implements the io.Serializable interface.
-func (c *changeView) DecodeBinary(r *io.BinReader) {
-	c.timestamp = r.ReadU64LE()
-	c.reason = payload.ChangeViewReason(r.ReadB())
-}
 
 // NewViewNumber implements the payload.ChangeView interface.
 func (c changeView) NewViewNumber() byte { return c.newViewNumber }
@@ -35,13 +23,13 @@ func (c changeView) NewViewNumber() byte { return c.newViewNumber }
 func (c *changeView) SetNewViewNumber(view byte) { c.newViewNumber = view }
 
 // Timestamp implements the payload.ChangeView interface.
-func (c changeView) Timestamp() uint64 { return c.timestamp }
+func (c changeView) Timestamp() uint64 { return c.TimestampExt }
 
 // SetTimestamp implements the payload.ChangeView interface.
-func (c *changeView) SetTimestamp(ts uint64) { c.timestamp = ts }
+func (c *changeView) SetTimestamp(ts uint64) { c.TimestampExt = ts }
 
 // Reason implements the payload.ChangeView interface.
-func (c changeView) Reason() payload.ChangeViewReason { return c.reason }
+func (c changeView) Reason() payload.ChangeViewReason { return c.ReasonExt }
 
 // SetReason implements the payload.ChangeView interface.
-func (c *changeView) SetReason(reason payload.ChangeViewReason) { c.reason = reason }
+func (c *changeView) SetReason(reason payload.ChangeViewReason) { c.ReasonExt = reason }

--- a/consensus/dbft/change_view_test.go
+++ b/consensus/dbft/change_view_test.go
@@ -3,6 +3,7 @@ package dbft
 import (
 	"testing"
 
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,4 +15,15 @@ func TestChangeView_Setters(t *testing.T) {
 
 	c.SetNewViewNumber(2)
 	require.EqualValues(t, 2, c.NewViewNumber())
+}
+
+func TestChangeView_RLP(t *testing.T) {
+	c := &changeView{TimestampExt: 123, ReasonExt: 3}
+	bytes, err := rlp.EncodeToBytes(c)
+	require.NoError(t, err)
+
+	decoded := &changeView{}
+	err = rlp.DecodeBytes(bytes, decoded)
+	require.NoError(t, err)
+	require.Equal(t, c, decoded)
 }

--- a/consensus/dbft/commit.go
+++ b/consensus/dbft/commit.go
@@ -2,30 +2,19 @@ package dbft
 
 import (
 	"github.com/nspcc-dev/dbft/payload"
-	"github.com/nspcc-dev/neo-go/pkg/io"
 )
 
 // commit represents dBFT Commit message.
 type commit struct {
-	signature [extraSeal]byte
+	SignatureExt [extraSeal]byte
 }
 
 var _ payload.Commit = (*commit)(nil)
 
-// EncodeBinary implements the io.Serializable interface.
-func (c *commit) EncodeBinary(w *io.BinWriter) {
-	w.WriteBytes(c.signature[:])
-}
-
-// DecodeBinary implements the io.Serializable interface.
-func (c *commit) DecodeBinary(r *io.BinReader) {
-	r.ReadBytes(c.signature[:])
-}
-
 // Signature implements the payload.Commit interface.
-func (c commit) Signature() []byte { return c.signature[:] }
+func (c commit) Signature() []byte { return c.SignatureExt[:] }
 
 // SetSignature implements the payload.Commit interface.
 func (c *commit) SetSignature(signature []byte) {
-	copy(c.signature[:], signature)
+	copy(c.SignatureExt[:], signature)
 }

--- a/consensus/dbft/commit_test.go
+++ b/consensus/dbft/commit_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/stretchr/testify/require"
 )
 
@@ -16,4 +17,19 @@ func TestCommit_Setters(t *testing.T) {
 	var c commit
 	c.SetSignature(sign[:])
 	require.Equal(t, sign[:], c.Signature())
+}
+
+func TestCommit_RLP(t *testing.T) {
+	var sign [extraSeal]byte
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r.Read(sign[:])
+
+	c := &commit{SignatureExt: sign}
+	bytes, err := rlp.EncodeToBytes(c)
+	require.NoError(t, err)
+
+	decoded := &commit{}
+	err = rlp.DecodeBytes(bytes, decoded)
+	require.NoError(t, err)
+	require.Equal(t, c, decoded)
 }

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1163,20 +1163,20 @@ events:
 
 			if msg.Type() == payload.RecoveryMessageType {
 				rec := msg.GetRecoveryMessage().(*recoveryMessage)
-				if rec.preparationHash == nil {
+				if rec.PreparationHashExt == nil {
 					req := rec.GetPrepareRequest(&msg, c.dbft.Validators, uint16(c.dbft.PrimaryIndex))
 					if req != nil {
 						h := req.Hash()
-						rec.preparationHash = &h
+						rec.PreparationHashExt = &h
 					}
 				}
 
 				fields = append(fields,
-					"#preparation", len(rec.preparationPayloads),
-					"#commit", len(rec.commitPayloads),
-					"#changeview", len(rec.changeViewPayloads),
-					"#request", rec.prepareRequest != nil,
-					"#hash", rec.preparationHash != nil)
+					"#preparation", len(rec.PreparationPayloads),
+					"#commit", len(rec.CommitPayloads),
+					"#changeview", len(rec.ChangeViewPayloads),
+					"#request", rec.PrepareRequest != nil,
+					"#hash", rec.PreparationHashExt != nil)
 			}
 			log.Debug("received message", fields...)
 			c.dbft.OnReceive(&msg)

--- a/consensus/dbft/payload.go
+++ b/consensus/dbft/payload.go
@@ -3,11 +3,11 @@ package dbft
 import (
 	"bytes"
 	"fmt"
+	"io"
 
 	dbftproto "github.com/ethereum/go-ethereum/eth/protocols/dbft"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/nspcc-dev/dbft/payload"
-	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 )
 
@@ -19,8 +19,17 @@ type (
 		BlockIndex     uint64
 		ValidatorIndex byte
 		ViewNumber     byte
+		msgPayload     interface{}
+	}
 
-		payload io.Serializable
+	// messageAux is an auxiliary structure for message RLP encoding.
+	messageAux struct {
+		Type           messageType
+		BlockIndex     uint64
+		ValidatorIndex byte
+		ViewNumber     byte
+		// rlp encoded bytes of msgPayload
+		MsgPayload rlp.RawValue
 	}
 
 	// Payload is a type for consensus-related messages.
@@ -61,38 +70,42 @@ func (p *Payload) SetType(t payload.MessageType) {
 
 // Payload implements the payload.ConsensusPayload interface.
 func (p Payload) Payload() any {
-	return p.payload
+	return p.msgPayload
 }
 
 // SetPayload implements the payload.ConsensusPayload interface.
 func (p *Payload) SetPayload(pl any) {
-	p.payload = pl.(io.Serializable)
+	p.msgPayload = pl
 }
 
 // GetChangeView implements the payload.ConsensusPayload interface.
-func (p Payload) GetChangeView() payload.ChangeView { return p.payload.(payload.ChangeView) }
+func (p Payload) GetChangeView() payload.ChangeView {
+	return p.msgPayload.(*changeView)
+}
 
 // GetPrepareRequest implements the payload.ConsensusPayload interface.
 func (p Payload) GetPrepareRequest() payload.PrepareRequest {
-	return p.payload.(payload.PrepareRequest)
+	return p.msgPayload.(*prepareRequest)
 }
 
 // GetPrepareResponse implements the payload.ConsensusPayload interface.
 func (p Payload) GetPrepareResponse() payload.PrepareResponse {
-	return p.payload.(payload.PrepareResponse)
+	return p.msgPayload.(*prepareResponse)
 }
 
 // GetCommit implements the payload.ConsensusPayload interface.
-func (p Payload) GetCommit() payload.Commit { return p.payload.(payload.Commit) }
+func (p Payload) GetCommit() payload.Commit {
+	return p.msgPayload.(*commit)
+}
 
 // GetRecoveryRequest implements the payload.ConsensusPayload interface.
 func (p Payload) GetRecoveryRequest() payload.RecoveryRequest {
-	return p.payload.(payload.RecoveryRequest)
+	return p.msgPayload.(*recoveryRequest)
 }
 
 // GetRecoveryMessage implements the payload.ConsensusPayload interface.
 func (p Payload) GetRecoveryMessage() payload.RecoveryMessage {
-	return p.payload.(payload.RecoveryMessage)
+	return p.msgPayload.(*recoveryMessage)
 }
 
 // ValidatorIndex implements the payload.ConsensusPayload interface.
@@ -156,45 +169,6 @@ func (p *Payload) Hash() util.Uint256 {
 	return p.Message.Hash().Uint256()
 }
 
-// EncodeBinary implements the io.Serializable interface.
-func (m *message) EncodeBinary(w *io.BinWriter) {
-	w.WriteB(byte(m.Type))
-	w.WriteU64LE(m.BlockIndex)
-	w.WriteB(m.ValidatorIndex)
-	w.WriteB(m.ViewNumber)
-	m.payload.EncodeBinary(w)
-}
-
-// DecodeBinary implements the io.Serializable interface.
-func (m *message) DecodeBinary(r *io.BinReader) {
-	m.Type = messageType(r.ReadB())
-	m.BlockIndex = r.ReadU64LE()
-	m.ValidatorIndex = r.ReadB()
-	m.ViewNumber = r.ReadB()
-
-	switch m.Type {
-	case changeViewType:
-		cv := new(changeView)
-		// newViewNumber is not marshaled
-		cv.newViewNumber = m.ViewNumber + 1
-		m.payload = cv
-	case prepareRequestType:
-		m.payload = new(prepareRequest)
-	case prepareResponseType:
-		m.payload = new(prepareResponse)
-	case commitType:
-		m.payload = new(commit)
-	case recoveryRequestType:
-		m.payload = new(recoveryRequest)
-	case recoveryMessageType:
-		m.payload = new(recoveryMessage)
-	default:
-		r.Err = fmt.Errorf("invalid type: 0x%02x", byte(m.Type))
-		return
-	}
-	m.payload.DecodeBinary(r)
-}
-
 // String implements fmt.Stringer interface.
 func (t messageType) String() string {
 	switch t {
@@ -215,25 +189,65 @@ func (t messageType) String() string {
 	}
 }
 
+// DecodeRLP decodes a message from RLP.
+func (m *message) DecodeRLP(s *rlp.Stream) error {
+	var em messageAux
+	if err := s.Decode(&em); err != nil {
+		return err
+	}
+	m.Type, m.BlockIndex, m.ValidatorIndex, m.ViewNumber = em.Type, em.BlockIndex, em.ValidatorIndex, em.ViewNumber
+	switch m.Type {
+	case changeViewType:
+		m.msgPayload = &changeView{
+			// newViewNumber is not marshaled
+			newViewNumber: m.ViewNumber + 1,
+		}
+	case prepareRequestType:
+		m.msgPayload = new(prepareRequest)
+	case prepareResponseType:
+		m.msgPayload = new(prepareResponse)
+	case commitType:
+		m.msgPayload = &commit{}
+	case recoveryRequestType:
+		m.msgPayload = new(recoveryRequest)
+	case recoveryMessageType:
+		m.msgPayload = new(recoveryMessage)
+	default:
+		err := fmt.Errorf("invalid type: 0x%02x", byte(m.Type))
+		return err
+	}
+	return rlp.DecodeBytes(em.MsgPayload, m.msgPayload)
+}
+
+// EncodeRLP serializes a message as RLP.
+func (m *message) EncodeRLP(w io.Writer) error {
+	bytes, err := rlp.EncodeToBytes(m.msgPayload)
+	if err != nil {
+		return err
+	}
+
+	return rlp.Encode(w, &messageAux{
+		Type:           m.Type,
+		BlockIndex:     m.BlockIndex,
+		ValidatorIndex: m.ValidatorIndex,
+		ViewNumber:     m.ViewNumber,
+		MsgPayload:     bytes,
+	})
+}
+
 func (p *Payload) encodeData() {
 	if p.Message.Data == nil {
 		p.Message.ValidBlockStart = 0
 		p.Message.ValidBlockEnd = p.BlockIndex
-		bw := io.NewBufBinWriter()
-		p.message.EncodeBinary(bw.BinWriter)
-		if bw.Err != nil {
-			panic(fmt.Errorf("failed to encode payload: %w", bw.Err))
+		data, err := rlp.EncodeToBytes(&p.message)
+		if err != nil {
+			panic(fmt.Errorf("failed to encode payload: %w", err))
 		}
-		p.Message.Data = bw.Bytes()
+		p.Message.Data = data
 	}
 }
 
 // decode data of payload into its message.
 func (p *Payload) decodeData() error {
-	br := io.NewBinReaderFromBuf(p.Message.Data)
-	p.message.DecodeBinary(br)
-	if br.Err != nil {
-		return fmt.Errorf("can't decode message: %w", br.Err)
-	}
-	return nil
+	return rlp.DecodeBytes(p.Message.Data, &p.message)
 }

--- a/consensus/dbft/prepare_request.go
+++ b/consensus/dbft/prepare_request.go
@@ -1,13 +1,9 @@
 package dbft
 
 import (
-	"fmt"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/nspcc-dev/dbft/payload"
-	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 )
 
@@ -67,25 +63,3 @@ func (p *prepareRequest) NextConsensus() util.Uint160 { return util.Uint160{} }
 
 // SetNextConsensus implements the payload.PrepareRequest interface.
 func (p *prepareRequest) SetNextConsensus(_ util.Uint160) {}
-
-// EncodeBinary implements the io.Serializable interface.
-func (p *prepareRequest) EncodeBinary(w *io.BinWriter) {
-	b, err := rlp.EncodeToBytes(p)
-	if err != nil {
-		w.Err = fmt.Errorf("failed to encode PrepareRequest to RLP: %w", err)
-		return
-	}
-	w.WriteVarBytes(b)
-}
-
-// DecodeBinary implements the io.Serializable interface.
-func (p *prepareRequest) DecodeBinary(r *io.BinReader) {
-	b := r.ReadVarBytes()
-	if r.Err != nil {
-		return
-	}
-	err := rlp.DecodeBytes(b, p)
-	if err != nil {
-		r.Err = fmt.Errorf("failed to decode PrepareRequest RLP: %w", err)
-	}
-}

--- a/consensus/dbft/prepare_request_test.go
+++ b/consensus/dbft/prepare_request_test.go
@@ -1,0 +1,50 @@
+package dbft
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareRequest_RLP(t *testing.T) {
+	pr := &prepareRequest{
+		SealingProposal: &types.Header{
+			ParentHash:       common.Hash{1, 2, 3},
+			UncleHash:        common.Hash{1, 2, 3},
+			Coinbase:         common.Address{1, 2, 3},
+			Root:             common.Hash{1, 2, 3},
+			TxHash:           common.Hash{1, 2, 3},
+			ReceiptHash:      common.Hash{1, 2, 3},
+			Bloom:            types.Bloom{1, 2, 3},
+			Difficulty:       big.NewInt(0),
+			Number:           big.NewInt(1),
+			GasLimit:         0,
+			GasUsed:          0,
+			Time:             0,
+			Extra:            []byte{1, 2, 3},
+			MixDigest:        common.Hash{1, 2, 3},
+			Nonce:            types.BlockNonce{},
+			BaseFee:          nil,
+			WithdrawalsHash:  nil,
+			BlobGasUsed:      nil,
+			ExcessBlobGas:    nil,
+			ParentBeaconRoot: nil,
+		},
+		TxHashes:       []util.Uint256{util.Uint256{}},
+		ParentSealHash: common.Hash{1, 2, 3},
+		ParentExtra:    []byte{1, 2, 3},
+	}
+
+	bytes, err := rlp.EncodeToBytes(pr)
+	require.NoError(t, err)
+
+	decoded := &prepareRequest{}
+	err = rlp.DecodeBytes(bytes, decoded)
+	require.NoError(t, err)
+	require.Equal(t, pr, decoded)
+}

--- a/consensus/dbft/prepare_response.go
+++ b/consensus/dbft/prepare_response.go
@@ -2,29 +2,18 @@ package dbft
 
 import (
 	"github.com/nspcc-dev/dbft/payload"
-	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 )
 
 // prepareResponse represents dBFT PrepareResponse message.
 type prepareResponse struct {
-	preparationHash util.Uint256
+	PreparationHashExt util.Uint256
 }
 
 var _ payload.PrepareResponse = (*prepareResponse)(nil)
 
-// EncodeBinary implements the io.Serializable interface.
-func (p *prepareResponse) EncodeBinary(w *io.BinWriter) {
-	w.WriteBytes(p.preparationHash[:])
-}
-
-// DecodeBinary implements the io.Serializable interface.
-func (p *prepareResponse) DecodeBinary(r *io.BinReader) {
-	r.ReadBytes(p.preparationHash[:])
-}
-
 // PreparationHash implements the payload.PrepareResponse interface.
-func (p *prepareResponse) PreparationHash() util.Uint256 { return p.preparationHash }
+func (p *prepareResponse) PreparationHash() util.Uint256 { return p.PreparationHashExt }
 
 // SetPreparationHash implements the payload.PrepareResponse interface.
-func (p *prepareResponse) SetPreparationHash(h util.Uint256) { p.preparationHash = h }
+func (p *prepareResponse) SetPreparationHash(h util.Uint256) { p.PreparationHashExt = h }

--- a/consensus/dbft/prepare_response_test.go
+++ b/consensus/dbft/prepare_response_test.go
@@ -3,6 +3,7 @@ package dbft
 import (
 	"testing"
 
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/stretchr/testify/require"
 )
@@ -12,4 +13,15 @@ func TestPrepareResponse_Setters(t *testing.T) {
 
 	p.SetPreparationHash(util.Uint256{1, 2, 3})
 	require.Equal(t, util.Uint256{1, 2, 3}, p.PreparationHash())
+}
+
+func TestPrepareResponse_RLP(t *testing.T) {
+	c := &prepareResponse{PreparationHashExt: util.Uint256{1}}
+	bytes, err := rlp.EncodeToBytes(c)
+	require.NoError(t, err)
+
+	decoded := &prepareResponse{}
+	err = rlp.DecodeBytes(bytes, decoded)
+	require.NoError(t, err)
+	require.Equal(t, c, decoded)
 }

--- a/consensus/dbft/recovery_message.go
+++ b/consensus/dbft/recovery_message.go
@@ -2,22 +2,32 @@ package dbft
 
 import (
 	"errors"
+	"io"
 
 	dbftproto "github.com/ethereum/go-ethereum/eth/protocols/dbft"
+	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/nspcc-dev/dbft/crypto"
 	"github.com/nspcc-dev/dbft/payload"
-	"github.com/nspcc-dev/neo-go/pkg/io"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 )
 
 type (
 	// recoveryMessage represents dBFT Recovery message.
 	recoveryMessage struct {
-		preparationHash     *util.Uint256
-		preparationPayloads []*preparationCompact
-		commitPayloads      []*commitCompact
-		changeViewPayloads  []*changeViewCompact
-		prepareRequest      *message
+		PreparationPayloads []*preparationCompact
+		CommitPayloads      []*commitCompact
+		ChangeViewPayloads  []*changeViewCompact
+		PreparationHashExt  *util.Uint256
+		PrepareRequest      *message
+	}
+
+	// recoveryMessageAux is an auxiliary structure for recoveryMessage RLP encoding.
+	recoveryMessageAux struct {
+		PreparationPayloads []*preparationCompact
+		CommitPayloads      []*commitCompact
+		ChangeViewPayloads  []*changeViewCompact
+		PreparationHashExt  *util.Uint256 `rlp:"optional"`
+		PrepareRequest      *message      `rlp:"optional"`
 	}
 
 	changeViewCompact struct {
@@ -42,140 +52,45 @@ type (
 
 var _ payload.RecoveryMessage = (*recoveryMessage)(nil)
 
-// DecodeBinary implements the io.Serializable interface.
-func (m *recoveryMessage) DecodeBinary(r *io.BinReader) {
-	r.ReadArray(&m.changeViewPayloads)
-
-	var hasReq = r.ReadBool()
-	if hasReq {
-		m.prepareRequest = &message{}
-		m.prepareRequest.DecodeBinary(r)
-		if r.Err == nil && m.prepareRequest.Type != prepareRequestType {
-			r.Err = errors.New("recovery message PrepareRequest has wrong type")
-			return
-		}
-	} else {
-		l := r.ReadVarUint()
-		if l != 0 {
-			if l == util.Uint256Size {
-				m.preparationHash = new(util.Uint256)
-				r.ReadBytes(m.preparationHash[:])
-			} else {
-				r.Err = errors.New("invalid data")
-			}
-		} else {
-			m.preparationHash = nil
-		}
-	}
-
-	r.ReadArray(&m.preparationPayloads)
-	r.ReadArray(&m.commitPayloads)
-}
-
-// EncodeBinary implements the io.Serializable interface.
-func (m *recoveryMessage) EncodeBinary(w *io.BinWriter) {
-	w.WriteArray(m.changeViewPayloads)
-
-	hasReq := m.prepareRequest != nil
-	w.WriteBool(hasReq)
-	if hasReq {
-		m.prepareRequest.EncodeBinary(w)
-	} else {
-		if m.preparationHash == nil {
-			w.WriteVarUint(0)
-		} else {
-			w.WriteVarUint(util.Uint256Size)
-			w.WriteBytes(m.preparationHash[:])
-		}
-	}
-
-	w.WriteArray(m.preparationPayloads)
-	w.WriteArray(m.commitPayloads)
-}
-
-// DecodeBinary implements the io.Serializable interface.
-func (p *changeViewCompact) DecodeBinary(r *io.BinReader) {
-	p.ValidatorIndex = r.ReadB()
-	p.OriginalViewNumber = r.ReadB()
-	p.Timestamp = r.ReadU64LE()
-	p.InvocationScript = r.ReadVarBytes(1024)
-}
-
-// EncodeBinary implements the io.Serializable interface.
-func (p *changeViewCompact) EncodeBinary(w *io.BinWriter) {
-	w.WriteB(p.ValidatorIndex)
-	w.WriteB(p.OriginalViewNumber)
-	w.WriteU64LE(p.Timestamp)
-	w.WriteVarBytes(p.InvocationScript)
-}
-
-// DecodeBinary implements the io.Serializable interface.
-func (p *commitCompact) DecodeBinary(r *io.BinReader) {
-	p.ViewNumber = r.ReadB()
-	p.ValidatorIndex = r.ReadB()
-	r.ReadBytes(p.Signature[:])
-	p.InvocationScript = r.ReadVarBytes(1024)
-}
-
-// EncodeBinary implements the io.Serializable interface.
-func (p *commitCompact) EncodeBinary(w *io.BinWriter) {
-	w.WriteB(p.ViewNumber)
-	w.WriteB(p.ValidatorIndex)
-	w.WriteBytes(p.Signature[:])
-	w.WriteVarBytes(p.InvocationScript)
-}
-
-// DecodeBinary implements the io.Serializable interface.
-func (p *preparationCompact) DecodeBinary(r *io.BinReader) {
-	p.ValidatorIndex = r.ReadB()
-	p.InvocationScript = r.ReadVarBytes(1024)
-}
-
-// EncodeBinary implements the io.Serializable interface.
-func (p *preparationCompact) EncodeBinary(w *io.BinWriter) {
-	w.WriteB(p.ValidatorIndex)
-	w.WriteVarBytes(p.InvocationScript)
-}
-
 // AddPayload implements the payload.RecoveryMessage interface.
 func (m *recoveryMessage) AddPayload(p payload.ConsensusPayload) {
 	validator := uint8(p.ValidatorIndex())
 
 	switch p.Type() {
 	case payload.PrepareRequestType:
-		m.prepareRequest = &message{
+		m.PrepareRequest = &message{
 			Type:       prepareRequestType,
 			ViewNumber: p.ViewNumber(),
-			payload:    p.GetPrepareRequest().(*prepareRequest),
+			msgPayload: p.GetPrepareRequest().(*prepareRequest),
 		}
 		h := p.Hash()
-		m.preparationHash = &h
-		m.preparationPayloads = append(m.preparationPayloads, &preparationCompact{
+		m.PreparationHashExt = &h
+		m.PreparationPayloads = append(m.PreparationPayloads, &preparationCompact{
 			ValidatorIndex:   validator,
 			InvocationScript: p.(*Payload).Witness,
 		})
 	case payload.PrepareResponseType:
-		m.preparationPayloads = append(m.preparationPayloads, &preparationCompact{
+		m.PreparationPayloads = append(m.PreparationPayloads, &preparationCompact{
 			ValidatorIndex:   validator,
 			InvocationScript: p.(*Payload).Witness,
 		})
 
-		if m.preparationHash == nil {
+		if m.PreparationHashExt == nil {
 			h := p.GetPrepareResponse().PreparationHash()
-			m.preparationHash = &h
+			m.PreparationHashExt = &h
 		}
 	case payload.ChangeViewType:
-		m.changeViewPayloads = append(m.changeViewPayloads, &changeViewCompact{
+		m.ChangeViewPayloads = append(m.ChangeViewPayloads, &changeViewCompact{
 			ValidatorIndex:     validator,
 			OriginalViewNumber: p.ViewNumber(),
 			Timestamp:          p.GetChangeView().Timestamp(),
 			InvocationScript:   p.(*Payload).Witness,
 		})
 	case payload.CommitType:
-		m.commitPayloads = append(m.commitPayloads, &commitCompact{
+		m.CommitPayloads = append(m.CommitPayloads, &commitCompact{
 			ValidatorIndex:   validator,
 			ViewNumber:       p.ViewNumber(),
-			Signature:        p.GetCommit().(*commit).signature,
+			Signature:        p.GetCommit().(*commit).SignatureExt,
 			InvocationScript: p.(*Payload).Witness,
 		})
 	}
@@ -183,12 +98,12 @@ func (m *recoveryMessage) AddPayload(p payload.ConsensusPayload) {
 
 // GetPrepareRequest implements the payload.RecoveryMessage interface.
 func (m *recoveryMessage) GetPrepareRequest(p payload.ConsensusPayload, validators []crypto.PublicKey, primary uint16) payload.ConsensusPayload {
-	if m.prepareRequest == nil {
+	if m.PrepareRequest == nil {
 		return nil
 	}
 
 	var compact *preparationCompact
-	for _, p := range m.preparationPayloads {
+	for _, p := range m.PreparationPayloads {
 		if p != nil && p.ValidatorIndex == uint8(primary) {
 			compact = p
 			break
@@ -199,7 +114,7 @@ func (m *recoveryMessage) GetPrepareRequest(p payload.ConsensusPayload, validato
 		return nil
 	}
 
-	req := fromPayload(prepareRequestType, p.(*Payload), m.prepareRequest.payload)
+	req := fromPayload(prepareRequestType, p.(*Payload), m.PrepareRequest.msgPayload)
 	req.SetValidatorIndex(primary)
 	req.Sender = validators[primary].(*PublicKey).Account
 	req.Witness = compact.InvocationScript
@@ -209,15 +124,15 @@ func (m *recoveryMessage) GetPrepareRequest(p payload.ConsensusPayload, validato
 
 // GetPrepareResponses implements the payload.RecoveryMessage interface.
 func (m *recoveryMessage) GetPrepareResponses(p payload.ConsensusPayload, validators []crypto.PublicKey) []payload.ConsensusPayload {
-	if m.preparationHash == nil {
+	if m.PreparationHashExt == nil {
 		return nil
 	}
 
-	ps := make([]payload.ConsensusPayload, len(m.preparationPayloads))
+	ps := make([]payload.ConsensusPayload, len(m.PreparationPayloads))
 
-	for i, resp := range m.preparationPayloads {
+	for i, resp := range m.PreparationPayloads {
 		r := fromPayload(prepareResponseType, p.(*Payload), &prepareResponse{
-			preparationHash: *m.preparationHash,
+			PreparationHashExt: *m.PreparationHashExt,
 		})
 		r.SetValidatorIndex(uint16(resp.ValidatorIndex))
 		r.Sender = validators[resp.ValidatorIndex].(*PublicKey).Account
@@ -231,12 +146,12 @@ func (m *recoveryMessage) GetPrepareResponses(p payload.ConsensusPayload, valida
 
 // GetChangeViews implements the payload.RecoveryMessage interface.
 func (m *recoveryMessage) GetChangeViews(p payload.ConsensusPayload, validators []crypto.PublicKey) []payload.ConsensusPayload {
-	ps := make([]payload.ConsensusPayload, len(m.changeViewPayloads))
+	ps := make([]payload.ConsensusPayload, len(m.ChangeViewPayloads))
 
-	for i, cv := range m.changeViewPayloads {
+	for i, cv := range m.ChangeViewPayloads {
 		c := fromPayload(changeViewType, p.(*Payload), &changeView{
 			newViewNumber: cv.OriginalViewNumber + 1,
-			timestamp:     cv.Timestamp,
+			TimestampExt:  cv.Timestamp,
 		})
 		c.message.ViewNumber = cv.OriginalViewNumber
 		c.SetValidatorIndex(uint16(cv.ValidatorIndex))
@@ -251,10 +166,10 @@ func (m *recoveryMessage) GetChangeViews(p payload.ConsensusPayload, validators 
 
 // GetCommits implements the payload.RecoveryMessage interface.
 func (m *recoveryMessage) GetCommits(p payload.ConsensusPayload, validators []crypto.PublicKey) []payload.ConsensusPayload {
-	ps := make([]payload.ConsensusPayload, len(m.commitPayloads))
+	ps := make([]payload.ConsensusPayload, len(m.CommitPayloads))
 
-	for i, c := range m.commitPayloads {
-		cc := fromPayload(commitType, p.(*Payload), &commit{signature: c.Signature})
+	for i, c := range m.CommitPayloads {
+		cc := fromPayload(commitType, p.(*Payload), &commit{SignatureExt: c.Signature})
 		cc.SetValidatorIndex(uint16(c.ValidatorIndex))
 		cc.Sender = validators[c.ValidatorIndex].(*PublicKey).Account
 		cc.Witness = c.InvocationScript
@@ -267,15 +182,15 @@ func (m *recoveryMessage) GetCommits(p payload.ConsensusPayload, validators []cr
 
 // PreparationHash implements the payload.RecoveryMessage interface.
 func (m *recoveryMessage) PreparationHash() *util.Uint256 {
-	return m.preparationHash
+	return m.PreparationHashExt
 }
 
 // SetPreparationHash implements the payload.RecoveryMessage interface.
 func (m *recoveryMessage) SetPreparationHash(h *util.Uint256) {
-	m.preparationHash = h
+	m.PreparationHashExt = h
 }
 
-func fromPayload(t messageType, recovery *Payload, p io.Serializable) *Payload {
+func fromPayload(t messageType, recovery *Payload, p any) *Payload {
 	return &Payload{
 		Message: dbftproto.Message{
 			ValidBlockEnd: recovery.BlockIndex,
@@ -285,7 +200,38 @@ func fromPayload(t messageType, recovery *Payload, p io.Serializable) *Payload {
 			Type:       t,
 			BlockIndex: recovery.BlockIndex,
 			ViewNumber: recovery.message.ViewNumber,
-			payload:    p,
+			msgPayload: p,
 		},
 	}
+}
+
+// EncodeRLP serializes recoveryMessage as RLP.
+func (m *recoveryMessage) EncodeRLP(w io.Writer) error {
+	return rlp.Encode(w, &recoveryMessageAux{
+		PreparationPayloads: m.PreparationPayloads,
+		CommitPayloads:      m.CommitPayloads,
+		ChangeViewPayloads:  m.ChangeViewPayloads,
+		PreparationHashExt:  m.PreparationHashExt,
+		PrepareRequest:      m.PrepareRequest,
+	})
+}
+
+// DecodeRLP decodes recoveryMessage from RLP.
+func (m *recoveryMessage) DecodeRLP(s *rlp.Stream) error {
+	var aux recoveryMessageAux
+	if err := s.Decode(&aux); err != nil {
+		return err
+	}
+
+	// Perform some validity checks.
+	if aux.PrepareRequest != nil && aux.PrepareRequest.Type != prepareRequestType {
+		return errors.New("recovery message PrepareRequest has wrong type")
+	}
+
+	m.PreparationPayloads = aux.PreparationPayloads
+	m.CommitPayloads = aux.CommitPayloads
+	m.ChangeViewPayloads = aux.ChangeViewPayloads
+	m.PreparationHashExt = aux.PreparationHashExt
+	m.PrepareRequest = aux.PrepareRequest
+	return nil
 }

--- a/consensus/dbft/recovery_message_test.go
+++ b/consensus/dbft/recovery_message_test.go
@@ -1,22 +1,23 @@
 package dbft
 
 import (
-	"crypto/rand"
 	"math/big"
+	"math/rand"
 	"testing"
+	"time"
 
-	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/crypto"
-	dbftproto "github.com/ethereum/go-ethereum/eth/protocols/dbft"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/nspcc-dev/neo-go/pkg/util"
 	"github.com/stretchr/testify/require"
 )
 
-func TestPayloadSerializable(t *testing.T) {
-	gk, _ := crypto.GenerateKey()
+func TestRecoverMessage_RLP(t *testing.T) {
+	var sign [extraSeal]byte
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	r.Read(sign[:])
+
 	pr := &prepareRequest{
 		SealingProposal: &types.Header{
 			ParentHash:       common.Hash{1, 2, 3},
@@ -40,19 +41,18 @@ func TestPayloadSerializable(t *testing.T) {
 			ExcessBlobGas:    nil,
 			ParentBeaconRoot: nil,
 		},
-		TxHashes:       []util.Uint256{},
+		TxHashes:       []util.Uint256{util.Uint256{}},
 		ParentSealHash: common.Hash{1, 2, 3},
 		ParentExtra:    []byte{1, 2, 3},
 	}
-	expected := &Payload{
-		Message: dbftproto.Message{
-			ValidBlockStart: 0,
-			ValidBlockEnd:   1,
-			Sender:          crypto.PubkeyToAddress(gk.PublicKey),
-			Data:            nil,
-			Witness:         nil,
-		},
-		message: message{
+
+	rm := &recoveryMessage{
+		PreparationHashExt: &util.Uint256{1, 2},
+		PreparationPayloads: []*preparationCompact{
+			{ValidatorIndex: 1, InvocationScript: []byte{1, 2, 3}}},
+		CommitPayloads:     []*commitCompact{{ViewNumber: 1, ValidatorIndex: 1, Signature: sign, InvocationScript: []byte{1, 2, 3, 4, 5}}},
+		ChangeViewPayloads: []*changeViewCompact{{ValidatorIndex: 1, OriginalViewNumber: 2, Timestamp: 3, InvocationScript: []byte{1, 2, 3, 4, 5, 6}}},
+		PrepareRequest: &message{
 			Type:           prepareRequestType,
 			BlockIndex:     1,
 			ValidatorIndex: 2,
@@ -61,29 +61,11 @@ func TestPayloadSerializable(t *testing.T) {
 		},
 	}
 
-	err := expected.Sign(&Signer{
-		Signer: crypto.PubkeyToAddress(gk.PublicKey),
-		SignFn: func(signer accounts.Account, mimeType string, message []byte) ([]byte, error) {
-			return gk.Sign(rand.Reader, crypto.Keccak256(message), nil)
-		},
-	})
-	require.NoError(t, err)
-	require.NotNil(t, expected.Data)
-	require.NotNil(t, expected.Witness)
-
-	m := expected.Message
-	h := m.Hash()
-	require.NotNil(t, h)
-
-	b, err := rlp.EncodeToBytes(m)
+	bytes, err := rlp.EncodeToBytes(rm)
 	require.NoError(t, err)
 
-	var actual = new(dbftproto.Message)
-	require.NoError(t, rlp.DecodeBytes(b, actual))
-	require.Equal(t, expected.Message, *actual)
-
-	actualP := payloadFromMessage(actual)
-	require.NoError(t, actualP.decodeData())
-
-	require.Equal(t, expected, actualP)
+	decoded := &recoveryMessage{}
+	err = rlp.DecodeBytes(bytes, decoded)
+	require.NoError(t, err)
+	require.Equal(t, rm, decoded)
 }

--- a/consensus/dbft/recovery_request.go
+++ b/consensus/dbft/recovery_request.go
@@ -2,28 +2,17 @@ package dbft
 
 import (
 	"github.com/nspcc-dev/dbft/payload"
-	"github.com/nspcc-dev/neo-go/pkg/io"
 )
 
 // recoveryRequest represents dBFT RecoveryRequest message.
 type recoveryRequest struct {
-	timestamp uint64
+	TimestampExt uint64
 }
 
 var _ payload.RecoveryRequest = (*recoveryRequest)(nil)
 
-// DecodeBinary implements the io.Serializable interface.
-func (m *recoveryRequest) DecodeBinary(r *io.BinReader) {
-	m.timestamp = r.ReadU64LE()
-}
-
-// EncodeBinary implements the io.Serializable interface.
-func (m *recoveryRequest) EncodeBinary(w *io.BinWriter) {
-	w.WriteU64LE(m.timestamp)
-}
-
 // Timestamp implements the payload.RecoveryRequest interface.
-func (m *recoveryRequest) Timestamp() uint64 { return m.timestamp }
+func (m *recoveryRequest) Timestamp() uint64 { return m.TimestampExt }
 
 // SetTimestamp implements the payload.RecoveryRequest interface.
-func (m *recoveryRequest) SetTimestamp(ts uint64) { m.timestamp = ts }
+func (m *recoveryRequest) SetTimestamp(ts uint64) { m.TimestampExt = ts }

--- a/consensus/dbft/recovery_request_test.go
+++ b/consensus/dbft/recovery_request_test.go
@@ -1,0 +1,19 @@
+package dbft
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecoveryRequest_RLP(t *testing.T) {
+	c := &recoveryRequest{TimestampExt: 12345}
+	bytes, err := rlp.EncodeToBytes(c)
+	require.NoError(t, err)
+
+	decoded := &recoveryRequest{}
+	err = rlp.DecodeBytes(bytes, decoded)
+	require.NoError(t, err)
+	require.Equal(t, c, decoded)
+}


### PR DESCRIPTION
Close #62. Use RLP encoding for dBFT payloads.