### PR TITLE
dbft: rework transactions routing

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"math"
 	"math/big"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -168,14 +169,17 @@ type DBFT struct {
 	broadcast func(m *dbftproto.Message) error
 
 	// requestTxs is a callback which is called to request the missing
-	// transactions from neighbor nodes.
+	// transactions from neighbor nodes. Requested transactions hashes are
+	// stored in txCbList and checked against the incoming transactions. If
+	// subsequent incoming transaction was requested then it'll be sent to the
+	// buffered txs channel.
 	requestTxs func(hashed []common.Hash)
+	txCbList   atomic.Value
+	txs        chan *types.Transaction
 
 	// various chain/mempool events and subscription management:
 	chainHeadSub    event.Subscription
 	chainHeadEvents chan core.ChainHeadEvent
-	txSub           event.Subscription
-	txEvents        chan core.NewTxsEvent
 
 	config *params.DBFTConfig // Consensus engine configuration parameters
 
@@ -245,7 +249,7 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 		blockQueue: newBlockQueue(),
 
 		messages:        make(chan Payload, msgsChCap),
-		txEvents:        make(chan core.NewTxsEvent, txSubCap),
+		txs:             make(chan *types.Transaction, txSubCap),
 		chainHeadEvents: make(chan core.ChainHeadEvent, 2),
 
 		quit:     make(chan struct{}),
@@ -417,15 +421,26 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 			}
 			return res
 		}),
