### PR TITLE
scripts: add a basic loading tool for privnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ privnet_stop: privnet_bootnode_stop privnet_nodes_stop
 privnet_clean: privnet_stop
 	@echo "Cleaning the nodes database files from $(MAIN_DIR)"
 	@find $(MAIN_DIR)/* -type d -name 'geth' -print -exec rm -rf {} +
-	@find $(MAIN_DIR)/* -type s,f -not \( -path '*/keystore/*' -or -name '*.json' -or -name '*.txt' -or -name '*.key' -or -name '*.md' \) -print -exec rm -f {} +
+	@find $(MAIN_DIR)/* -type s,f -not \( -path '*/keystore/*' -or -path '*/scripts/*' -or -name '*.json' -or -name '*.txt' -or -name '*.key' -or -name '*.md' \) -print -exec rm -f {} +
 
 $(SINGLE_DIR)/$(NODE1)/geth:
 	@echo "Initializing $(NODE1) from genesis"

--- a/privnet/scripts/load.go
+++ b/privnet/scripts/load.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"os"
+	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+const (
+	// loadInterval is a time interval between subsequent transactions batch sending.
+	loadInterval = time.Second * 15
+	// txBatchSize is a number of transactions per batch.
+	txBatchSize = 10
+)
+
+var (
+	// RPC endpoints.
+	rpc1 = "http://localhost:8552"
+	rpc5 = "http://localhost:8556"
+
+	// Wallet data.
+	keystore1 = "./privnet/four/node1/keystore/UTC--2023-12-05T08-14-15.728267292Z--d4d71adea0eeb18568fecf0fae0810a8520b438b"
+	pass1     = "b3Qx3RxWEFEFbQ5dRtaeEzeBRXR4rasV"
+
+	// Nodes addresses.
+	node1         = common.HexToAddress("d4d71adea0eeb18568fecf0fae0810a8520b438b")
+	node2         = common.HexToAddress("be0c8b1251697f919af32a42b7892b13026433b8")
+	node3         = common.HexToAddress("a6b78921e12d527e13a3907da9d6a1fd8e6f8d0a")
+	node4         = common.HexToAddress("021d70769889c46db0a8b0b22245c7ffd956d343")
+	nodeAddresses = []common.Address{node1, node2, node3, node4}
+)
+
+func main() {
+	rpcC1, err := rpc.Dial(rpc1)
+	check(err)
+	c := ethclient.NewClient(rpcC1)
+	ctx := context.Background()
+
+	chainID, err := c.ChainID(ctx)
+	check(err)
+
+	ks1, err := os.Open(keystore1)
+	check(err)
+	opts, err := bind.NewTransactorWithChainID(ks1, pass1, chainID)
+	check(err)
+
+	var (
+		gasFeeCap        = big.NewInt(1000)
+		gasTipCap        = big.NewInt(500)
+		gasLimit  uint64 = 30000
+		value            = big.NewInt(250)
+	)
+	gasPrice, err := c.SuggestGasPrice(ctx)
+	check(err)
+
+	opts.Value = value
+	opts.GasFeeCap = gasFeeCap
+	opts.GasTipCap = gasTipCap
+	opts.GasLimit = gasLimit
+
+	var batchCnt int
+	for {
+		nonce, err := c.PendingNonceAt(ctx, opts.From)
+		check(err)
+		var sentCnt int
+		for i := 0; i < txBatchSize; i++ {
+			baseTx := &types.LegacyTx{
+				To:       &nodeAddresses[i%4],
+				Nonce:    nonce,
+				GasPrice: gasPrice,
+				Gas:      gasLimit,
+				Value:    value,
+				Data:     nil,
+			}
+			rawTx := types.NewTx(baseTx)
+			signedTx, err := opts.Signer(opts.From, rawTx)
+			check(err)
+
+			err = c.SendTransaction(ctx, signedTx)
+			if err == nil {
+				sentCnt++
+			}
+			nonce++
+		}
+		batchCnt++
+		fmt.Printf("Batch #%d:\n\t%d transactions sent\n\tlast nonce %d\n", batchCnt, sentCnt, nonce-1)
+		time.Sleep(loadInterval)
+	}
+}
+
+func check(err error) {
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
Tool is capable of sending simple ETH transfer transactions from authorized sender (one of the consensus nodes) to another consensus node. Transactions grouped in batches with customizable number of transactions per batch. Batches are being sent with some pre-defined time interval.

I've used this tool to test 4-nodes privnet and detect "Invalid merkle root" problem described in https://github.com/bane-labs/go-ethereum/issues/80. The target branch was taken from https://github.com/bane-labs/go-ethereum/pull/79. However, my privnet properly accepts generated transactions, e.g. here's the result of `$ cat privnet/four/node1/geth_node.log | grep tx_count`:
```
2023-12-27T16:28:46.681+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 663, "hash": "418f75f9ebbac30fc2c686364147a70c47641bf80eaac313d8f833b2e89026b3", "tx_count": 10, "merkle": "54cb79764b918092953a26d448c866bf9de148f6809415065e44173da9aafdf6", "prev": "a231c6f615e6ffc461ab2e929755cb19e1ee58f84ba82617479b76890b7e17a5"}
2023-12-27T16:29:01.696+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 664, "hash": "5c6c7909df8fdbc89901c4eeab9cfbb2fca1d0d372b0a4e96f09e14ad5d69818", "tx_count": 10, "merkle": "714b179ff96960756fa969f367ea06a3ad9e6106dcbcb0e8b332036407220d08", "prev": "4a15ab01b9780bdf8fce44d8a8db6d575ae927a16748f147dbbc6aeccbda0282"}
2023-12-27T16:29:16.701+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 665, "hash": "12db379bb868ab9746dbde6010281f260cd906210fe8edd373ee4fbd7135020a", "tx_count": 10, "merkle": "e53958ac9c835eec0b360992064263bc2adb37c779df4fb0792ea55d92f44f67", "prev": "35efd92b1739caf3d1f395a8dd77e7f7921e06de85d46645e5f228d14cb9421f"}
2023-12-27T16:29:31.814+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 666, "hash": "223b8c48f5e61f4de47c01513b02e51ee2d18f23632d968a185f0a24f3b2c492", "tx_count": 10, "merkle": "df835e0a0fc2664b7f25d9c1363259b7ffa1a67417afd5e71ce8459cf8215edd", "prev": "69730012d84351a1e5d1991ac9c56d944cfbbfc51114a0128bac689d4211b3c4"}
2023-12-27T16:29:46.818+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 667, "hash": "8525f15022ca9dc2de6955511a017ea422b8f7c3254c8d50dadbe877b01503f6", "tx_count": 10, "merkle": "b8285b6b3b2ad7faf3cd45a4a80bb66d04a14216bfb21356b49a4692a82ea2d0", "prev": "6c08d59717bfd824eb79a825745972588dd0355d018fa51ff92dc4dfa3237537"}
2023-12-27T16:30:01.877+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 668, "hash": "2efb72164f3d7b3059cefb981990f74730d86e953c2d544c1b375c9bbe89707b", "tx_count": 10, "merkle": "1f8a502ebaeb800c4742b77a5d4ad9c29dd14a0798ce31244415746b30e5f3b2", "prev": "9edbaec1f831d0e71bc7e4ccac6491046b02433b36011067095decbe9da9f233"}
2023-12-27T16:30:16.897+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 669, "hash": "e6609ccc6246cc26a69745fbcbf4059e840352748ac44c0d36da66049dca279d", "tx_count": 10, "merkle": "5199029e7d8e0109bb143891f947cf4454142f7ea9172a071c33c756d4e263f4", "prev": "a0ae2ab83c2c8ded4d742e5e57f00a61c403068be75a5d519e4f5f62e343a4e4"}
2023-12-27T16:30:31.902+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 670, "hash": "9a5a5f63aa8b3a11fa1bc6ccdad2651020a68bf508f1f110faf416c3b7af3b62", "tx_count": 10, "merkle": "ce43e633afb3319ab8fdf5ee301540af700ff6cd7d229bebe8bcfb75106ce034", "prev": "c9e584ecccd4c2c028a7f6c43374272184777c4f479c46effd40a19446d23adb"}
2023-12-27T16:30:46.907+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 671, "hash": "db4a14144e75b8b3b68fca0b6ed270a626d8a184ab0d9082758b0a3c4d2e7a65", "tx_count": 10, "merkle": "7e92335fbbe6b7d0a96f8578978ce9872b9e51de7bf585a3d8a6d8f7c3ffb1d9", "prev": "d510c065092c06433bde56b31146c64d2932186d33a4f7fedbace03d5456f8e9"}
2023-12-27T16:31:01.945+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 672, "hash": "6aef3d07a75f8a1df4ba38ce72d37d38b54be59930a3a950c9afbd5c5d2a8f6d", "tx_count": 10, "merkle": "1e7117ecba414049a78552657d90422dac8cc80b64efac839dffd8c79891d0ea", "prev": "7b1e0eba77a19458cfb5b41f2d43da1eda03c8d65a49d33bb58ac1e48788db37"}
2023-12-27T16:31:16.964+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 673, "hash": "b469053dd1d68fdd0a0190af1bc5dfa34269ac73fd9cbcf764d8c7fb2a141e85", "tx_count": 10, "merkle": "c4235c2a39c54863be63a778e70ac11914b5d334a9606e2d2be6d1f868919441", "prev": "1b85c816cb453f33ddf26294869ba8190de8de4c6a6620656db7e669ef6d70a1"}
2023-12-27T16:31:31.970+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 674, "hash": "591ff2facf7e4e0f265b1bb6c8070f85b39918290fa57386829a892aec3ef8ab", "tx_count": 10, "merkle": "c2de190bb6f232f7ef71461f4e8459ad4fbe00f4692f8963ef77cbf3e3175d36", "prev": "be929a37df82293d3317a436d18f402b5e406410b5254f8cc5f5b6c7dbf94ebc"}
2023-12-27T16:31:46.984+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 675, "hash": "c47cbfdee3a741ac5454cc364ea70fc48ec23b5db78895581c6d7191ccef94c5", "tx_count": 10, "merkle": "d0c5f4a2a6cae160d881371db1a01a7141b9668a6604948206405b52f8fc22d9", "prev": "d479caee2a6ef1c71fa74d7f7fbdb3bb9575bd21540edd27487b266807302f3c"}
```
Here's the example of tool logs:
```
Batch #63:
        10 transactions sent
        last nonce 1230
Batch #64:
        10 transactions sent
        last nonce 1240
Batch #65:
        10 transactions sent
        last nonce 1250
Batch #66:
        10 transactions sent
        last nonce 1260
```
And with one of CN missing from the network, the rest 3 CNs continues block accepting with periodical CV that happens due to one CN is missing, and the network works as expected. That's what `$ cat privnet/four/node1/geth_node.log | grep tx_count` tells:
```
2023-12-27T16:48:48.467+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 728, "hash": "bce0fa6ffcee5919e60d9e0b61f775276765ab4ae9bbecf1a727b7e664d9f4f5", "tx_count": 70, "merkle": "f025cecaa50e7ec420c9568470898037da37f8055b9b2aa131ccb88dc354c4da", "prev": "901b0efa23b4848eb4c8a59b8c97177f7061d762cc728ccb0757a916e904e6c0"}
2023-12-27T16:49:03.473+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 729, "hash": "6d77d61bc0a02cbdd47eaaea5dcc3fe25689f80af54da7944a3a2125c0f4a207", "tx_count": 0, "merkle": "f025cecaa50e7ec420c9568470898037da37f8055b9b2aa131ccb88dc354c4da", "prev": "5e1b497c53ce872d3ac694e017d37bbb4514612f83604632415e9edd0956f411"}
2023-12-27T16:49:18.482+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 730, "hash": "f895d61add3cb13e1eeb7fe07888fb3913401db8f17083b0933908ab5154abb5", "tx_count": 10, "merkle": "b50ba38420776bf00085828abe093e148a8b8123a76469606eaab4f373a1859f", "prev": "405318406fcefc0434fe3e3788e530bb56eb595f6de3ae1fa9954a122cac22b1"}
2023-12-27T16:49:33.496+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 731, "hash": "3635bf1a14b195eef3ce24b8d869dab1af60a9ff09a21452a5eeda9928a35186", "tx_count": 10, "merkle": "898d6998c64cc0cb872d9a93fe5249d1b0aedcfd353d2bc6e7b2a41fcc0b8b33", "prev": "ec3ed5bcc14bd59b8f18fa012c748cceccca8e9fc93d660b25a50a5ec943d24d"}
2023-12-27T16:51:03.515+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 732, "hash": "991232d8e15dcbc7a2b02c0f91d0334d383c2301cd2512cb03bc5298e197ed16", "tx_count": 70, "merkle": "f408aca8137cbc337488acb655dda36ffd1864006d1dbdc59326d49af2b69ecc", "prev": "756ae9a520be2d6531ca97ebf53410b11dadecd8d8ae53d453ae4e0412eb736d"}
2023-12-27T16:51:18.527+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 733, "hash": "b27530cc3d975ae61f3bb1b54994ba090355e208440a3c9037af578b982ac74e", "tx_count": 0, "merkle": "f408aca8137cbc337488acb655dda36ffd1864006d1dbdc59326d49af2b69ecc", "prev": "b9dba5f3c56c8d27addd544f7ee75b86159274b8b7f294d4c1024ebd4c155e8c"}
2023-12-27T16:51:33.540+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 734, "hash": "6a2d6cf71fedc12bae2fecc5935d689e3ba9281cf59b7fd24c66384b8e93c3e0", "tx_count": 10, "merkle": "c98efec735616e6cd35914d788b90c2a9c03b6c879e992cacc03a038180591b4", "prev": "b45f6489a09168b77a56323f0ecb0403d6b19960205fd6cc45fc894428aad40c"}
2023-12-27T16:51:48.554+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 735, "hash": "a66f9a80bf12dcf978c0999f9808ca4328190865a7e54e2cdc46a748e6939520", "tx_count": 10, "merkle": "9ccd7167ce376b23ed5e8f48a09d8aae9f9fa2174af514368454680915d00162", "prev": "b8f3796c5b732a3ac24cf4cab81ddd6166e1bd64aadda46bc536ef3e88e4b7b8"}
2023-12-27T16:53:18.573+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 736, "hash": "68926d11b7e8c9494bdf49584c99ea796767086b6c6bfb6d19495fff92419944", "tx_count": 70, "merkle": "ac820315f9e90cccd81ee43f02dce5128235ea3f9b20feb95176ad4b6658feba", "prev": "8dfa0aa8ea9496b4bbbdfa76621a91c7cdc138db5e7c8a8264eb2f62ce9fff10"}
2023-12-27T16:53:33.586+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 737, "hash": "ca278a3ae0261017afa479b59ff1ed20034dc9ab48fcd56a3a783b0a46ec4d41", "tx_count": 0, "merkle": "ac820315f9e90cccd81ee43f02dce5128235ea3f9b20feb95176ad4b6658feba", "prev": "47987736ef79ce6821f909d263ea2390a7b32c4a032da8ed8c27a73c51932116"}
2023-12-27T16:53:48.594+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 738, "hash": "8ee4e805a86b485c47c11d50a85498cbed9d73a36726afb54383b6e482e5c247", "tx_count": 10, "merkle": "dbf2ad535818fad8ad1781249720d122e5ee54090a7eedb8ac5f2b6c5c55e3a8", "prev": "03a5d4b7f593bd498acac340edc0226a70dc3460cf9525035e211b39dbe18485"}
2023-12-27T16:54:03.600+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 739, "hash": "d219336dd47ea396cb0e8d091285a9b1d02ed0ca9d06a594ecaa4f31c6ca4feb", "tx_count": 10, "merkle": "702f096fa9d9051aacfa76ce595ae9d71bde1c8a781384bb36438f17eecae727", "prev": "02e4db60c18c4a830da05dfc3c69ffb7ff980fb580f0faea509518ef8d11541f"}
2023-12-27T16:55:33.623+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 740, "hash": "d26cb96a8cc588a5b86f771f463763318eda42d8f2023aa9fbcf0b08ba15766e", "tx_count": 70, "merkle": "663835c8fae3585e85ad3700f2ef79af52e2a58547bf0f9d2168ae287d1a863c", "prev": "c47eaabbe59a70a4f180ef0ef66e3f1212cc802bb97fbe5f539750a4d5d050d7"}
2023-12-27T16:55:48.636+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 741, "hash": "a7764209c24973d21cd7d16e055983c147eabd688bfbb74aa9b5cd1017435f2e", "tx_count": 0, "merkle": "663835c8fae3585e85ad3700f2ef79af52e2a58547bf0f9d2168ae287d1a863c", "prev": "a2fb4a3da558ab9649dd61f71d38dc228ceb204963d9f58c78731d2f67b7513a"}
2023-12-27T16:56:03.639+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 742, "hash": "5b2462524167d00735e10ed9174f007c98bfa217e9a6b1c04f697ffef28f568e", "tx_count": 10, "merkle": "a45f36dcb78180148b6a77980994fd36c134ce3b949e6bb26aeb312074900c05", "prev": "0d8216c0e29107f658cca96603709b35b4dce266a8d6ddf6dcbd9e79454451af"}
2023-12-27T16:56:18.646+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 743, "hash": "c2bc43da7c5fbf5c7ed6eb36d9fe46e0060bb7041fe02f52e197ea18c3a56420", "tx_count": 10, "merkle": "545ba70cbf9e0f18f38cf22b0f33e894e0c7a9c54654e64637b84d1eee9368cc", "prev": "d0ba35823ee8306c2c8a52a5d752e7cae407b196be3d18d5d428a62378c40f74"}
2023-12-27T16:57:48.668+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 744, "hash": "dcee9f2840fae39d9757069734179c329dd8fe52f5a26956afb8a7bdf6f78639", "tx_count": 70, "merkle": "40c059e5b6c687975edce596a62fe21e2a3caf3f6c438993031023b0bb51e29b", "prev": "8a3bb57a1f5d7507efb9fb8fe593f480b4697a6d63be17c1a394b56fc4329175"}
2023-12-27T16:58:03.692+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 745, "hash": "b61e84a7d3bbd6032b2db57184077d14a2db58ccf3d6068164c9591cc2d3275e", "tx_count": 0, "merkle": "40c059e5b6c687975edce596a62fe21e2a3caf3f6c438993031023b0bb51e29b", "prev": "0b1c717602efc305a81488c5e207d511019cb7f392f1e774c24330ca746a3fc8"}
2023-12-27T16:58:18.700+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 746, "hash": "dc2250926c6ba68054b58a8b3909bdea2ebe28f3abe3007268fc69d331b1d542", "tx_count": 10, "merkle": "cc54b7b28beef10faa1dd51293e9c612c51a7071d2b1b09dda0fd319a51c155b", "prev": "76e5cf2727ea33f038f290a03e1f3757a6d218468e788193767c94267795456c"}
2023-12-27T16:58:33.711+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 747, "hash": "76c625d67a650c55b159f3e5b3b0d100d7cebeec1b22ecd17010fecb7a34261b", "tx_count": 10, "merkle": "de923008deeb7c24b793cf8f9d7fbd18e78ced30c6414d4c2e111e7f7db5a40f", "prev": "26e1650641305ab558f9d0aea37e319711f01e4f9840dd59bdbc56051a9d832d"}
2023-12-27T17:00:03.732+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 748, "hash": "0e4cc83fec4f957a80006666246acd27a0653be92025c9513543186f54894dc7", "tx_count": 70, "merkle": "b1e22d58e6d0920b8d532e3f8aea106f0972d2f1c55202cf45b6f020ff37e91a", "prev": "7f5f1ebab68a2a57ca145b3dce4fe74844ec2e07f57730018ce7e01de41e22f4"}
2023-12-27T17:00:18.745+0300	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 749, "hash": "dc6055d5840387bd25c06adbabead971cfa3717c7040d8367feb46a9f0664e24", "tx_count": 0, "merkle": "b1e22d58e6d0920b8d532e3f8aea106f0972d2f1c55202cf45b6f020ff37e91a", "prev": "700ea1ff9a8828dcb9f2a80478d5e70b16a1670b96660c89cca7130b6b4d80c7"}

```

A side note: to use this tool, RPC token auth should be disabled. The tool may be improved in future.