### PR TITLE
Add `--http.vhosts "*"` to privnet launch command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ define run_node
 		--http \
 		--http.port $(5) \
 		--http.addr 0.0.0.0 \
+		--http.vhosts "*" \
 		--ws \
 		--ws.addr 0.0.0.0 \
 		--ws.port $(6) \


### PR DESCRIPTION
This enables we execute the following request:

`curl -v -X POST -H "Content-Type: application/json" --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' http://neox-node:8563`

using the `neox-node` hostname, instead of the IP address of the HTTP endpoint.

This is useful when running geth in docker-compose, where an internal network is established with hostnames. 😅 
