### PR TITLE
dbft: use precalculated receipts (if available) to store block

### DIFF
--- a/consensus/dbft/block.go
+++ b/consensus/dbft/block.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	ecrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/nspcc-dev/dbft/block"
@@ -23,6 +24,10 @@ type Block struct {
 	header              *types.Header
 	transactions        []*types.Transaction
 	localSignatureBytes []byte
+
+	// Local data filled in during constructed block verification. Allowed to be empty.
+	receipts types.Receipts
+	state    *state.StateDB
 }
 
 // Version implements block.Block interface.

--- a/consensus/dbft/blockqueue.go
+++ b/consensus/dbft/blockqueue.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -48,7 +49,7 @@ func (bq *blockQueue) SetChain(chain ChainHeaderWriter) {
 // PutBlock routs block either to miner or (if there's no suitable sealing task)
 // directly to blockchain. No block verification is performed, it is assumed that
 // provided block is sealed and valid.
-func (bq *blockQueue) PutBlock(b *types.Block) error {
+func (bq *blockQueue) PutBlock(b *types.Block, taskReceipts []*types.Receipt, taskState *state.StateDB) error {
 	h := WorkerSealHash(b.Header())
 
 	bq.tasksLock.Lock()
@@ -97,12 +98,52 @@ func (bq *blockQueue) PutBlock(b *types.Block) error {
 		return nil
 	}
 
-	_, err := bq.chain.InsertChain(types.Blocks{b})
-	if err != nil {
-		return fmt.Errorf("failed to insert block into chain: %w", err)
+	if taskState == nil {
+		_, err := bq.chain.InsertChain(types.Blocks{b})
+		if err != nil {
+			return fmt.Errorf("failed to insert block into chain: %w", err)
+		}
+		return nil
 	}
 
-	return err
+	// Different block could share same sealhash, deep copy here to prevent write-write conflict.
+	var (
+		receipts = make([]*types.Receipt, len(taskReceipts))
+		logs     []*types.Log
+		hash     = b.Hash()
+	)
+	for i, taskReceipt := range taskReceipts {
+		receipt := new(types.Receipt)
+		receipts[i] = receipt
+		*receipt = *taskReceipt
+
+		// add block location fields
+		receipt.BlockHash = hash
+		receipt.BlockNumber = b.Number()
+		receipt.TransactionIndex = uint(i)
+
+		// Update the block hash in all logs since it is now available and not when the
+		// receipt/log of individual transactions were created.
+		receipt.Logs = make([]*types.Log, len(taskReceipt.Logs))
+		for i, taskLog := range taskReceipt.Logs {
+			log := new(types.Log)
+			receipt.Logs[i] = log
+			*log = *taskLog
+			log.BlockHash = hash
+		}
+		logs = append(logs, receipt.Logs...)
+	}
+	// Commit block and state to database.
+	_, err := bq.chain.WriteBlockAndSetHead(b, receipts, logs, taskState, true)
+	if err != nil {
+		log.Error("Failed writing block to chain and set head",
+			"number", b.NumberU64(),
+			"err", err)
+		return fmt.Errorf("failed to write block into chain: %w", err)
+	}
+	log.Info("Successfully enqueued new block", "number", b.Number(), "hash", hash)
+
+	return nil
 }
 
 // clearStaleTasks removes all stale tasks up to the specified height (including

--- a/consensus/dbft/chainreader.go
+++ b/consensus/dbft/chainreader.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 )
@@ -15,7 +16,7 @@ type ChainHeaderReader interface {
 	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
 	HasBlock(hash common.Hash, number uint64) bool
 	GetBlockByNumber(uint64) *types.Block
-	VerifyBlock(block *types.Block) error
+	VerifyBlock(block *types.Block) (types.Receipts, *state.StateDB, error)
 }
 
 // ChainHeaderWriter is a Blockchain API abstraction needed for proper blockQueue
@@ -24,4 +25,5 @@ type ChainHeaderWriter interface {
 	ChainHeaderReader
 	InsertChain(chain types.Blocks) (int, error)
 	InsertBlockWithoutSetHead(b *types.Block) error
+	WriteBlockAndSetHead(block *types.Block, receipts []*types.Receipt, logs []*types.Log, state *state.StateDB, emitHeadEvent bool) (status core.WriteStatus, err error)
 }

--- a/consensus/dbft/chainreader.go
+++ b/consensus/dbft/chainreader.go
@@ -15,6 +15,7 @@ type ChainHeaderReader interface {
 	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
 	HasBlock(hash common.Hash, number uint64) bool
 	GetBlockByNumber(uint64) *types.Block
+	VerifyBlock(block *types.Block) error
 }
 
 // ChainHeaderWriter is a Blockchain API abstraction needed for proper blockQueue

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -520,8 +520,8 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 
 			err := c.chain.VerifyBlock(res)
 			if err != nil {
-				err = fmt.Errorf("VerifyBlock failed: %w", err)
-				log.Warn(err.Error())
+				log.Warn("proposed block verification failed",
+					"err", err.Error())
 				return false
 			}
 			return true

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -513,7 +513,19 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 			if !ok {
 				return false
 			}
-
+			parent := c.chain.CurrentBlock()
+			if parent.Number.Cmp(ethBlock.header.Number) >= 0 {
+				log.Warn("proposed block has already outdated",
+					"current block number", parent.Number.Uint64(),
+					"proposed block number", ethBlock.header.Number)
+				return false
+			}
+			if c.lastTimestamp > ethBlock.header.Time {
+				log.Warn("proposed block has small timestamp",
+					"ts", ethBlock.header.Time,
+					"last", c.lastTimestamp)
+				return false
+			}
 			res := types.NewBlockWithHeader(ethBlock.header)
 			// Uncles are always nil in dBFT-like consensus.
 			res = res.WithBody(ethBlock.transactions, nil)

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -508,6 +508,24 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 
 			return nil
 		}),
