### PR TITLE
dbft: always clear BlockQueue tasks after new block is accepted

### DIFF
--- a/consensus/dbft/blockqueue.go
+++ b/consensus/dbft/blockqueue.go
@@ -10,11 +10,15 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-// blockQueueCap is the number of tasks blockQueue can fit at once. It's OK for
-// the blockQueue not to have a proper task for the newly-created block, and
-// normally a single task is expected to be present in blockQueue. But we still
-// need blockQueueCap restriction for the case of endless change views.
-const blockQueueCap = 100
+const (
+	// blockQueueCap is the number of tasks blockQueue can fit at once. It's OK for
+	// the blockQueue not to have a proper task for the newly-created block, and
+	// normally a single task is expected to be present in blockQueue. But we still
+	// need blockQueueCap restriction for the case of endless change views.
+	blockQueueCap = 100
+
+	clearAllMatchingTasks = -1
+)
 
 // blockQueue is an entity that collects sealed blocks from dBFT and routs these
 // blocks to a proper place (either to miner or directly to chain).
@@ -54,7 +58,7 @@ func (bq *blockQueue) PutBlock(b *types.Block) error {
 	bq.tasksLock.Lock()
 	task, ok := bq.tasks[h]
 
-	bq.clearStaleTasks(b.NumberU64(), -1)
+	bq.clearStaleTasks(b.NumberU64(), clearAllMatchingTasks)
 
 	if ok {
 		var (
@@ -105,15 +109,26 @@ func (bq *blockQueue) PutBlock(b *types.Block) error {
 	return err
 }
 
+// ClearStaleTasks removes all stale tasks up to the specified height (including
+// the height itself).
+func (bq *blockQueue) ClearStaleTasks(till uint64) {
+	bq.tasksLock.Lock()
+	defer bq.tasksLock.Unlock()
+
+	bq.clearStaleTasks(till, clearAllMatchingTasks)
+}
+
 // clearStaleTasks removes all stale tasks up to the specified height (including
 // the height itself). It doesn't hold tasksLock, so it's the caller's responsibility.
 func (bq *blockQueue) clearStaleTasks(till uint64, count int) {
 	for h, task := range bq.tasks {
 		if task.height <= till {
 			delete(bq.tasks, h)
-			count--
-			if count <= 0 {
-				break
+			if count != clearAllMatchingTasks {
+				count--
+				if count <= 0 {
+					break
+				}
 			}
 		}
 	}

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -479,6 +480,8 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 					return fmt.Errorf("failed to put proposed parent to the storage: no parent found for height %d", req.SealingProposal.Number.Uint64()-1)
 				}
 				newHeader := savedParent.Header()
+				oldHash := c.lastBlockHash
+				oldExtra := c.lastBlockExtra
 				newHeader.Extra = req.ParentExtra
 				err = c.blockQueue.PutBlock(savedParent.WithSeal(newHeader))
 				if err != nil {
@@ -495,6 +498,14 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 				c.lastBlockHash = req.SealingProposal.ParentHash
 				c.lastBlockExtra = req.ParentExtra
 				c.dbft.PrevHash = req.SealingProposal.ParentHash.Uint256()
+
+				log.Info("New parent stored",
+					"number", newHeader.Number,
+					"old hash", oldHash.String(),
+					"new hash", req.SealingProposal.ParentHash.String(),
+					"sealhash", req.ParentSealHash.String(),
+					"old extra", hex.EncodeToString(oldExtra),
+					"new extra", hex.EncodeToString(req.ParentExtra))
 			}
 
 			c.sealingProposal = req.SealingProposal

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -577,7 +577,8 @@ func (c *DBFT) WithTxPool(pool txPool) {
 
 // postBlock is a callback that updates latest accepted block data and resets
 // last proposal data. It must be called every time new block arrives from chain
-// or from consensus.
+// or from consensus. It also clears all BlockQueue tasks up to the accepted block
+// height.
 func (c *DBFT) postBlock(b *types.Block) {
 	if c.lastIndex < b.NumberU64() {
 		h := b.Header()
@@ -587,6 +588,8 @@ func (c *DBFT) postBlock(b *types.Block) {
 		c.lastBlockHash = b.Hash()
 		c.lastBlockSealHash = HonestSealHash(h)
 		c.lastBlockExtra = h.Extra
+
+		c.blockQueue.ClearStaleTasks(b.NumberU64())
 	}
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1126,6 +1126,7 @@ func (w *worker) commit(env *environment, interval func(), update bool, start ti
 				fees := totalFees(block, env.receipts)
 				feesInEther := new(big.Float).Quo(new(big.Float).SetInt(fees), big.NewFloat(params.Ether))
 				log.Info("Commit new sealing work", "number", block.Number(), "sealhash", w.engine.SealHash(block.Header()),
+					"parent hash", block.ParentHash(),
 					"etherbase", block.Coinbase().String(),
 					"txs", env.tcount, "gas", block.GasUsed(), "fees", feesInEther,
 					"elapsed", common.PrettyDuration(time.Since(start)))


### PR DESCRIPTION
It's possible that new block is received via P2P before dBFT finishes the consensus process for this height. On networks with large delays it just means that some other CN collected all commits earlier than other CNs and it relays the accepted block. This situation is normal and in this case we need to store the accepted block and initialize consensus at the next height, and we properly perform these actions. However, if block queue's tasks are not cleared for the accepted height, then the node ends up in a situation when WithVerifyPrepareRequest callback fails to insert updated parent for the next height's PrepareRequest.

WithVerifyPrepareRequest puts parent to the BlockQueue, BlockQueue finds the corresponding miner's task for it and pushes block into miner's channel. However, miner refused to store this block since it has removed all stale tasks earlier for this height.

E.g. in the node logs we firstly see that block 172 was received via P2P before the dBFT able to collect all Commits. After that dBFT is initialized at the next height (173):
```
    2024-01-24T10:54:26.545Z        INFO    dbft@v0.0.0-20230515113611-25db6ba61d5c/dbft.go:507     received Commit {"validator": 3}
    2024-01-24T10:54:26.545Z        DEBUG   dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:57     not enough to commit    {"count": 4}
    INFO [01-24|10:54:26.963] Imported new chain segment               number=172 hash=70b13e..d272b7 blocks=1 txs=0 mgas=0.000 elapsed=5.205ms     mgasps=0.000 triedirty=0.00B
    INFO [01-24|10:54:26.964] New block in the chain                   "dbft index"=172 "chain index"=172 hash=0x70b13e7566ef532085dcaa779c287151f29f0d17d85cf5b5367d5eba51d272b7 "parent hash"=0xdc644e1c12f877487858e0e626ff73b7d0c663926a39fccf07ac14a273cc9158 primary=4 coinbase=0x1212100000000000000000000000000000000003
    INFO [01-24|10:54:26.964] Fetching latest sealing proposal         "desired number"=173
    INFO [01-24|10:54:26.964] Commit new sealing work                  number=173 sealhash=355652..67baba etherbase=0x1212100000000000000000000000000000000003 txs=0 gas=0 fees=0 elapsed="100.499µs"
    INFO [01-24|10:54:27.364] Imported new chain segment               number=172 hash=4bf439..c9f324 blocks=1 txs=0 mgas=0.000 elapsed=3.235ms     mgasps=0.000 triedirty=0.00B
    INFO [01-24|10:54:27.964] Sealing proposal updated                 number=173 sealhash=355652..67baba "parent hash"=70b13e..d272b7 txs=0
    2024-01-24T10:54:27.964Z        INFO    dbft@v0.0.0-20230515113611-25db6ba61d5c/dbft.go:107     initializing dbft       {"height": 173, "view": 0, "index": 6, "role": "Backup"}
 ```

However, BlockQueue still keeping sealing task for height 172. Once PrepareRequest for height 173 arrives, WithVerifyPrepareRequest callback sends the updated parent to the BlockQueue which sends parent to the miner. And miner logs error in a while:
```
    2024-01-24T10:54:37.165Z        DEBUG   dbft@v0.0.0-20230515113611-25db6ba61d5c/dbft.go:214     received message        {"type": "PrepareRequest", "from": 5, "height": 173, "view": 0, "my_height": 173, "my_view": 0}
    2024-01-24T10:54:37.166Z        DEBUG   dbft@v0.0.0-20230515113611-25db6ba61d5c/dbft.go:325     received empty PrepareRequest
    2024-01-24T10:54:37.166Z        INFO    dbft@v0.0.0-20230515113611-25db6ba61d5c/dbft.go:333     received PrepareRequest {"validator": 5, "tx": 0}
    2024-01-24T10:54:37.166Z        INFO    dbft@v0.0.0-20230515113611-25db6ba61d5c/send.go:106     sending PrepareResponse {"height": 173, "view": 0}
    2024-01-24T10:54:37.166Z        DEBUG   dbft@v0.0.0-20230515113611-25db6ba61d5c/send.go:9       broadcasting message    {"type": "PrepareResponse", "height": 173, "view": 0}
    ERROR[01-24|10:54:37.166] Block found but no relative pending task number=172 sealhash=00e5e9..661cff hash=888867..8c5916
```

Node continues consensus process and once it accepts 173 block, the following error occurs on attempt to store 173 block (parent block 172 is unknown):
```
2024-01-24T10:54:37.776Z	DEBUG	dbft@v0.0.0-20230515113611-25db6ba61d5c/dbft.go:214	received message	{"type": "Commit", "from": 5, "height": 173, "view": 0, "my_height": 173, "my_view": 0}
2024-01-24T10:54:37.777Z	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/dbft.go:507	received Commit	{"validator": 5}
2024-01-24T10:54:37.777Z	INFO	dbft@v0.0.0-20230515113611-25db6ba61d5c/check.go:66	approving block	{"height": 173, "hash": "27cd4cb41d22fdb363c9d99d3ddd519551b61f9746e196cc030216b0887be85d", "tx_count": 0, "merkle": "4e268cc3879dced285c623f0cc8105e2343336810e46823e926bd6edd995a7b1", "prev": "888867dfe4ae19a79d6e807b4a978ac3f394157619b2f71e3f9682ee798c5916"}
WARN [01-24|10:54:37.777] Failed to load old bad blocks            error="pebble: not found"
ERROR[01-24|10:54:37.780] 
########## BAD BLOCK #########
Block: 173 (0xc044ae15313c9fab23baef365fcf5673f16ef330f90a8de5532f104a7a7c31d1)
Error: unknown ancestor
Platform: geth (devel) go1.21.5 amd64 linux
VCS: e9d041e7-20240123
Chain config: &params.ChainConfig{ChainID:12227330, HomesteadBlock:0, DAOForkBlock:<nil>, DAOForkSupport:false, EIP150Block:0, EIP155Block:0, EIP158Block:0, ByzantiumBlock:0, ConstantinopleBlock:0, PetersburgBlock:0, IstanbulBlock:0, MuirGlacierBlock:0, BerlinBlock:0, LondonBlock:0, ArrowGlacierBlock:0, GrayGlacierBlock:0, MergeNetsplitBlock:<nil>, ShanghaiTime:(*uint64)(nil), CancunTime:(*uint64)(nil), PragueTime:(*uint64)(nil), VerkleTime:(*uint64)(nil), TerminalTotalDifficulty:<nil>, TerminalTotalDifficultyPassed:false, Ethash:(*params.EthashConfig)(nil), Clique:(*params.CliqueConfig)(nil), DBFT:(*params.DBFTConfig)(0xc00036e100), IsDevMode:false}
Receipts: 
##############################
 
WARN [01-24|10:54:37.780] error on enqueue block                   error="failed to insert block into chain: unknown ancestor"
```
