### PR TITLE
dbft: remove `staterootenabled` mentions

### DIFF
--- a/consensus/dbft/recovery_message.go
+++ b/consensus/dbft/recovery_message.go
@@ -17,7 +17,6 @@ type (
 		preparationPayloads []*preparationCompact
 		commitPayloads      []*commitCompact
 		changeViewPayloads  []*changeViewCompact
-		stateRootEnabled    bool
 		prepareRequest      *message
 	}
 


### PR DESCRIPTION
It's left from NeoGo, it's not related to Geth.