### PR TITLE
Improve dBFT engine shutdown

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -180,9 +180,10 @@ type DBFT struct {
 	signFn SignerFn       // Signer function to authorize hashes with
 	lock   sync.RWMutex   // Protects the signer field
 
-	dbft        *dbft.DBFT
-	dbftStarted atomic.Bool
-	blockQueue  *blockQueue
+	dbft             *dbft.DBFT
+	dbftStarted      atomic.Bool
+	eventLoopStarted atomic.Bool
+	blockQueue       *blockQueue
 
 	// lastTimestamp, lastIndex and lastBlockHash are updated on every new header
 	// received from dBFT or from chain. These fields have exactly those type
@@ -1004,6 +1005,11 @@ func (c *DBFT) waitForNewSealingProposal(desiredHeight uint64, updateContext boo
 		if ok {
 			break
 		}
+		select {
+		case <-c.quit:
+			return errors.New("shutdown detected")
+		default:
+		}
 		time.Sleep(time.Second)
 	}
 
@@ -1057,11 +1063,14 @@ func (c *DBFT) waitForNewSealingProposal(desiredHeight uint64, updateContext boo
 }
 
 func (c *DBFT) eventLoop() {
+	c.eventLoopStarted.Store(true)
+	log.Info("dBFT event loop started")
 events:
 	for {
 		oldView := c.dbft.ViewNumber
 		select {
 		case <-c.quit:
+			log.Info("shutting down dBFT event loop")
 			c.dbft.Timer.Stop()
 
 			c.chainHeadSub.Unsubscribe()
@@ -1166,7 +1175,7 @@ drainLoop:
 	close(c.txEvents)
 	close(c.chainHeadEvents)
 	close(c.finished)
-	log.Info("dBFT service event loop finished")
+	log.Info("dBFT event loop finished")
 }
 
 // OnPayload handles Payload receive.
@@ -1389,10 +1398,14 @@ func encodeSigHeader(w io.Writer, header *types.Header) {
 
 // Close implements consensus.Engine.
 func (c *DBFT) Close() error {
-	if c.dbftStarted.Load() {
+	if c.dbftStarted.CompareAndSwap(true, false) {
+		log.Info("Shutting down dBFT engine")
 		close(c.quit)
-		<-c.finished
+		if c.eventLoopStarted.CompareAndSwap(true, false) {
+			<-c.finished
+		}
 	}
+	log.Info("dBFT engine stopped")
 	return nil
 }
 

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -950,6 +950,7 @@ func (c *DBFT) Start(chain ChainHeaderWriter) {
 			log.Warn("Failed to fetch latest sealing proposal",
 				"index", c.lastIndex+1,
 				"err", err.Error())
+			return
 		}
 
 		log.Info("Starting dBFT engine",
@@ -1112,7 +1113,13 @@ events:
 				c.dbft.OnTransaction(&Transaction{Tx: tx})
 			}
 		case b := <-c.chainHeadEvents:
-			c.handleChainBlock(b.Block)
+			err := c.handleChainBlock(b.Block)
+			if err != nil {
+				log.Warn("Failed to handle chain block",
+					"index", b.Block.NumberU64(),
+					"err", err.Error())
+				break events
+			}
 		case err := <-c.txSub.Err():
 			// System has stopped.
 			log.Info("Stopping dBFT service since transaction subscriptions are stopped")
@@ -1142,7 +1149,13 @@ events:
 			}
 		}
 		if latestBlock.Block != nil {
-			c.handleChainBlock(latestBlock.Block)
+			err := c.handleChainBlock(latestBlock.Block)
+			if err != nil {
+				log.Warn("Failed to handle latest chain block",
+					"index", latestBlock.Block.NumberU64(),
+					"err", err.Error())
+				break events
+			}
 		}
 		newView := c.dbft.ViewNumber
 		// If ChangeView has happened, we always need to wait for the new proposal
@@ -1154,6 +1167,7 @@ events:
 				log.Warn("Failed to fetch latest sealing proposal",
 					"index", c.dbft.Context.BlockIndex,
 					"err", err.Error())
+				break events
 			}
 			log.Info("Start dBFT process for updated sealing work",
 				"index", c.dbft.Context.BlockIndex,
@@ -1237,7 +1251,7 @@ func (c *DBFT) newPayload(ctx *dbft.Context, t payload.MessageType, msg any) pay
 	return cp
 }
 
-func (c *DBFT) handleChainBlock(b *types.Block) {
+func (c *DBFT) handleChainBlock(b *types.Block) error {
 	// We can get our own block here, so check for index.
 	if uint32(b.Number().Uint64()) >= c.dbft.BlockIndex {
 		log.Info("New block in the chain",
@@ -1254,9 +1268,11 @@ func (c *DBFT) handleChainBlock(b *types.Block) {
 			log.Warn("Failed to fetch latest sealing proposal",
 				"index", c.lastIndex+1,
 				"err", err.Error())
+			return err
 		}
 		c.dbft.InitializeConsensus(0, c.lastTimestamp*NsInS)
 	}
+	return nil
 }
 
 // CalcDifficulty is the difficulty adjustment algorithm. It returns the difficulty

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -499,7 +499,8 @@ func (s *Ethereum) StartMining() error {
 				cli.Authorize(eb, wallet.SignData)
 			}
 			if bft != nil {
-				log.Info("initializing BFT consensus")
+				log.Info("Initializing BFT consensus",
+					"account", eb.String())
 				bft.Authorize(eb, wallet.SignData)
 			}
 		}


### PR DESCRIPTION
dBFT hangs on graceful node shutdown if waiting for new sealing proposal during initialisation (recovering from missing block state). Discovered during #100 debugging.

The example of logs when dBFT hangs on shutdown:
```
anna@kiwi:~/Documents/GitProjects/bane-labs/go-ethereum$ cat privnet/single/node1/geth_node.log 
INFO [02-01|14:24:25.639] Enabling metrics collection 
INFO [02-01|14:24:25.640] Maximum peer count                       ETH=50 LES=0 total=50
INFO [02-01|14:24:25.641] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [02-01|14:24:25.642] Using pebble as the backing database 
INFO [02-01|14:24:25.642] Allocated cache and file handles         database=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/privnet/single/node1/geth/chaindata cache=512.00MiB handles=2048
INFO [02-01|14:24:25.643] Opened ancient database                  database=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/privnet/single/node1/geth/chaindata/ancient/chain readonly=true
INFO [02-01|14:24:25.643] State scheme set to already existing     scheme=hash
INFO [02-01|14:24:25.644] Set global gas cap                       cap=50,000,000
INFO [02-01|14:24:25.644] Initializing the KZG library             backend=gokzg
INFO [02-01|14:24:25.675] Allocated trie memory caches             clean=154.00MiB dirty=256.00MiB
INFO [02-01|14:24:25.675] Using pebble as the backing database 
INFO [02-01|14:24:25.675] Allocated cache and file handles         database=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/privnet/single/node1/geth/chaindata cache=512.00MiB handles=2048
INFO [02-01|14:24:25.692] Opened ancient database                  database=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/privnet/single/node1/geth/chaindata/ancient/chain readonly=false
INFO [02-01|14:24:25.693] Initialising Ethereum protocol           network=2,312,051,126 dbversion=8
INFO [02-01|14:24:25.693]  
INFO [02-01|14:24:25.693] --------------------------------------------------------------------------------------------------------------------------------------------------------- 
INFO [02-01|14:24:25.693] Chain ID:  2312051126 (unknown) 
INFO [02-01|14:24:25.693] Consensus: dBFT (proof-of-authority) 
INFO [02-01|14:24:25.693]  
INFO [02-01|14:24:25.693] Pre-Merge hard forks (block based): 
INFO [02-01|14:24:25.693]  - Homestead:                   #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/homestead.md) 
INFO [02-01|14:24:25.693]  - Tangerine Whistle (EIP 150): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/tangerine-whistle.md) 
INFO [02-01|14:24:25.693]  - Spurious Dragon/1 (EIP 155): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md) 
INFO [02-01|14:24:25.693]  - Spurious Dragon/2 (EIP 158): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md) 
INFO [02-01|14:24:25.693]  - Byzantium:                   #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/byzantium.md) 
INFO [02-01|14:24:25.693]  - Constantinople:              #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/constantinople.md) 
INFO [02-01|14:24:25.693]  - Petersburg:                  #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/petersburg.md) 
INFO [02-01|14:24:25.693]  - Istanbul:                    #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/istanbul.md) 
INFO [02-01|14:24:25.693]  - Muir Glacier:                #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/muir-glacier.md) 
INFO [02-01|14:24:25.693]  - Berlin:                      #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/berlin.md) 
INFO [02-01|14:24:25.693]  - London:                      #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/london.md) 
INFO [02-01|14:24:25.693]  - Arrow Glacier:               #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/arrow-glacier.md) 
INFO [02-01|14:24:25.693]  - Gray Glacier:                #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/gray-glacier.md) 
INFO [02-01|14:24:25.693]  
INFO [02-01|14:24:25.693] The Merge is not yet available for this network! 
INFO [02-01|14:24:25.693]  - Hard-fork specification: https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/paris.md 
INFO [02-01|14:24:25.693]  
INFO [02-01|14:24:25.693] Post-Merge hard forks (timestamp based): 
INFO [02-01|14:24:25.693]  
INFO [02-01|14:24:25.693] --------------------------------------------------------------------------------------------------------------------------------------------------------- 
INFO [02-01|14:24:25.693]  
INFO [02-01|14:24:25.693] Loaded most recent local header          number=440 hash=6ea683..243c83 td=881 age=21m5s
INFO [02-01|14:24:25.693] Loaded most recent local block           number=427 hash=7c3bfe..c78168 td=855 age=22m10s
INFO [02-01|14:24:25.693] Loaded most recent local snap block      number=440 hash=6ea683..243c83 td=881 age=21m5s
WARN [02-01|14:24:25.693] Enabling snapshot recovery               chainhead=427 diskbase=427
INFO [02-01|14:24:25.693] Initialized transaction indexer          limit=2,350,000
INFO [02-01|14:24:25.697] Setting new local account                address=0xD40110De287C8d55E72a28600630a40283E4b8aa
INFO [02-01|14:24:25.700] Loaded local transaction journal         transactions=48 dropped=0
INFO [02-01|14:24:25.700] Regenerated local transaction journal    transactions=48 accounts=1
WARN [02-01|14:24:25.707] Switch sync mode from snap sync to full sync 
INFO [02-01|14:24:25.707] Gasprice oracle is ignoring threshold set threshold=2
WARN [02-01|14:24:25.708] Unclean shutdown detected                booted=2024-02-01T13:13:28+0300 age=1h10m57s
WARN [02-01|14:24:25.708] Unclean shutdown detected                booted=2024-02-01T14:00:07+0300 age=24m18s
WARN [02-01|14:24:25.708] Unclean shutdown detected                booted=2024-02-01T14:21:08+0300 age=3m17s
WARN [02-01|14:24:25.708] Engine API enabled                       protocol=eth
WARN [02-01|14:24:25.708] Engine API started but chain not configured for merge yet 
INFO [02-01|14:24:25.708] Starting peer-to-peer node               instance=Geth/v1.13.1-stable-df01fe2a/linux-amd64/go1.21.1
INFO [02-01|14:24:25.744] New local node record                    seq=1,706,782,408,842 id=c64f54948b97ba50 ip=127.0.0.1 udp=30306 tcp=30306
INFO [02-01|14:24:25.744] Started P2P networking                   self=enode://3da9077451db191513ca906ce62bfe2768c1b849722e45c33e6aa7442ad67939ff2f6ad0984afc7a80cde55d41af8683c9e5fd951650256d48ba4fd4ca1cb33b@127.0.0.1:30306
INFO [02-01|14:24:25.745] IPC endpoint opened                      url=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/privnet/single/node1/geth.ipc
INFO [02-01|14:24:25.745] Loaded JWT secret file                   path=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/privnet/single/node1/geth/jwtsecret crc32=0x9bb6f222
INFO [02-01|14:24:25.746] WebSocket enabled                        url=ws://127.0.0.1:8552
INFO [02-01|14:24:25.746] HTTP server started                      endpoint=127.0.0.1:8552 auth=true prefix= cors=localhost vhosts=localhost
INFO [02-01|14:24:26.396] Unlocked account                         address=0xD40110De287C8d55E72a28600630a40283E4b8aa
INFO [02-01|14:24:26.396] Legacy pool tip threshold updated        tip=0
INFO [02-01|14:24:26.396] Legacy pool tip threshold updated        tip=1,000,000,000
INFO [02-01|14:24:26.396] initializing BFT consensus 
INFO [02-01|14:24:26.396] Fetching latest sealing proposal         "desired number"=441
INFO [02-01|14:24:26.397] Commit new sealing work                  number=428 sealhash=a3b312..2e2117 "parent hash"=7c3bfe..c78168 etherbase=0x1212100000000000000000000000000000000001 txs=48 gas=1,008,000 fees=0.001008 elapsed="852.103µs"
INFO [02-01|14:24:35.764] Looking for peers                        peercount=0 tried=1 static=0
INFO [02-01|14:24:45.783] Looking for peers                        peercount=0 tried=0 static=0
INFO [02-01|14:24:55.800] Looking for peers                        peercount=0 tried=0 static=0
INFO [02-01|14:25:05.816] Looking for peers                        peercount=0 tried=0 static=0
INFO [02-01|14:25:15.835] Looking for peers                        peercount=0 tried=0 static=0
INFO [02-01|14:25:25.853] Looking for peers                        peercount=0 tried=0 static=0
INFO [02-01|14:25:35.870] Looking for peers                        peercount=0 tried=0 static=0
INFO [02-01|14:25:45.888] Looking for peers                        peercount=0 tried=0 static=0
INFO [02-01|14:25:55.905] Looking for peers                        peercount=0 tried=0 static=0
INFO [02-01|14:26:05.923] Looking for peers                        peercount=0 tried=0 static=0
INFO [02-01|14:26:15.940] Looking for peers                        peercount=0 tried=0 static=0
INFO [02-01|14:26:25.958] Looking for peers                        peercount=0 tried=0 static=0
INFO [02-01|14:26:35.976] Looking for peers                        peercount=0 tried=0 static=0
INFO [02-01|14:26:45.991] Looking for peers                        peercount=0 tried=0 static=0
INFO [02-01|14:26:56.009] Looking for peers                        peercount=0 tried=0 static=0
INFO [02-01|14:27:06.028] Looking for peers                        peercount=0 tried=0 static=0
INFO [02-01|14:27:16.046] Looking for peers                        peercount=0 tried=0 static=0
INFO [02-01|14:27:26.061] Looking for peers                        peercount=0 tried=0 static=0
INFO [02-01|14:27:37.145] Got interrupt, shutting down... 
INFO [02-01|14:27:37.145] HTTP server stopped                      endpoint=127.0.0.1:8552
INFO [02-01|14:27:37.145] IPC endpoint closed                      url=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/privnet/single/node1/geth.ipc
INFO [02-01|14:27:37.145] Ethereum protocol stopped 
INFO [02-01|14:27:37.145] Transaction pool stopped 
INFO [02-01|14:27:37.160] Writing cached state to disk             block=427 hash=7c3bfe..c78168 root=487881..0ac5ca
INFO [02-01|14:27:37.160] Persisted trie from memory database      nodes=0 size=0.00B time="9.069µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=0 livesize=0.00B
INFO [02-01|14:27:37.160] Writing cached state to disk             block=426 hash=0ac4dc..714f19 root=487881..0ac5ca
INFO [02-01|14:27:37.160] Persisted trie from memory database      nodes=0 size=0.00B time="5.458µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=0 livesize=0.00B
INFO [02-01|14:27:37.160] Writing cached state to disk             block=300 hash=950199..52994b root=487881..0ac5ca
INFO [02-01|14:27:37.160] Persisted trie from memory database      nodes=0 size=0.00B time="5.056µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=0 livesize=0.00B
INFO [02-01|14:27:37.160] Writing snapshot state to disk           root=487881..0ac5ca
INFO [02-01|14:27:37.160] Persisted trie from memory database      nodes=0 size=0.00B time="2.791µs" gcnodes=0 gcsize=0.00B gctime=0s livenodes=0 livesize=0.00B
INFO [02-01|14:27:37.160] Blockchain stopped 
INFO [02-01|14:27:37.160] Shutting down dBFT engine 
```