### PR TITLE
dbft: use MimetypeTextPlain for dbft Sign()

### DIFF
--- a/consensus/dbft/signer.go
+++ b/consensus/dbft/signer.go
@@ -22,5 +22,5 @@ type Signer struct {
 // In case of block, msg is expected to be dbftRLP(header) that must be
 // guaranteed by Block.Sign method.
 func (s *Signer) Sign(msg []byte) ([]byte, error) {
-	return s.SignFn(accounts.Account{Address: s.Signer}, accounts.MimetypeClique, msg)
+	return s.SignFn(accounts.Account{Address: s.Signer}, accounts.MimetypeTextPlain, msg)
 }


### PR DESCRIPTION
Close #61 
For now we don't need a special type for dBFT block signatures since no special operations should be performed with the signature. Let's reuse the existing  `MimetypeTextPlain` type.