### PR TITLE
.github: add basic release CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,14 +29,14 @@ jobs:
         arch: [amd64]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.ref }}
           # Allows to fetch all history for all branches and tags. Need this for proper versioning.
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.21'
           cache: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,18 +56,18 @@ jobs:
         run: make all
 
       - name: Rename geth binary
-        run: mv ./build/bin/geth* ./build/bin/geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}${{ (matrix.os.bin-name == 'windows' && '.exe') || '' }}
+        run: mv ./build/bin/geth ./build/bin/geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}
-          path: ./build/bin/geth*
+          path: ./build/bin/geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}
           if-no-files-found: error
 
       - name: Attach binary to the release as an asset
         if: ${{ github.event_name == 'release' }}
-        run: gh release upload ${{ github.event.release.tag_name }} ./build/bin/geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}${{ (matrix.os.bin-name == 'windows' && '.exe') || '' }}
+        run: gh release upload ${{ github.event.release.tag_name }} ./build/bin/geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ on:
     # Build for the bane-main branch.
     branches:
       - bane-main
+  release:
+    types:
+      - published
   workflow_dispatch:
     inputs:
       ref:
@@ -25,8 +28,8 @@ jobs:
     runs-on: ${{matrix.os.name}}
     strategy:
       matrix:
-        os: [{ name: ubuntu-20.04 }]
-        arch: [amd64]
+        os: [{ name: ubuntu-22.04, bin-name: linux }]
+        arch: [amd64, arm64]
 
     steps:
       - uses: actions/checkout@v4
@@ -43,3 +46,19 @@ jobs:
 
       - name: Build geth
         run: make all
+
+      - name: Rename geth binary
+        run: mv ./build/bin/geth* ./build/bin/geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}${{ (matrix.os.bin-name == 'windows' && '.exe') || '' }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}
+          path: ./build/bin/geth*
+          if-no-files-found: error
+
+      - name: Attach binary to the release as an asset
+        if: ${{ github.event_name == 'release' }}
+        run: gh release upload ${{ github.event.release.tag_name }} ./build/bin/geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}${{ (matrix.os.bin-name == 'windows' && '.exe') || '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,14 @@ on:
         description: 'Ref to build geth [default: latest bane-main; examples: v0.92.0, 0a4ff9d3e4a9ab432fd5812eb18c98e03b5a7432]'
         required: false
         default: ''
+      push_image:
+        description: 'Push images to DockerHub [default: false; examples: true, false]'
+        required: false
+        default: 'false'
+      use_latest_tag:
+        description: 'Use `latest` tag while pushing images to DockerHub (applied to Ubuntu image only) [default: false; examples: true, false]'
+        required: false
+        default: 'false'
 
 jobs:
   build_cli:
@@ -62,3 +70,59 @@ jobs:
         run: gh release upload ${{ github.event.release.tag_name }} ./build/bin/geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}${{ (matrix.os.bin-name == 'windows' && '.exe') || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build_image:
+    name: Build and push Docker image
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+          cache: true
+
+      - name: Build geth
+        run: |
+          make geth
+          ./build/bin/geth --version
+
+      - name: Set env
+        id: setvars
+        run: echo "version=$(./build/bin/geth -v | sed -e "s/^geth version //" -e "s/-stable-.*//")" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.push_image == 'true') }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Set latest tag
+        id: setlatest
+        if: ${{ (github.event_name == 'release' && github.event.release.target_commitish == 'bane-main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.use_latest_tag == 'true') }}
+        run: echo "latest=,developerneox/neox_nodes:latest" >> $GITHUB_OUTPUT
+
+      - name: Build and push Geth
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.push_image == 'true') }}
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            REPO=github.com/${{ github.repository }}
+            VERSION=${{ steps.setvars.outputs.version }}
+          tags: developerneox/neox_nodes:${{ steps.setvars.outputs.version }}${{ steps.setlatest.outputs.latest }}
+          file: Dockerfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,9 @@ jobs:
       - name: Set latest tag
         id: setlatest
         if: ${{ (github.event_name == 'release' && github.event.release.target_commitish == 'bane-main') || (github.event_name == 'workflow_dispatch' && github.event.inputs.use_latest_tag == 'true') }}
-        run: echo "latest=,developerneox/neox_nodes:latest" >> $GITHUB_OUTPUT
+        run: |
+          echo "latest=,developerneox/neox_nodes:latest" >> $GITHUB_OUTPUT
+          echo "alltoolslatest=,developerneox/neox_nodes_alltools:latest" >> $GITHUB_OUTPUT
 
       - name: Build and push Geth
         uses: docker/build-push-action@v5
@@ -127,3 +129,16 @@ jobs:
             COMMIT=${{ github.sha }}
           tags: developerneox/neox_nodes:${{ steps.setvars.outputs.version }}${{ steps.setlatest.outputs.latest }}
           file: Dockerfile
+
+      - name: Build and push Alltools
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.push_image == 'true') }}
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            REPO=github.com/${{ github.repository }}
+            VERSION=${{ steps.setvars.outputs.version }}
+            COMMIT=${{ github.sha }}
+          tags: developerneox/neox_nodes_alltools:${{ steps.setvars.outputs.version }}${{ steps.setlatest.outputs.alltoolslatest }}
+          file: Dockerfile.alltools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{matrix.os.name}}
     strategy:
       matrix:
-        os: [{ name: ubuntu-22.04, bin-name: linux }]
+        os: [{ name: ubuntu-22.04, bin-name: linux }, { name: macos-12, bin-name: darwin }]
         arch: [amd64, arm64]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,5 +124,6 @@ jobs:
           build-args: |
             REPO=github.com/${{ github.repository }}
             VERSION=${{ steps.setvars.outputs.version }}
