### PR TITLE
dBFT: recalculate proposed Merkle state if needed

### DIFF
--- a/consensus/dbft/block.go
+++ b/consensus/dbft/block.go
@@ -124,9 +124,6 @@ func (b *Block) Hash() util.Uint256 {
 func (b *Block) ToEthBlock() *types.Block {
 	res := types.NewBlockWithHeader(b.header)
 	// Uncles are always nil in dBFT-like consensus.
-	res = res.WithBody(b.transactions, nil)
-	if b.withdrawals != nil {
-		res = res.WithWithdrawals(b.withdrawals)
-	}
+	res = res.WithBody(b.transactions, nil).WithWithdrawals(b.withdrawals)
 	return res
 }

--- a/consensus/dbft/block.go
+++ b/consensus/dbft/block.go
@@ -120,7 +120,7 @@ func (b *Block) Hash() util.Uint256 {
 	return WorkerSealHash(b.header).Uint256()
 }
 
-// Convert dbft.Blcok to types.Block
+// ToEthBlock converts [dbft.Block] to [types.Block].
 func (b *Block) ToEthBlock() *types.Block {
 	res := types.NewBlockWithHeader(b.header)
 	// Uncles are always nil in dBFT-like consensus.

--- a/consensus/dbft/block.go
+++ b/consensus/dbft/block.go
@@ -3,8 +3,9 @@ package dbft
 import (
 	"errors"
 	"fmt"
-
+	
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	ecrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/nspcc-dev/dbft/block"
@@ -24,6 +25,10 @@ type Block struct {
 	withdrawals         []*types.Withdrawal
 	transactions        []*types.Transaction
 	localSignatureBytes []byte
+
+	// Local data calculated during dBFT block verification. Allowed to be empty.
+	state    *state.StateDB
+	receipts types.Receipts
 }
 
 // Version implements block.Block interface.

--- a/consensus/dbft/blockqueue.go
+++ b/consensus/dbft/blockqueue.go
@@ -3,6 +3,7 @@ package dbft
 import (
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/core/state"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -52,7 +53,7 @@ func (bq *blockQueue) SetChain(chain ChainHeaderWriter) {
 // PutBlock routs block either to miner or (if there's no suitable sealing task)
 // directly to blockchain. No block verification is performed, it is assumed that
 // provided block is sealed and valid.
-func (bq *blockQueue) PutBlock(b *types.Block) error {
+func (bq *blockQueue) PutBlock(b *types.Block, state *state.StateDB, receipts []*types.Receipt) error {
 	h := WorkerSealHash(b.Header())
 
 	bq.tasksLock.Lock()
@@ -97,16 +98,47 @@ func (bq *blockQueue) PutBlock(b *types.Block) error {
 	//  3) or we're not a primary node in this consensus round and thus,
 	//     worker's task differs from the dBFT's proposal. In this case we
 	//     need to try to insert block right into chain.
-	if bq.chain.HasBlock(b.Hash(), b.NumberU64()) {
+	hash := b.Hash()
+	if bq.chain.HasBlock(hash, b.NumberU64()) {
 		return nil
 	}
 
-	_, err := bq.chain.InsertChain(types.Blocks{b})
-	if err != nil {
-		return fmt.Errorf("failed to insert block into chain: %w", err)
+	// Short circuit if we don't have pre-calculated state.
+	if state == nil {
+		_, err := bq.chain.InsertChain(types.Blocks{b})
+		if err != nil {
+			return fmt.Errorf("failed to insert block into chain: %w", err)
+		}
+		log.Info("Successfully inserted new block", "number", b.Number(), "hash", hash)
+		return nil
 	}
 
-	return err
+	// Insert state directly if we have one.
+	var logs []*types.Log
+	for i, receipt := range receipts {
+		// Add block location fields.
+		receipt.BlockHash = hash
+		receipt.BlockNumber = b.Number()
+		receipt.TransactionIndex = uint(i)
+
+		// Update the block hash in all logs since it is now available and not when the
+		// receipt/log of individual transactions were created.
+		for _, taskLog := range receipt.Logs {
+			taskLog.BlockHash = hash
+		}
+		logs = append(logs, receipt.Logs...)
+	}
+	// Commit block and state to database.
+	_, err := bq.chain.WriteBlockAndSetHead(b, receipts, logs, state, true)
+	if err != nil {
+		log.Error("Failed to write block to chain and set head",
+			"number", b.NumberU64(),
+			"err", err)
+		return fmt.Errorf("failed to write block into chain: %w", err)
+	}
+	log.Info("Successfully wrote new block with state", "number", b.Number(), "hash", hash)
+
+	return nil
 }
 
 // ClearStaleTasks removes all stale tasks up to the specified height (including

--- a/consensus/dbft/chainreader.go
+++ b/consensus/dbft/chainreader.go
@@ -25,5 +25,5 @@ type ChainHeaderReader interface {
 type ChainHeaderWriter interface {
 	ChainHeaderReader
 	InsertChain(chain types.Blocks) (int, error)
-	InsertBlockWithoutSetHead(b *types.Block) error
+	WriteBlockAndSetHead(block *types.Block, receipts []*types.Receipt, logs []*types.Log, state *state.StateDB, emitHeadEvent bool) (core.WriteStatus, error)
 }

--- a/consensus/dbft/chainreader.go
+++ b/consensus/dbft/chainreader.go
@@ -17,6 +17,7 @@ type ChainHeaderReader interface {
 	HasBlock(hash common.Hash, number uint64) bool
 	GetBlockByNumber(uint64) *types.Block
 	VerifyBlock(block *types.Block) (*state.StateDB, types.Receipts, error)
+	ProcessState(block *types.Block) (*state.StateDB, types.Receipts, []*types.Log, uint64, error)
 }
 
 // ChainHeaderWriter is a Blockchain API abstraction needed for proper blockQueue

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -350,32 +350,7 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 			if prepareReq == nil {
 				panic("can't create new block from context: prepare request is nil")
 			}
-			proposal := prepareReq.GetPrepareRequest().(*prepareRequest)
-			// Avoid changing PrepareRequest itself.
-			h := types.CopyHeader(proposal.SealingProposal)
-
-			// BlockIndex -> Number
-			h.Number = big.NewInt(int64(ctx.BlockIndex))
-
-			// PrimaryIndex -> Nonce
-			binary.BigEndian.PutUint64(h.Nonce[:], uint64(ctx.PrimaryIndex))
-
-			h.Difficulty = c.getDifficulty(int(ctx.PrimaryIndex), uint64(ctx.BlockIndex))
-
-			// Do not fill block's transactions. First of all, transactions are not
-			// needed for block signing or block signature verification. Secondly, some
-			// transactions may be missing by the moment of call to NewBlockFromContext
-			// (dBFT has only the full set of their hashes). Once all transactions are
-			// fetched and the commits are collected, SetTransactions callback will be
-			// called by dBFT library to properly initialize block's transactions.
-			res := &Block{
-				header: h,
-			}
-			// Withdrawals are temporary empty if Shanghai is passed.
-			if c.chain.Config().IsShanghai(h.Number, h.Time) {
-				res.withdrawals = emptyWithdrawals
-			}
-			return res
+			return c.newBlockFromContext(prepareReq.GetPrepareRequest().(*prepareRequest).SealingProposal)
 		}),
 		dbft.WithWatchOnly(func() bool {
 			return false
@@ -448,10 +423,44 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 			// NextConsensus -> MixHash
 			c.sealingProposal.MixDigest = c.lastBlockNextNextConsensus
 
+			// Recalculate block state provided by miner and update sealing proposal if CV happened and context-related
+			// block fields were changed.
+			if c.dbft.Context.ViewNumber != 0 {
+				dbftBlock := c.newBlockFromContext(c.sealingProposal)
+				dbftBlock.transactions = c.sealingTransactions
+				ethBlock := dbftBlock.ToEthBlock()
+
+				state, receipts, _, _, err := c.chain.ProcessState(ethBlock)
+				if err != nil {
+					log.Crit("failed to process state from proposal",
+						"err", err,
+						"number", ethBlock.NumberU64(),
+						"seal hash", c.SealHash(ethBlock.Header()),
+						"parent hash", ethBlock.ParentHash().String(),
+						"intermediate merkle root", ethBlock.Root(),
+						"coinbase", ethBlock.Coinbase().String(),
+						"gas limit", ethBlock.GasLimit(),
+						"gas used", ethBlock.GasUsed(),
+						"difficulty", ethBlock.Difficulty().String(),
+						"mix digest", ethBlock.MixDigest().String(),
+						"nonce", ethBlock.Nonce(),
+						"time", ethBlock.Time(),
+						"uncle hash", ethBlock.UncleHash().String(),
+						"txs", len(ethBlock.Transactions()))
+				}
+				b, err := c.FinalizeAndAssemble(c.chain, dbftBlock.header, state, dbftBlock.transactions, nil, receipts, dbftBlock.withdrawals)
+				if err != nil {
+					log.Crit("failed to finalize and assemble proposal",
+						"err", err)
+				}
+
+				c.sealingProposal = b.Header()
+			}
+
 			// Fill in only proposal and receipts, transactions will be properly
 			// set from context later in SetTransactionHashes callback.
 			req.SealingProposal = c.sealingProposal
-
+			
 			req.ParentSealHash = c.lastBlockSealHash
 			req.ParentExtra = c.lastBlockExtra
 
@@ -582,6 +591,38 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 	return c, nil
 }
 
+// newBlockFromContext is a dBFT callback that builds [Block] from the provided dBFT proposal
+// filling all appropriate fields from dBFT context. It doesn't set transactions or any
+// other information except the header itself.
+func (c *DBFT) newBlockFromContext(sealingProposal *types.Header) *Block {
+	ctx := c.dbft.Context
+
+	// Avoid changing PrepareRequest itself.
+	h := types.CopyHeader(sealingProposal)
+
+	// BlockIndex -> Number
+	h.Number = big.NewInt(int64(ctx.BlockIndex))
+
+	// PrimaryIndex -> Nonce
+	binary.BigEndian.PutUint64(h.Nonce[:], uint64(ctx.PrimaryIndex))
+
+	h.Difficulty = c.getDifficulty(int(ctx.PrimaryIndex), uint64(ctx.BlockIndex))
+
+	// Do not fill block's transactions. First of all, transactions are not
+	// needed for block signing or block signature verification. Secondly, some
+	// transactions may be missing by the moment of call to NewBlockFromContext
+	// (dBFT has only the full set of their hashes). Once all transactions are
+	// fetched and the commits are collected, SetTransactions callback will be
+	// called by dBFT library to properly initialize block's transactions.
+	res := &Block{
+		header: h,
+	}
+	// Withdrawals are temporary empty if Shanghai is passed.
+	if c.chain.Config().IsShanghai(h.Number, h.Time) {
+		res.withdrawals = emptyWithdrawals
+	}
+	return res
+}
 func (c *DBFT) getBlockWitness() []byte {
 	dctx := c.dbft.Context
 

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -321,8 +321,8 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 			return res
 		}),
 		dbft.WithProcessBlock(func(b block.Block) {
-			ethBlock := b.(*Block)
-			if uint64(ethBlock.Index()) <= c.lastIndex {
+			dbftBlock := b.(*Block)
+			if uint64(dbftBlock.Index()) <= c.lastIndex {
 				return
 			}
 
@@ -330,16 +330,9 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 			// of code is guaranteed to be called once thanks to condition above,
 			// c.lastIndex is updated in postBlock callback every time new block
 			// with higher index is accepted.
-			dBFTHeader := ethBlock.header
-			dBFTHeader.Extra = append(dBFTHeader.Extra, c.getBlockWitness()...) // Extra version isn't changed, validators addresses and signatures are added.
+			dbftBlock.header.Extra = append(dbftBlock.header.Extra, c.getBlockWitness()...) // Extra version isn't changed, validators addresses and signatures are added.
 
-			res := types.NewBlockWithHeader(ethBlock.header)
-			// Uncles are always nil in dBFT-like consensus.
-			res = res.WithBody(ethBlock.transactions, nil)
-			if ethBlock.withdrawals != nil {
-				res = res.WithWithdrawals(ethBlock.withdrawals)
-			}
-
+			res := dbftBlock.ToEthBlock()
 			// Firstly, notify chain about new block.
 			if err := c.blockQueue.PutBlock(res); err != nil {
 				// The block might already be added via the regular network

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -457,10 +457,9 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 				c.sealingProposal = b.Header()
 			}
 
-			// Fill in only proposal and receipts, transactions will be properly
+			// Fill in only proposal and last block info, transactions will be properly
 			// set from context later in SetTransactionHashes callback.
 			req.SealingProposal = c.sealingProposal
-			
 			req.ParentSealHash = c.lastBlockSealHash
 			req.ParentExtra = c.lastBlockExtra
 
@@ -575,7 +574,7 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 			}
 			dbftBlock.state = state
 			dbftBlock.receipts = receipts
-			
+
 			return true
 		}),
 		dbft.WithBroadcast(func(p payload.ConsensusPayload) {

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -68,7 +68,6 @@ import (
 var (
 	uncleHash = types.CalcUncleHash(nil) // Always Keccak256(RLP([])) as uncles are meaningless outside of PoW.
 
-	diffStub   = big.NewInt(3) // Block difficulty stub that is used for miner's task preparation.
 	diffInTurn = big.NewInt(2) // Block difficulty for in-turn signatures
 	diffNoTurn = big.NewInt(1) // Block difficulty for out-of-turn signatures
 
@@ -944,9 +943,10 @@ func (c *DBFT) Prepare(chain consensus.ChainHeaderReader, header *types.Header) 
 	// for now.
 	header.Nonce = types.BlockNonce{}
 
-	// Use difficulty stub to let the Beacon engine know that sealing task should be handled
-	// by PoA engine. This stub will be overridden during further dBFT process anyway.
-	header.Difficulty = diffStub
+	// Use in-turn difficulty as a base for miner's transactions processing to skip dBFT transactions reprocessing in best
+	// case. In worse case this field will be overridden during further dBFT consensus in case of CV and state will be
+	// recalculated by dBFT based on new value.
+	header.Difficulty = new(big.Int).Set(diffInTurn)
 
 	// Ensure the extra data has all its components. Set default Extra version if not
 	// provided by miner.

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -333,7 +333,7 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 
 			res := dbftBlock.ToEthBlock()
 			// Firstly, notify chain about new block.
-			if err := c.blockQueue.PutBlock(res); err != nil {
+			if err := c.blockQueue.PutBlock(res, dbftBlock.state, dbftBlock.receipts); err != nil {
 				// The block might already be added via the regular network
 				// interaction.
 				if h := c.chain.GetHeaderByNumber(res.Number().Uint64()); h == nil {
@@ -515,7 +515,7 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 				oldHash := c.lastBlockHash
 				oldExtra := c.lastBlockExtra
 				parentHeader.Extra = req.ParentExtra
-				err = c.blockQueue.PutBlock(parent.WithSeal(parentHeader))
+				err = c.blockQueue.PutBlock(parent.WithSeal(parentHeader), nil, nil)
 				if err != nil {
 					err = fmt.Errorf("failed to enqueue parent with updated extra for height %d (old hash %s, new hash %s): %w",
 						req.SealingProposal.Number.Uint64()-1,
@@ -567,12 +567,15 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 				return false
 			}
 			ethBlock := dbftBlock.ToEthBlock()
-			_, _, err := c.chain.VerifyBlock(ethBlock)
+			state, receipts, err := c.chain.VerifyBlock(ethBlock)
 			if err != nil {
 				log.Warn("proposed block verification failed",
 					"err", err.Error())
 				return false
 			}
+			dbftBlock.state = state
+			dbftBlock.receipts = receipts
+			
 			return true
 		}),
 		dbft.WithBroadcast(func(p payload.ConsensusPayload) {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2485,7 +2485,7 @@ func (bc *BlockChain) ProcessState(block *types.Block) (*state.StateDB, types.Re
 	return statedb, receipts, logs, usedGas, nil
 }
 
-// VerifyBlock checks block state
+// VerifyBlock validates block body, processes block and validates the resulting state, receipts and gas used.
 func (bc *BlockChain) VerifyBlock(block *types.Block) (*state.StateDB, types.Receipts, error) {
 	err := bc.validator.ValidateBody(block)
 	if err != nil {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2458,29 +2458,22 @@ func (bc *BlockChain) GetTrieFlushInterval() time.Duration {
 func (bc *BlockChain) ProcessState(block *types.Block) (*state.StateDB, types.Receipts, []*types.Log, uint64, error) {
 	parent := bc.GetBlockByHash(block.ParentHash())
 	if parent == nil {
-		err := fmt.Errorf("failed to retrieve parent by hash to process block, %s: %v, %s: %s", "parent number", block.NumberU64()-1,
+		log.Error("failed to retrieve parent by hash to process block state",
+			"parent number", block.NumberU64()-1,
 			"parent hash", block.ParentHash().String())
-		log.Error(err.Error())
 		parent = bc.GetBlockByNumber(block.NumberU64() - 1)
 		if parent == nil {
-			err = fmt.Errorf("failed to retrieve canonical parent by number to process block, %s: %v, %s: %s", "parent number", block.NumberU64()-1,
-				"parent hash", block.ParentHash().String())
-			log.Error(err.Error())
-			return nil, nil, nil, 0, err
+			return nil, nil, nil, 0, fmt.Errorf("failed to retrieve canonical parent by number to process block state (number %d, hash %s)", block.NumberU64()-1, block.ParentHash().String())
 		}
 	}
 	statedb, err := bc.StateAt(parent.Root())
 	if err != nil {
-		err = fmt.Errorf("failed to retrieve state at %s: %w", parent.Root(), err)
-		log.Error(err.Error())
-		return nil, nil, nil, 0, err
+		return nil, nil, nil, 0, fmt.Errorf("failed to retrieve state at %d, %s: %w", parent.NumberU64(), parent.Root(), err)
 	}
 
 	receipts, logs, usedGas, err := bc.processor.Process(block, statedb, bc.vmConfig)
 	if err != nil {
-		err = fmt.Errorf("failed to process block: %w", err)
-		log.Error(err.Error())
-		return nil, nil, nil, 0, err
+		return nil, nil, nil, 0, fmt.Errorf("failed to process block: %w", err)
 	}
 	return statedb, receipts, logs, usedGas, nil
 }
@@ -2489,22 +2482,16 @@ func (bc *BlockChain) ProcessState(block *types.Block) (*state.StateDB, types.Re
 func (bc *BlockChain) VerifyBlock(block *types.Block) (*state.StateDB, types.Receipts, error) {
 	err := bc.validator.ValidateBody(block)
 	if err != nil {
-		err = fmt.Errorf("failed to validate body: %w", err)
-		log.Error(err.Error())
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to validate body: %w", err)
 	}
 
 	statedb, receipts, _, usedGas, err := bc.ProcessState(block)
 	if err != nil {
-		err = fmt.Errorf("failed to process block state: %w", err)
-		log.Error(err.Error())
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to process block state: %w", err)
 	}
 
 	if err := bc.validator.ValidateState(block, statedb, receipts, usedGas); err != nil {
-		err = fmt.Errorf("failed to verify state: %w", err)
-		log.Error(err.Error())
-		return nil, nil, err
+		return nil, nil, fmt.Errorf("failed to verify state: %w", err)
 	}
 	return statedb, receipts, nil
 }


### PR DESCRIPTION
Close #140. Close #60. Port #141 with some changes.

In this PR:
* Ensure all header's fields that affect miner's state calculations are properly set in `(*DBFT).Prepare`. A part of #140.
* Recalculate Merkle state depending on updated dBFT context information in case of CV. Close #140.
* Optimize accepted block insertion into chain using state calculated during PrepareRequest-level block verification (port the #124). Close #60.

Tested on privnet with transactions, works as expected. @chenquanyu, @nicolegys, welcome to review and test.