-		dbft.WithRequestTx(func(h ...util.Uint256) {
-			if len(h) == 0 {
+		dbft.WithRequestTx(func(hashes ...util.Uint256) {
+			if len(hashes) == 0 {
 				return
 			}
-			hashes := make([]common.Hash, len(h))
-			for i := range h {
-				hashes = append(hashes, common.Hash(h[i]))
+
+			var sorted = make([]common.Hash, len(hashes))
+			for i := range hashes {
+				sorted[i] = common.Hash(hashes[i])
 			}
-			c.requestTxs(hashes)
+			sort.Slice(sorted, func(i, j int) bool {
+				return sorted[i].Cmp(sorted[j]) < 0
+			})
+
+			c.txCbList.Store(sorted)
+
+			c.requestTxs(sorted)
+		}),
+		dbft.WithStopTxFlow(func() {
+			var hashes []common.Hash
+			c.txCbList.Store(hashes)
 		}),
 		dbft.WithGetConsensusAddress(func(keys ...dbftCrypto.PublicKey) util.Uint160 {
 			// NextConsensus is filled manually in WithNewPrepareRequest callback.
@@ -1027,9 +1042,7 @@ func (c *DBFT) Start(chain ChainHeaderWriter) {
 			"last timestamp", c.lastTimestamp)
 		c.dbft.Start(c.lastTimestamp * NsInS)
 
-		// Subscribe for minted blocks and transactions (both new and resurrected)
-		// from mempool.
-		c.txSub = c.txpool.SubscribeTransactions(c.txEvents, true)
+		// Subscribe for minted blocks.
 		c.chainHeadSub = c.chain.SubscribeChainHeadEvent(c.chainHeadEvents)
 
 		go c.eventLoop()
@@ -1145,7 +1158,6 @@ events:
 			c.dbft.Timer.Stop()
 
 			c.chainHeadSub.Unsubscribe()
-			c.txSub.Unsubscribe()
 			break events
 		case <-c.dbft.Timer.C():
 			hv := c.dbft.Timer.HV()
@@ -1178,10 +1190,8 @@ events:
 			}
 			log.Debug("received message", fields...)
 			c.dbft.OnReceive(&msg)
-		case txs := <-c.txEvents:
-			for _, tx := range txs.Txs {
-				c.dbft.OnTransaction(&Transaction{Tx: tx})
-			}
+		case tx := <-c.txs:
+			c.dbft.OnTransaction(&Transaction{Tx: tx})
 		case b := <-c.chainHeadEvents:
 			err := c.handleChainBlock(b.Block)
 			if err != nil {
@@ -1190,14 +1200,6 @@ events:
 					"err", err.Error())
 				break events
 			}
-		case err := <-c.txSub.Err():
-			// System has stopped.
-			log.Info("Stopping dBFT service since transaction subscriptions are stopped")
-			if err != nil {
-				log.Info("Transaction subscriptions error",
-					"error", err.Error())
-			}
-			break events
 		case err := <-c.chainHeadSub.Err():
 			// System has stopped.
 			log.Info("Stopping dBFT service since block subscriptions are stopped")
@@ -1249,14 +1251,14 @@ drainLoop:
 	for {
 		select {
 		case <-c.messages:
-		case <-c.txEvents:
+		case <-c.txs:
 		case <-c.chainHeadEvents:
 		default:
 			break drainLoop
 		}
 	}
 	close(c.messages)
-	close(c.txEvents)
+	close(c.txs)
 	close(c.chainHeadEvents)
 	close(c.finished)
 	log.Info("dBFT event loop finished")
@@ -1283,6 +1285,29 @@ func (c *DBFT) OnPayload(cp *dbftproto.Message) error {
 
 	c.messages <- *p
 	return nil
+}
+
+// OnTransaction is a dBFT callback that reacts on new incoming transaction arrived
+// via P2P. It's important to call this callback on every incoming transaction
+// skipping mempool filtering for proper dBFT functioning.
+func (c *DBFT) OnTransaction(txs []*types.Transaction) {
+	if c.dbft == nil || !c.dbftStarted.Load() {
+		log.Debug("Skip txs batch handling: dbft is inactive or not started yet")
+		return
+	}
+
+	var cbList = c.txCbList.Load()
+	if cbList != nil {
+		for _, tx := range txs {
+			var list = cbList.([]common.Hash)
+			var i = sort.Search(len(list), func(i int) bool {
+				return list[i].Cmp(tx.Hash()) >= 0
+			})
+			if i < len(list) && list[i].Cmp(tx.Hash()) == 0 {
+				c.txs <- tx
+			}
+		}
+	}
 }
 
 func payloadFromMessage(ep *dbftproto.Message) *Payload {

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1267,7 +1267,7 @@ drainLoop:
 // OnPayload handles Payload receive.
 func (c *DBFT) OnPayload(cp *dbftproto.Message) error {
 	if c.dbft == nil || !c.dbftStarted.Load() {
-		log.Debug("skip dBFT payload handling: dbft is inactive or not started yet", "hash", cp.Hash())
+		log.Debug("Skip dBFT payload handling: dbft is inactive or not started yet", "hash", cp.Hash())
 		return nil
 	}
 

--- a/consensus/dbft/txpool.go
+++ b/consensus/dbft/txpool.go
@@ -2,32 +2,13 @@ package dbft
 
 import (
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/event"
 )
 
 // txPool defines the methods needed from a transaction pool implementation to
 // support all the operations needed by the Ethereum chain protocols.
 type txPool interface {
-	// Has returns an indicator whether txpool has a transaction
-	// cached with the given hash.
-	Has(hash common.Hash) bool
-
 	// Get retrieves the transaction from local txpool with given
 	// tx hash.
 	Get(hash common.Hash) *types.Transaction
-
-	// Add should add the given transactions to the pool.
-	Add(txs []*types.Transaction, local bool, sync bool) []error
-
-	// Pending should return pending transactions.
-	// The slice should be modifiable by the caller.
-	Pending(enforceTips bool) map[common.Address][]*txpool.LazyTransaction
-
-	// SubscribeTransactions should return an event subscription of
-	// NewTxsEvent and send events to the given channel. It supports
-	// feeding only newly seen or also resurrected transactions.
-	SubscribeTransactions(ch chan<- core.NewTxsEvent, reorgs bool) event.Subscription
 }

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/beacon"
+	"github.com/ethereum/go-ethereum/consensus/dbft"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/forkid"
 	"github.com/ethereum/go-ethereum/core/rawdb"
@@ -281,7 +282,20 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		}
 		return p.RequestTxs(hashes)
 	}
+	var bft *dbft.DBFT
+	switch t := h.chain.Engine().(type) {
+	case *dbft.DBFT:
+		bft = t
+	case *beacon.Beacon:
+		switch inner := t.InnerEngine().(type) {
+		case *dbft.DBFT:
+			bft = inner
+		}
+	}
 	addTxs := func(txs []*types.Transaction) []error {
+		if bft != nil {
+			bft.OnTransaction(txs)
+		}
 		return h.txpool.Add(txs, false, false)
 	}
 	h.txFetcher = fetcher.NewTxFetcher(h.txpool.Has, addTxs, fetchTx, h.removePeer)


### PR DESCRIPTION
This commit contains two changes in the dBFT-related transactions handling:
    1. Store the sorted set of requested transactions and filter incoming ones wrt this set.
    2. Do not subscribe for mempooled transactions. Instead, receive transactions directly via P2P bypassing mempool since mempool assumes additional tx filtering.

Close #98.

Tested on multinodes privnet under high load, works as expected. Debugging logs are removed:
```
2024-02-08T17:41:56.760+0300	DEBUG	dbft@v0.0.0-20240130131324-6d59675ad370/dbft.go:214	received message	{"type": "PrepareResponse", "from": 6, "height": 93, "view": 0, "my_height": 93, "my_view": 0}
2024-02-08T17:41:56.760+0300	INFO	dbft@v0.0.0-20240130131324-6d59675ad370/dbft.go:437	received PrepareResponse	{"validator": 6}
2024-02-08T17:41:56.761+0300	DEBUG	dbft@v0.0.0-20240130131324-6d59675ad370/check.go:10	check prepare: some transactions are missing	{"hashes": ["0xa668dae019721657d6df6cf49970a95337972d0c6ec1ff657e764e3dd6ec77fd","0x37424a26adb5592b6ff02ccd5557b987bdf19cc1eba17c0c8cbeeedab2e326fb","0xaf07b0283a2d2908c5e288a58efbe9c730f835623a800d7a6c9d6731f9ce3bfe","0x9834f3568e4cc91b144589961e061045b091de91f632ed4a75f12890df7dc9fb","0x6910b7b6784187976bd8ed90f7f3950115cd4b64919375d083d58f7e4d8054fe","0x11f836dcd10ab6dc9e30af43f934375614c3ab88eaa739c5a6cb8d91036205fe","0x847040698e6075777856382167bbca9cc03c5c67eb87533294bf119c412bdefe","0x212347d714161e709a9dee512bf8b19ffef25171f8497acd8fa81cec8e4e50fe","0xe3f6157bcd30d90bbb5364bd0a66706b85202461addefe3aaba4c652f30600fc","0xc6e0a2a7882d70a00774264400c8b61b68588b0751d3c556ed9652d2bd7c17ff","0x5dd2fcccbf728af31fb6cbc5a12cfebe6ccb90c3c8b69d07652dc9da834910fe","0x5e1e06e6ac1da102974a092b9f410c282016c2c862ebcae63ca01809bf01aaff","0x959f1ae1200f1625772d4a4901180d26301235228f07550b931f17b30e390efe","0xe1cbb338d779dced9b71b00172659168e9d8bac3cc968a47d3f9f48aaa5c8bfd","0x21a3302c7c14e91259155a53b1cead3c2d15352de774f5434bd152d3fc855dfd","0xf10a635daf1216c93a7fb6024b54550c1b1e3845fb86748371e29af293410ffe","0x447de77541b4a14b9f5284a3f19c93519bdd7388ae5c4542b2282dd1a01adafd","0xc5a609d5e72738b8f533f27dbb6bb293c5e1800fab7532446768cda06e26deff","0x28dfc0c86f7853cdc7b2ab87cc42041c0d06e0934e3fbad9056dcc8a3887bfff","0x8274d2fd0ff5882d2b7b87f627cad1e5bc581e8dfc1e610b6c857c3e977f95fb"]}
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.765] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.766] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.766] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.766] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.766] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.766] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.766] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.766] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.766] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.766] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.766] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.766] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.766] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.766] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.766] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.787] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.787] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.787] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.787] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.787] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.787] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.787] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.787] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.787] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.787] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.787] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.787] ########          Received requested transaction       ############## 
2024-02-08T17:41:56.788+0300	DEBUG	dbft@v0.0.0-20240130131324-6d59675ad370/dbft.go:214	received message	{"type": "PrepareResponse", "from": 0, "height": 93, "view": 0, "my_height": 93, "my_view": 0}
2024-02-08T17:41:56.788+0300	INFO	dbft@v0.0.0-20240130131324-6d59675ad370/dbft.go:437	received PrepareResponse	{"validator": 0}
2024-02-08T17:41:56.788+0300	DEBUG	dbft@v0.0.0-20240130131324-6d59675ad370/check.go:10	check prepare: some transactions are missing	{"hashes": ["0xa668dae019721657d6df6cf49970a95337972d0c6ec1ff657e764e3dd6ec77fd","0x37424a26adb5592b6ff02ccd5557b987bdf19cc1eba17c0c8cbeeedab2e326fb","0xaf07b0283a2d2908c5e288a58efbe9c730f835623a800d7a6c9d6731f9ce3bfe","0x9834f3568e4cc91b144589961e061045b091de91f632ed4a75f12890df7dc9fb","0x6910b7b6784187976bd8ed90f7f3950115cd4b64919375d083d58f7e4d8054fe","0x11f836dcd10ab6dc9e30af43f934375614c3ab88eaa739c5a6cb8d91036205fe","0x847040698e6075777856382167bbca9cc03c5c67eb87533294bf119c412bdefe","0x212347d714161e709a9dee512bf8b19ffef25171f8497acd8fa81cec8e4e50fe","0xe3f6157bcd30d90bbb5364bd0a66706b85202461addefe3aaba4c652f30600fc","0xc6e0a2a7882d70a00774264400c8b61b68588b0751d3c556ed9652d2bd7c17ff","0x5dd2fcccbf728af31fb6cbc5a12cfebe6ccb90c3c8b69d07652dc9da834910fe","0x5e1e06e6ac1da102974a092b9f410c282016c2c862ebcae63ca01809bf01aaff","0x959f1ae1200f1625772d4a4901180d26301235228f07550b931f17b30e390efe","0xe1cbb338d779dced9b71b00172659168e9d8bac3cc968a47d3f9f48aaa5c8bfd","0x21a3302c7c14e91259155a53b1cead3c2d15352de774f5434bd152d3fc855dfd","0xf10a635daf1216c93a7fb6024b54550c1b1e3845fb86748371e29af293410ffe","0x447de77541b4a14b9f5284a3f19c93519bdd7388ae5c4542b2282dd1a01adafd","0xc5a609d5e72738b8f533f27dbb6bb293c5e1800fab7532446768cda06e26deff","0x28dfc0c86f7853cdc7b2ab87cc42041c0d06e0934e3fbad9056dcc8a3887bfff","0x8274d2fd0ff5882d2b7b87f627cad1e5bc581e8dfc1e610b6c857c3e977f95fb"]}
INFO [02-08|17:41:56.789] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.789] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.789] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.789] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.789] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.789] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.789] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.789] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.789] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.789] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.789] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.789] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.789] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.789] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.789] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.789] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.789] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.789] ########          Received requested transaction       ############## 
2024-02-08T17:41:56.800+0300	DEBUG	dbft@v0.0.0-20240130131324-6d59675ad370/dbft.go:214	received message	{"type": "PrepareResponse", "from": 1, "height": 93, "view": 0, "my_height": 93, "my_view": 0}
2024-02-08T17:41:56.800+0300	INFO	dbft@v0.0.0-20240130131324-6d59675ad370/dbft.go:437	received PrepareResponse	{"validator": 1}
2024-02-08T17:41:56.800+0300	DEBUG	dbft@v0.0.0-20240130131324-6d59675ad370/check.go:10	check prepare: some transactions are missing	{"hashes": ["0xa668dae019721657d6df6cf49970a95337972d0c6ec1ff657e764e3dd6ec77fd","0x37424a26adb5592b6ff02ccd5557b987bdf19cc1eba17c0c8cbeeedab2e326fb","0xaf07b0283a2d2908c5e288a58efbe9c730f835623a800d7a6c9d6731f9ce3bfe","0x9834f3568e4cc91b144589961e061045b091de91f632ed4a75f12890df7dc9fb","0x6910b7b6784187976bd8ed90f7f3950115cd4b64919375d083d58f7e4d8054fe","0x11f836dcd10ab6dc9e30af43f934375614c3ab88eaa739c5a6cb8d91036205fe","0x847040698e6075777856382167bbca9cc03c5c67eb87533294bf119c412bdefe","0x212347d714161e709a9dee512bf8b19ffef25171f8497acd8fa81cec8e4e50fe","0xe3f6157bcd30d90bbb5364bd0a66706b85202461addefe3aaba4c652f30600fc","0xc6e0a2a7882d70a00774264400c8b61b68588b0751d3c556ed9652d2bd7c17ff","0x5dd2fcccbf728af31fb6cbc5a12cfebe6ccb90c3c8b69d07652dc9da834910fe","0x5e1e06e6ac1da102974a092b9f410c282016c2c862ebcae63ca01809bf01aaff","0x959f1ae1200f1625772d4a4901180d26301235228f07550b931f17b30e390efe","0xe1cbb338d779dced9b71b00172659168e9d8bac3cc968a47d3f9f48aaa5c8bfd","0x21a3302c7c14e91259155a53b1cead3c2d15352de774f5434bd152d3fc855dfd","0xf10a635daf1216c93a7fb6024b54550c1b1e3845fb86748371e29af293410ffe","0x447de77541b4a14b9f5284a3f19c93519bdd7388ae5c4542b2282dd1a01adafd","0xc5a609d5e72738b8f533f27dbb6bb293c5e1800fab7532446768cda06e26deff","0x28dfc0c86f7853cdc7b2ab87cc42041c0d06e0934e3fbad9056dcc8a3887bfff","0x8274d2fd0ff5882d2b7b87f627cad1e5bc581e8dfc1e610b6c857c3e977f95fb"]}
INFO [02-08|17:41:56.800] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.801] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.801] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.801] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.801] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.801] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.801] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
INFO [02-08|17:41:56.807] ########          Received requested transaction       ############## 
2024-02-08T17:41:56.807+0300	INFO	dbft@v0.0.0-20240130131324-6d59675ad370/send.go:106	sending PrepareResponse	{"height": 93, "view": 0}
2024-02-08T17:41:56.807+0300	DEBUG	dbft@v0.0.0-20240130131324-6d59675ad370/send.go:9	broadcasting message	{"type": "PrepareResponse", "height": 93, "view": 0}
```