+            COMMIT=${{ github.sha }}
           tags: developerneox/neox_nodes:${{ steps.setvars.outputs.version }}${{ steps.setlatest.outputs.latest }}
           file: Dockerfile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,22 +52,34 @@ jobs:
           go-version: '1.21'
           cache: true
 
-      - name: Build geth
+      - name: Build Alltools
         run: make all
 
-      - name: Rename geth binary
-        run: mv ./build/bin/geth ./build/bin/geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}
+      - name: Prepare Geth and Alltools target binaries
+        run: |
+          mkdir ./build/standalone
+          cp ./build/bin/geth ./build/standalone/geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}
+          mv ./build/bin/ ./build/alltools-${{ matrix.os.bin-name }}-${{ matrix.arch }}
 
-      - name: Upload artifact
+      - name: Upload Geth artifact
         uses: actions/upload-artifact@v4
         with:
           name: geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}
-          path: ./build/bin/geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}
+          path: ./build/standalone/geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}
           if-no-files-found: error
 
-      - name: Attach binary to the release as an asset
+      - name: Upload Alltools artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: alltools-${{ matrix.os.bin-name }}-${{ matrix.arch }}
+          path: ./build/alltools-${{ matrix.os.bin-name }}-${{ matrix.arch }}
+          if-no-files-found: error
+
+      - name: Attach binaries to the release as assets
         if: ${{ github.event_name == 'release' }}
-        run: gh release upload ${{ github.event.release.tag_name }} ./build/bin/geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} ./build/standalone/geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}
+          gh release upload ${{ github.event.release.tag_name }} ./build/alltools-${{ matrix.os.bin-name }}-${{ matrix.arch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+This document outlines major changes between releases.

--- a/docs/release-instruction.md
+++ b/docs/release-instruction.md
@@ -1,0 +1,87 @@
+# Release instructions
+
+This document outlines the Bane release process. It can be used as a todo
+list for a new release.
+
+## Check the state
+
+These should run successfully:
+* build
+* unit-tests
+* privnet with consensus nodes
+* mainnet/testnet synchronization for compatible releases
+
+## Update CHANGELOG
+
+Add an entry to the CHANGELOG.md following the style established there. Add a
+codename, version and release date in the heading. Write a paragraph
+describing the most significant changes done in this release. In case if the node
+configuration was changed, some API was marked as deprecated, any experimental
+changes were made in the user-facing code and the users' feedback is needed or
+if there's any other information that requires user's response, write
+another separate paragraph for those who owns Bane node or uses any external
+API. Then, add sections with release content describing each change in detail
+and with a reference to GitHub issues and/or PRs. Minor issues that doesn't
+affect the node end-user may be grouped under a single label.
+* "New features" section should include new abilities that were added to the
+  node/API/services, are directly visible or available to the user and are large
+  enough to be treated as a feature. Do not include minor user-facing
+  improvements and changes that don't affect the user-facing functionality
+  even if they are new.
+* "Behaviour changes" section should include any incompatible changes in default
+  settings, in the way commands operate or in API that are available to the
+  user. Add a note about changes user needs to make if he uses the affected code.
+* "Improvements" section should include user-facing changes that are too
+  insignificant to be treated as a feature (e.g. new CLI flags) and are not
+  directly visible to the node end-user, such as performance optimizations,
+  refactoring and internal API changes.
+* "Bugs fixed" section should include a set of bugs fixed since the previous
+  release with optional bug cause or consequences description.
+
+Create a PR with CHANGELOG changes, review/merge it.
+
+## Update Geth version
+
+Update `VersionMeta` constant value located at the [version file](../params/version.go)
+from `unstable` to `stable`. Create a PR with the change, review/merge it.
+
+## Create a GitHub release and a tag
+
+Use "Draft a new release" button in the "Releases" section. Create a new
+`vX.Y.Z` tag for it following the semantic versioning standard. Put change log
+for this release into the description. Do not attach any binaries at this step.
+Set the "Set as the latest release" checkbox if this is the latest stable
+release or "Set as a pre-release" if this is an unstable pre-release.
+Press the "Publish release" button.
+
+## Add automatically-built binaries
+
+New release created at the previous step triggers automatic builds (if not,
+start them manually from the Build GitHub workflow), so wait for them to
+finish. Built binaries should be automatically attached to the release as an
+asset, check it on the release page. If binaries weren't attached after building
+workflow completion, then submit the bug, download currently supported binaries
+from the building job artifacts, unpack archives and add resulting binaries
+(named in the same way as archives) to the previously created release via
+"Edit release" button.
+
+## Close GitHub milestone
+
+Close corresponding X.Y.Z GitHub milestone.
+
+## Begin next version cycle
+
+Update `VersionMajor`, `VersionMinor` and `VersionPatch` constants value located
+at the [version file](../params/version.go) to match the next release number.
+Update `VersionMeta` constant from `stable` to `unstable`. Create a PR with the
+changes, review/merge it.
+
+## Announcements
+
+Copy the GitHub release page link to:
+* Discord channel
+* Element channel
+
+## Deployment
+
+Deploy the updated version to the mainnet/testnet.

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1        // Major version component of the current release
-	VersionMinor = 13       // Minor version component of the current release
-	VersionPatch = 11       // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 0          // Major version component of the current release
+	VersionMinor = 1          // Minor version component of the current release
+	VersionPatch = 0          // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
Close #78, close #103.

In this PR:
- Add binary builder job that always uploads built binaries as artifacts and (on release) attaches them to the Github release.
- Add Docker image builder job that always build Docker image and (on release or request) uploads it to the Dockerhub.

Draft PR, need to:

- [x] Decide about first version number.
- [x] ~~Set first Git tag.~~ Will be done on first release.
- [x] Test.
- [x] Add release instructions file.