### PR TITLE
workflows: upload build artifacts only on release or manual trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,7 @@ jobs:
           mv ./build/bin/ ./build/alltools-${{ matrix.os.bin-name }}-${{ matrix.arch }}
 
       - name: Upload Geth artifact
+        if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
         uses: actions/upload-artifact@v4
         with:
           name: geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}
@@ -69,6 +70,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload Alltools artifact
+        if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
         uses: actions/upload-artifact@v4
         with:
           name: alltools-${{ matrix.os.bin-name }}-${{ matrix.arch }}


### PR DESCRIPTION
We're hitting GitHub storage limits, so reduce the number of artifacts to be uploaded.