### PR TITLE
eth: support empty withdrawals in block fetcher

### DIFF
--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -599,10 +599,13 @@ func (f *BlockFetcher) loop() {
 						announce.time = task.time
 
 						// If the block is empty (header only), short circuit into the final import queue
-						if header.TxHash == types.EmptyTxsHash && header.UncleHash == types.EmptyUncleHash {
+						if header.TxHash == types.EmptyTxsHash && header.UncleHash == types.EmptyUncleHash && (header.WithdrawalsHash == nil || *header.WithdrawalsHash == types.EmptyWithdrawalsHash) {
 							log.Trace("Block empty, skipping body retrieval", "peer", announce.origin, "number", header.Number, "hash", header.Hash())
 
 							block := types.NewBlockWithHeader(header)
+							if header.WithdrawalsHash != nil {
+								block = block.WithWithdrawals([]*types.Withdrawal{})
+							}
 							block.ReceivedAt = task.time
 
 							complete = append(complete, block)
@@ -687,6 +690,10 @@ func (f *BlockFetcher) loop() {
 						matched = true
 						if f.getBlock(hash) == nil {
 							block := types.NewBlockWithHeader(announce.header).WithBody(task.transactions[i], task.uncles[i])
+							if announce.header.WithdrawalsHash != nil && *announce.header.WithdrawalsHash == types.EmptyWithdrawalsHash {
+								// Only empty withdrawals are supported in case of pre-merge dBFT with Shanghai enabled.
+								block = block.WithWithdrawals([]*types.Withdrawal{})
+							}
 							block.ReceivedAt = task.time
 							blocks = append(blocks, block)
 						} else {


### PR DESCRIPTION
Sometimes dBFT-backed node may request new block via eth's block fetcher. Block fetcher is supposed to be disabled in post-merge, but since dBFT engine operates based on the pre-merge node state, we need to support at least empty withdrawals in block fetcher. Otherwise the block received via block fetcher will be considered as invalid due to missing withdrawals with Shanghai enabled:
```
TRACE[02-06|12:28:03.135] << NEIGHBORS/v4                          id=2d994a6405a0cffa addr=127.0.0.1:30306 err=nil
TRACE[02-06|12:28:03.136] << FINDNODE/v4                           id=f51525d61d00264a addr=127.0.0.1:30311 err=nil
TRACE[02-06|12:28:03.136] >> NEIGHBORS/v4                          id=f51525d61d00264a addr=127.0.0.1:30311 err=nil
TRACE[02-06|12:28:03.410] Fetching scheduled headers               peer=3ecc8844dfb5e6d3bd3862b2ecc013733ea4084bb85b4473bc5adb7e9a02bb3a list=[0x4c2965bad4347c843e2a781f2401e1713ee3ce313485a07448438b7e1f56f714]
DEBUG[02-06|12:28:03.410] Fetching single header                   id=3ecc8844dfb5e6d3 conn=inbound hash=4c2965..56f714
TRACE[02-06|12:28:03.411] Filtering headers                        peer=3ecc8844dfb5e6d3bd3862b2ecc013733ea4084bb85b4473bc5adb7e9a02bb3a headers=1
TRACE[02-06|12:28:03.411] Block empty, skipping body retrieval     peer=3ecc8844dfb5e6d3bd3862b2ecc013733ea4084bb85b4473bc5adb7e9a02bb3a number=5796 hash=4c2965..56f714
DEBUG[02-06|12:28:03.411] Queued delivered header or block         peer=3ecc8844dfb5e6d3bd3862b2ecc013733ea4084bb85b4473bc5adb7e9a02bb3a number=5796 hash=4c2965..56f714 queued=1
DEBUG[02-06|12:28:03.411] Importing propagated block               peer=3ecc8844dfb5e6d3bd3862b2ecc013733ea4084bb85b4473bc5adb7e9a02bb3a number=5796 hash=4c2965..56f714
TRACE[02-06|12:28:03.413] Propagated block                         hash=4c2965..56f714 recipients=2 duration=1.277ms
TRACE[02-06|12:28:03.414] Propagated block                         id=1bd74a141e39d5f6 conn=dyndial number=5796 hash=4c2965..56f714 td=11593
TRACE[02-06|12:28:03.414] Propagated block                         id=f51525d61d00264a conn=dyndial number=5796 hash=4c2965..56f714 td=11593
ERROR[02-06|12:28:03.418] 
########## BAD BLOCK #########
Block: 5796 (0x4c2965bad4347c843e2a781f2401e1713ee3ce313485a07448438b7e1f56f714)
Error: missing withdrawals in block body
Platform: geth (devel) go1.21.1 amd64 linux
VCS: 5ff60681-20240204
Chain config: &params.ChainConfig{ChainID:2312251829, HomesteadBlock:0, DAOForkBlock:<nil>, DAOForkSupport:false, EIP150Block:0, EIP155Block:0, EIP158Block:0, ByzantiumBlock:0, ConstantinopleBlock:0, PetersburgBlock:0, IstanbulBlock:0, MuirGlacierBlock:0, BerlinBlock:0, LondonBlock:0, ArrowGlacierBlock:0, GrayGlacierBlock:0, MergeNetsplitBlock:<nil>, ShanghaiTime:(*uint64)(0xc000699538), CancunTime:(*uint64)(nil), PragueTime:(*uint64)(nil), VerkleTime:(*uint64)(nil), TerminalTotalDifficulty:<nil>, TerminalTotalDifficultyPassed:false, Ethash:(*params.EthashConfig)(nil), Clique:(*params.CliqueConfig)(nil), DBFT:(*params.DBFTConfig)(0xc0006acb40), IsDevMode:false}
Receipts: 
##############################
 
DEBUG[02-06|12:28:03.419] Propagated block import failed           peer=3ecc8844dfb5e6d3bd3862b2ecc013733ea4084bb85b4473bc5adb7e9a02bb3a number=5796 hash=4c2965..56f714 err="missing withdrawals in block body"
```

This commit should be a part of #122. Close #126. Note that this commit allows only empty withdrawals, and thus additional code is needed if one day we decide to support non-empty withdrawals in dBFT.

@roman-khimov, I'd like to pay your attention to the problem mentioned in https://github.com/bane-labs/go-ethereum/pull/122#issuecomment-1919581036:
> we are starting to mix the post-merge behaviour (Shanghai is a post-merge hardfork) with pre-merge miner behaviour (difficulty/forks resolving related things belong to pre-merge). It's OK with Shanghai, but with some other fork it may break something inside the node.

This mix of post-merge hardforks with pre-merge behaviour dBFT engine is based on is not OK even with Shanghai, because block fetcher is supposed to be disabled in post-merge (ref. https://github.com/ethereum/go-ethereum/pull/26484):
https://github.com/bane-labs/go-ethereum/blob/d1dd2994df381057c4e4c66dcf497c0a8d7978ee/eth/fetcher/block_fetcher.go#L543-L545

And thus, block fetcher doesn't include code that fetches/handles withdrawals. This PR makes the block fetcher compatible with Shanghai, but in future we may need to adopt other hardforks which may lead to unexpected consequences since dBFT is based on the pre-merge behaviour. I'm afraid that one day we may break something in the node. Also this diviation makes it harder to synchronize with original Geth repo since the code they build right now is based on the post-merge behaviour. I'd suggest at least to create an issue about migration from pre-merge-based dBFT behaviour to post-merge (and implement this issue after #48, but then complete network restart may be needed). We need to investigate how dBFT engine can be untied from miner/worker since miner is not supposed to be started after post-merge. What do you think?