### PR TITLE
dBFT: recalculate proposed Merkle state if needed (T2)

### DIFF
--- a/consensus/dbft/block.go
+++ b/consensus/dbft/block.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	ecrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/nspcc-dev/dbft/block"
@@ -23,6 +24,10 @@ type Block struct {
 	header              *types.Header
 	transactions        []*types.Transaction
 	localSignatureBytes []byte
+
+	// Local data calculated during dBFT block verification. Allowed to be empty.
+	state    *state.StateDB
+	receipts types.Receipts
 }
 
 // Version implements block.Block interface.

--- a/consensus/dbft/blockqueue.go
+++ b/consensus/dbft/blockqueue.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -52,7 +53,7 @@ func (bq *blockQueue) SetChain(chain ChainHeaderWriter) {
 // PutBlock routs block either to miner or (if there's no suitable sealing task)
 // directly to blockchain. No block verification is performed, it is assumed that
 // provided block is sealed and valid.
-func (bq *blockQueue) PutBlock(b *types.Block) error {
+func (bq *blockQueue) PutBlock(b *types.Block, state *state.StateDB, receipts []*types.Receipt) error {
 	h := WorkerSealHash(b.Header())
 
 	bq.tasksLock.Lock()
@@ -97,16 +98,47 @@ func (bq *blockQueue) PutBlock(b *types.Block) error {
 	//  3) or we're not a primary node in this consensus round and thus,
 	//     worker's task differs from the dBFT's proposal. In this case we
 	//     need to try to insert block right into chain.
-	if bq.chain.HasBlock(b.Hash(), b.NumberU64()) {
+	hash := b.Hash()
+	if bq.chain.HasBlock(hash, b.NumberU64()) {
 		return nil
 	}
 
-	_, err := bq.chain.InsertChain(types.Blocks{b})
-	if err != nil {
-		return fmt.Errorf("failed to insert block into chain: %w", err)
+	// Short circuit if we don't have pre-calculated state.
+	if state == nil {
+		_, err := bq.chain.InsertChain(types.Blocks{b})
+		if err != nil {
+			return fmt.Errorf("failed to insert block into chain: %w", err)
+		}
+		log.Info("Successfully inserted new block", "number", b.Number(), "hash", hash)
+		return nil
 	}
 
-	return err
+	// Insert state directly if we have one.
+	var logs []*types.Log
+	for i, receipt := range receipts {
+		// Add block location fields.
+		receipt.BlockHash = hash
+		receipt.BlockNumber = b.Number()
+		receipt.TransactionIndex = uint(i)
+
+		// Update the block hash in all logs since it is now available and not when the
+		// receipt/log of individual transactions were created.
+		for _, taskLog := range receipt.Logs {
+			taskLog.BlockHash = hash
+		}
+		logs = append(logs, receipt.Logs...)
+	}
+	// Commit block and state to database.
+	_, err := bq.chain.WriteBlockAndSetHead(b, receipts, logs, state, true)
+	if err != nil {
+		log.Error("Failed writing block to chain and set head",
+			"number", b.NumberU64(),
+			"err", err)
+		return fmt.Errorf("failed to write block into chain: %w", err)
+	}
+	log.Info("Successfully wrote new block with state", "number", b.Number(), "hash", hash)
+
+	return nil
 }
 
 // ClearStaleTasks removes all stale tasks up to the specified height (including

--- a/consensus/dbft/chainreader.go
+++ b/consensus/dbft/chainreader.go
@@ -16,7 +16,7 @@ type ChainHeaderReader interface {
 	SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription
 	HasBlock(hash common.Hash, number uint64) bool
 	GetBlockByNumber(uint64) *types.Block
-	VerifyBlock(block *types.Block) error
+	VerifyBlock(block *types.Block) (*state.StateDB, types.Receipts, error)
 	ProcessState(block *types.Block) (*state.StateDB, types.Receipts, []*types.Log, uint64, error)
 }
 
@@ -25,5 +25,5 @@ type ChainHeaderReader interface {
 type ChainHeaderWriter interface {
 	ChainHeaderReader
 	InsertChain(chain types.Blocks) (int, error)
-	InsertBlockWithoutSetHead(b *types.Block) error
+	WriteBlockAndSetHead(block *types.Block, receipts []*types.Receipt, logs []*types.Log, state *state.StateDB, emitHeadEvent bool) (status core.WriteStatus, err error)
 }

--- a/consensus/dbft/chainreader.go
+++ b/consensus/dbft/chainreader.go
@@ -4,6 +4,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 )
@@ -16,6 +17,7 @@ type ChainHeaderReader interface {
 	HasBlock(hash common.Hash, number uint64) bool
 	GetBlockByNumber(uint64) *types.Block
 	VerifyBlock(block *types.Block) error
+	ProcessState(block *types.Block) (*state.StateDB, types.Receipts, []*types.Log, uint64, error)
 }
 
 // ChainHeaderWriter is a Blockchain API abstraction needed for proper blockQueue

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -68,7 +68,6 @@ var (
 
 	uncleHash = types.CalcUncleHash(nil) // Always Keccak256(RLP([])) as uncles are meaningless outside of PoW.
 
-	diffStub   = big.NewInt(3) // Block difficulty stub that is used for miner's task preparation.
 	diffInTurn = big.NewInt(2) // Block difficulty for in-turn signatures
 	diffNoTurn = big.NewInt(1) // Block difficulty for out-of-turn signatures
 )
@@ -892,9 +891,10 @@ func (c *DBFT) Prepare(chain consensus.ChainHeaderReader, header *types.Header) 
 	// for now.
 	header.Nonce = types.BlockNonce{}
 
-	// Use difficulty stub to let the Beacon engine know that sealing task should be handled
-	// by PoA engine. This stub will be overridden during further dBFT process anyway.
-	header.Difficulty = diffStub
+	// Use in-turn difficulty as a base for miner's transactions processing to skip dBFT transactions reprocessing in best
+	// case. In worse case this field will be overridden during further dBFT consensus in case of CV and state will be
+	// recalculated by dBFT based on new value.
+	header.Difficulty = diffInTurn
 
 	// Ensure the extra data has all its components
 	if len(header.Extra) < extraVanity {

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -346,33 +346,8 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 				panic("can't create new block from context: prepare request is nil")
 			}
 			proposal := prepareReq.GetPrepareRequest().(*prepareRequest)
-			// Avoid changing PrepareRequest itself.
-			h := types.CopyHeader(proposal.SealingProposal)
 
-			// BlockIndex -> Number
-			h.Number = big.NewInt(int64(ctx.BlockIndex))
-
-			// PrimaryIndex -> Nonce
-			binary.BigEndian.PutUint64(h.Nonce[:], uint64(ctx.PrimaryIndex))
-
-			h.Difficulty = c.getDifficulty(int(ctx.PrimaryIndex), uint64(ctx.BlockIndex))
-
-			// NextConsensus -> MixHash
-			nextVals, err := c.getNextBlockValidators(c.lastBlockHash, c.lastIndex, true) // always compute as it's NextConsensus.
-			if err != nil {
-				panic(fmt.Errorf("failed to retrieve next block validators: %w", err))
-			}
-			h.MixDigest = dbftutil.GetNextConsensusHash(nextVals)
-
-			// Do not fill block's transactions. First of all, transactions are not
-			// needed for block signing or block signature verification. Secondly, some
-			// transactions may be missing by the moment of call to NewBlockFromContext
-			// (dBFT has only the full set of their hashes). Once all transactions are
-			// fetched and the commits are collected, SetTransactions callback will be
-			// called by dBFT library to properly initialize block's transactions.
-			return &Block{
-				header: h,
-			}
+			return c.newBlockFromContext(proposal.SealingProposal)
 		}),
 		dbft.WithWatchOnly(func() bool {
 			return false
@@ -430,13 +405,31 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 			if c.sealingProposal == nil {
 				panic("bug: sealing proposal is not initialized")
 			}
-			// Fill in only proposal and receipts, transactions will be properly
-			// set from context later in SetTransactionHashes callback.
-			req.SealingProposal = c.sealingProposal
-
 			req.ParentSealHash = c.lastBlockSealHash
 			req.ParentExtra = c.lastBlockExtra
 
+			// Recalculate block state provided by miner and update sealing proposal if CV happened and context-related
+			// block fields were changed.
+			if c.dbft.Context.ViewNumber != 0 {
+				dbftBlock := c.newBlockFromContext(c.sealingProposal)
+				dbftBlock.transactions = c.sealingTransactions
+				ethBlock := dbftBlock.ToEthBlock()
+
+				state, receipts, _, _, err := c.chain.ProcessState(ethBlock)
+				if err != nil {
+					panic(fmt.Errorf("failed to process proposal state: %w", err))
+				}
+				b, err := c.FinalizeAndAssemble(c.chain, dbftBlock.header, state, c.sealingTransactions, nil, receipts, nil)
+				if err != nil {
+					panic(fmt.Errorf("faield to finalize proposal: %w", err))
+				}
+
+				c.sealingProposal = b.Header()
+			}
+
+			// Fill in only proposal, transactions will be properly set from context later in SetTransactionHashes
+			// callback.
+			req.SealingProposal = c.sealingProposal
 			return req
 		}),
 		dbft.WithNewCommit(func() payload.Commit { return new(commit) }),
@@ -557,6 +550,41 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 	)
 
 	return c, nil
+}
+
+// newBlockFromContext is a dBFT callback that builds Block from the provided dBFT proposal
+// filling all appropriate fields from dBFT context. It doesn't set transactions or any
+// other information except the header itself.
+func (c *DBFT) newBlockFromContext(sealingProposal *types.Header) *Block {
+	// Avoid changing PrepareRequest itself.
+	h := types.CopyHeader(sealingProposal)
+	ctx := c.dbft.Context
+
+	// BlockIndex -> Number
+	h.Number = big.NewInt(int64(ctx.BlockIndex))
+
+	// PrimaryIndex -> Nonce
+	binary.BigEndian.PutUint64(h.Nonce[:], uint64(ctx.PrimaryIndex))
+
+	h.Difficulty = c.getDifficulty(int(ctx.PrimaryIndex), uint64(ctx.BlockIndex))
+
+	// NextConsensus -> MixHash
+	nextVals, err := c.getNextBlockValidators(c.lastBlockHash, c.lastIndex, true) // always compute as it's NextConsensus.
+	if err != nil {
+		panic(fmt.Errorf("failed to retrieve next block validators: %w", err))
+	}
+	h.MixDigest = dbftutil.GetNextConsensusHash(nextVals)
+
+	// Do not fill block's transactions. First of all, transactions are not
+	// needed for block signing or block signature verification. Secondly, some
+	// transactions may be missing by the moment of call to NewBlockFromContext
+	// (dBFT has only the full set of their hashes). Once all transactions are
+	// fetched and the commits are collected, SetTransactions callback will be
+	// called by dBFT library to properly initialize block's transactions.
+	return &Block{
+		header: h,
+	}
+
 }
 
 func (c *DBFT) getBlockWitness() []byte {

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -328,7 +328,7 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 			res = res.WithBody(ethBlock.transactions, nil)
 
 			// Firstly, notify chain about new block.
-			if err := c.blockQueue.PutBlock(res); err != nil {
+			if err := c.blockQueue.PutBlock(res, ethBlock.state, ethBlock.receipts); err != nil {
 				// The block might already be added via the regular network
 				// interaction.
 				if h := c.chain.GetHeaderByNumber(res.Number().Uint64()); h == nil {
@@ -476,7 +476,7 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 				oldHash := c.lastBlockHash
 				oldExtra := c.lastBlockExtra
 				parentHeader.Extra = req.ParentExtra
-				err = c.blockQueue.PutBlock(parent.WithSeal(parentHeader))
+				err = c.blockQueue.PutBlock(parent.WithSeal(parentHeader), nil, nil)
 				if err != nil {
 					err = fmt.Errorf("failed to enqueue parent with updated extra for height %d (old hash %s, new hash %s): %w",
 						req.SealingProposal.Number.Uint64()-1,
@@ -528,7 +528,9 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 				return false
 			}
 			ethBlock := dbftBlock.ToEthBlock()
-			err := c.chain.VerifyBlock(ethBlock)
+			state, receipts, err := c.chain.VerifyBlock(ethBlock)
+			dbftBlock.state = state
+			dbftBlock.receipts = receipts
 			if err != nil {
 				log.Warn("proposed block verification failed",
 					"err", err.Error())

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2640,25 +2640,25 @@ func (bc *BlockChain) ProcessState(block *types.Block) (*state.StateDB, types.Re
 }
 
 // VerifyBlock checks block state
-func (bc *BlockChain) VerifyBlock(block *types.Block) error {
+func (bc *BlockChain) VerifyBlock(block *types.Block) (*state.StateDB, types.Receipts, error) {
 	err := bc.validator.ValidateBody(block)
 	if err != nil {
 		err = fmt.Errorf("failed to validate body: %w", err)
 		log.Error(err.Error())
-		return err
+		return nil, nil, err
 	}
 
 	statedb, receipts, _, usedGas, err := bc.ProcessState(block)
 	if err != nil {
 		err = fmt.Errorf("failed to process block state: %w", err)
 		log.Error(err.Error())
-		return err
+		return nil, nil, err
 	}
 
 	if err := bc.validator.ValidateState(block, statedb, receipts, usedGas); err != nil {
 		err = fmt.Errorf("failed to verify state: %w", err)
 		log.Error(err.Error())
-		return err
+		return nil, nil, err
 	}
-	return nil
+	return statedb, receipts, nil
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2606,6 +2606,39 @@ func (bc *BlockChain) GetTrieFlushInterval() time.Duration {
 	return time.Duration(bc.flushInterval.Load())
 }
 
+// ProcessState processes the state changes according to the Ethereum rules by running
+// the transaction messages using the statedb and applying any rewards to both
+// the processor (coinbase) and any included uncles. It doesn't persist any data.
+func (bc *BlockChain) ProcessState(block *types.Block) (*state.StateDB, types.Receipts, []*types.Log, uint64, error) {
+	parent := bc.GetBlockByHash(block.ParentHash())
+	if parent == nil {
+		err := fmt.Errorf("failed to retrieve parent by hash to process block, %s: %v, %s: %s", "parent number", block.NumberU64()-1,
+			"parent hash", block.ParentHash().String())
+		log.Error(err.Error())
+		parent = bc.GetBlockByNumber(block.NumberU64() - 1)
+		if parent == nil {
+			err = fmt.Errorf("failed to retrieve canonical parent by number to process block, %s: %v, %s: %s", "parent number", block.NumberU64()-1,
+				"parent hash", block.ParentHash().String())
+			log.Error(err.Error())
+			return nil, nil, nil, 0, err
+		}
+	}
+	statedb, err := bc.StateAt(parent.Root())
+	if err != nil {
+		err = fmt.Errorf("failed to retrieve state at %s: %w", parent.Root(), err)
+		log.Error(err.Error())
+		return nil, nil, nil, 0, err
+	}
+
+	receipts, logs, usedGas, err := bc.processor.Process(block, statedb, bc.vmConfig)
+	if err != nil {
+		err = fmt.Errorf("failed to process block: %w", err)
+		log.Error(err.Error())
+		return nil, nil, nil, 0, err
+	}
+	return statedb, receipts, logs, usedGas, nil
+}
+
 // VerifyBlock checks block state
 func (bc *BlockChain) VerifyBlock(block *types.Block) error {
 	err := bc.validator.ValidateBody(block)
@@ -2615,32 +2648,13 @@ func (bc *BlockChain) VerifyBlock(block *types.Block) error {
 		return err
 	}
 
-	parent := bc.GetBlockByHash(block.ParentHash())
-	if parent == nil {
-		err = fmt.Errorf("failed to retrieve parent by hash to verify block, %s: %v, %s: %s", "parent number", block.NumberU64()-1,
-			"parent hash", block.ParentHash().String())
-		log.Error(err.Error())
-		parent = bc.GetBlockByNumber(block.NumberU64() - 1)
-		if parent == nil {
-			err = fmt.Errorf("failed to retrieve canonical parent by number to verify block, %s: %v, %s: %s", "parent number", block.NumberU64()-1,
-				"parent hash", block.ParentHash().String())
-			log.Error(err.Error())
-			return err
-		}
-	}
-	statedb, err := bc.StateAt(parent.Root())
+	statedb, receipts, _, usedGas, err := bc.ProcessState(block)
 	if err != nil {
-		err = fmt.Errorf("failed to retrieve state at %s: %w", parent.Root(), err)
+		err = fmt.Errorf("failed to process block state: %w", err)
 		log.Error(err.Error())
 		return err
 	}
 
-	receipts, _, usedGas, err := bc.processor.Process(block, statedb, bc.vmConfig)
-	if err != nil {
-		err = fmt.Errorf("failed to process block: %w", err)
-		log.Error(err.Error())
-		return err
-	}
 	if err := bc.validator.ValidateState(block, statedb, receipts, usedGas); err != nil {
 		err = fmt.Errorf("failed to verify state: %w", err)
 		log.Error(err.Error())


### PR DESCRIPTION
Close #140. Close #60. For T2 only, I'll port changes to bane-main after the current PR is merged.

In this PR:
* Ensure all header's fields that affect miner's state calculations are properly set in `(*DBFT).Prepare`. A part of #140.
* Recalculate Merkle state depending on updated dBFT context information in case of CV. Close #140.
* Optimize accepted block insertion into chain using state calculated during PrepareRequest-level block verification (port the #124). Close #60.

@roman-khimov, this PR doesn't contain miner's "slimming" part that we've discussed, mainly because this part contains some transactions filtering, I'd like to keep this code in the node:
https://github.com/bane-labs/go-ethereum/blob/7b56bf71af205bb183265e49513e6226d69a9f13/miner/worker.go#L855-L873
I've tried to completely move this part to dBFT, but this requires moving a substantial amount of related transaction management logic from worker to the dBFT and the code doesn't look nice. However, after a bit of thinking I've checked the set of fields that affect miner's transactions processing and turns out that in pre-merge it's only Difficulty. So I suggest the following modification of our initial concept:
1. Allow miner to execute transactions initially with `in-turn` difficulty (and the rest of related fields partially set by `(*DBFT).Prepare`). Get some initial state, this state will always be relevant for the 0 dBFT view. If block is accepted in this view, then OK, the state is valid.
2. If CV happens, then recalculate block state with the updated data inside the dBFT. Propose the updated state in PrepareRequest. Any further CVs lead to the same dBFT state recalculation.
3. Always recalculate state on PrepareRequest verification and store it for further block insertion optimisation.

This scheme in future allow us to integrate anti-MEV transactions processing since state recalculation at the last anti-MEV stage may be done using the same API that dBFT uses in this PR. Also, initial transactions state processing made by miner is useful during the first anti-MEV stage when nodes have to agree on unencrypted set of transactions.

What do you think?

@chenquanyu, @nicolegys you're welcomed to review and test.

TODO:
- [ ] Establish privnet test where transaction with DIFFICULTY opcode is being pushed to the network before\after CV. I need to ensure that this code works in the situation described in #140.