+		dbft.WithVerifyBlock(func(b block.Block) bool {
+			ethBlock, ok := b.(*Block)
+			if !ok {
+				return false
+			}
+
+			res := types.NewBlockWithHeader(ethBlock.header)
+			// Uncles are always nil in dBFT-like consensus.
+			res = res.WithBody(ethBlock.transactions, nil)
+
+			err := c.chain.VerifyBlock(res)
+			if err != nil {
+				err = fmt.Errorf("VerifyBlock failed: %w", err)
+				log.Warn(err.Error())
+				return false
+			}
+			return true
+		}),
 		dbft.WithBroadcast(func(p payload.ConsensusPayload) {
 			if err := p.(*Payload).Sign(c.dbft.Priv.(*Signer)); err != nil {
 				log.Warn("can't sign consensus payload", "error", err)

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -328,7 +328,7 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 			res = res.WithBody(ethBlock.transactions, nil)
 
 			// Firstly, notify chain about new block.
-			if err := c.blockQueue.PutBlock(res); err != nil {
+			if err := c.blockQueue.PutBlock(res, ethBlock.receipts, ethBlock.state); err != nil {
 				// The block might already be added via the regular network
 				// interaction.
 				if h := c.chain.GetHeaderByNumber(res.Number().Uint64()); h == nil {
@@ -480,7 +480,7 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 				}
 				newHeader := savedParent.Header()
 				newHeader.Extra = req.ParentExtra
-				err = c.blockQueue.PutBlock(savedParent.WithSeal(newHeader))
+				err = c.blockQueue.PutBlock(savedParent.WithSeal(newHeader), nil, nil)
 				if err != nil {
 					err = fmt.Errorf("failed to enqueue parent with updated extra for height %d (old hash %s, new hash %s): %w",
 						req.SealingProposal.Number.Uint64()-1,
@@ -530,12 +530,15 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 			// Uncles are always nil in dBFT-like consensus.
 			res = res.WithBody(ethBlock.transactions, nil)
 
-			err := c.chain.VerifyBlock(res)
+			receipts, st, err := c.chain.VerifyBlock(res)
 			if err != nil {
 				log.Warn("proposed block verification failed",
 					"err", err.Error())
 				return false
 			}
+
+			ethBlock.receipts = receipts
+			ethBlock.state = st
 			return true
 		}),
 		dbft.WithBroadcast(func(p payload.ConsensusPayload) {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2607,19 +2607,20 @@ func (bc *BlockChain) GetTrieFlushInterval() time.Duration {
 }
 
 // VerifyBlock checks block state
-func (bc *BlockChain) VerifyBlock(block *types.Block) error {
+func (bc *BlockChain) VerifyBlock(block *types.Block) (types.Receipts, *state.StateDB, error) {
 	parent := bc.GetBlockByHash(block.ParentHash())
 	statedb, err := bc.StateAt(parent.Root())
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 
+	// TODO: make statedb copy before transaction execution?
 	receipts, _, usedGas, err := bc.processor.Process(block, statedb, bc.vmConfig)
 	if err != nil {
-		return err
+		return nil, nil, err
 	}
 	if err := bc.validator.ValidateState(block, statedb, receipts, usedGas); err != nil {
-		return err
+		return nil, nil, err
 	}
-	return nil
+	return receipts, statedb, nil
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2605,3 +2605,21 @@ func (bc *BlockChain) SetTrieFlushInterval(interval time.Duration) {
 func (bc *BlockChain) GetTrieFlushInterval() time.Duration {
 	return time.Duration(bc.flushInterval.Load())
 }
+
+// VerifyBlock checks block state
+func (bc *BlockChain) VerifyBlock(block *types.Block) error {
+	parent := bc.GetBlockByHash(block.ParentHash())
+	statedb, err := bc.StateAt(parent.Root())
+	if err != nil {
+		return err
+	}
+
+	receipts, _, usedGas, err := bc.processor.Process(block, statedb, bc.vmConfig)
+	if err != nil {
+		return err
+	}
+	if err := bc.validator.ValidateState(block, statedb, receipts, usedGas); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
WIP, strongly depends on #87.

**Warning**
I'm not quite sure about code correctness, there may be some caveats during in-flight transactions processing, so this PR seems quite dangerous to me. It was an attempt to solve #100, but the problem described in #100 isn't fixed with this code, so I've checked that receipts-less block insertion (via `InsertChain` API instead of `WriteBlockAndSetHead`) works OK for us and this PR may be safely postponed (it's kind of optimization) or even closed until we have enough time to properly review the correctness of receipts calculations presented in this PR.

**PR content**
The idea of this PR is to keep block's receipts got after PrepareRequest level block verification and use them while submitting the resulting block to the chain in order to save some time on receipts recalculation. Close https://github.com/bane-labs/go-ethereum/issues/60.

The previous behaviour is the following:
* if no CV happens after sealing proposal initialisation by miner (i.e. on primary node), then receipts are not being recalculated (they are calculated and submitted to chain by miner)
* on backup nodes receipts recalculation happens firstly inside the `WithVerifyBlock` callback to verify proposal; and secondly during the resulting block insertion into chain via BlockQueue using `InsertChain`to store the resulting receipts.
* on watch-only nodes recalculation happens once while inserting final block via BlockQueue using `InsertChain` since no block verification is being performed by watch-only nodes.

Current behaviour is the following:
* if no CV happens after sealing proposal initialisation by miner (i.e. on primary node), then receipts are not being recalculated (they are calculated and submitted to chain by miner)
* on backup nodes receipts recalculation happens once inside the `WithVerifyBlock` callback to verify proposal; the resulting receipts are being inserted into chain in the end via `WriteBlockAndSetHead` API
* on watch-only nodes receipts recalculation still happens once, no behaviour changes.

**Motivation**
Originally this commit aimed to solve the problem described in https://github.com/bane-labs/go-ethereum/issues/100. However, seems that direct receipts-less block insertion also works fine and it's not the root of the problem described in https://github.com/bane-labs/go-ethereum/issues/100.