### PR TITLE
dbft: Shut down Geth gracefully

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ privnet_init_seven: privnet_clean
 
 privnet_nodes_stop:
 	@echo "Killing nodes processes"
-	@killall -w -v -9 geth || :
+	@killall -w -v -INT geth || :
 
 privnet_bootnode_stop:
 	@echo "Killing bootnode processes"

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1456,8 +1456,10 @@ func encodeSigHeader(w io.Writer, header *types.Header) {
 
 // Close implements consensus.Engine.
 func (c *DBFT) Close() error {
-	close(c.quit)
-	<-c.finished
+	if c.dbftStarted.Load() {
+		close(c.quit)
+		<-c.finished
+	}
 	return nil
 }
 


### PR DESCRIPTION
Close #32 Shut down Geth gracefully. This issue is caused by the DBFT ```Close()``` method reads channel from not started ```eventLoop()```.