### PR TITLE
dbft: skip sealing task awaiting during node sync

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -183,6 +183,9 @@ type DBFT struct {
 	// various chain/mempool events and subscription management:
 	chainHeadSub    event.Subscription
 	chainHeadEvents chan core.ChainHeadEvent
+	// minerInterrupted is the callback indicating whether miner is temporary interrupted
+	// due to the node sync.
+	minerInterrupted func() bool
 
 	config *params.DBFTConfig // Consensus engine configuration parameters
 
@@ -684,6 +687,12 @@ func (c *DBFT) WithBroadcast(f func(m *dbftproto.Message) error) {
 // WithRequestTxs sets callback to request the missing transactions from neighbor nodese.
 func (c *DBFT) WithRequestTxs(f func(hashed []common.Hash)) {
 	c.requestTxs = f
+}
+
+// WithMinerInterrupted sets callback to indicate whether miner is interrupted due
+// to the ongoing node sync process.
+func (c *DBFT) WithMinerInterrupted(f func() bool) {
+	c.minerInterrupted = f
 }
 
 // WithTxPool initializes transaction pool API for DBFT interactions with memory pool
@@ -1412,6 +1421,13 @@ func (c *DBFT) newPayload(ctx *dbft.Context, t payload.MessageType, msg any) pay
 }
 
 func (c *DBFT) handleChainBlock(b *types.Block) error {
+	// A short path if miner is not active and the node is in the process of block
+	// sync. In this case dBFT can't react properly on the newcoming blocks since no
+	// sealing task is expected from miner.
+	if c.minerInterrupted() {
+		return nil
+	}
+
 	// We can get our own block here, so check for index.
 	if uint32(b.Number().Uint64()) >= c.dbft.BlockIndex {
 		log.Info("New block in the chain",

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -296,6 +296,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		bft.WithBroadcast(eth.dbftSrv.BroadcastMessage)
 		bft.WithTxPool(eth.TxPool())
 		bft.WithRequestTxs(eth.handler.BroadcastRequestTxs)
+		bft.WithMinerInterrupted(eth.miner.Syncing)
 	}
 
 	// Setup DNS discovery iterators.

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -185,6 +185,11 @@ func (miner *Miner) Mining() bool {
 	return miner.worker.isRunning()
 }
 
+// Syncing indicates whether mining is currently interrupted due to the node's Downloader work.
+func (miner *Miner) Syncing() bool {
+	return miner.worker.isSyncing()
+}
+
 func (miner *Miner) Hashrate() uint64 {
 	if pow, ok := miner.engine.(consensus.PoW); ok {
 		return uint64(pow.Hashrate())

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -382,6 +382,12 @@ func (w *worker) isRunning() bool {
 	return w.running.Load()
 }
 
+// isSyncing returns an indicator whether the node is in the sync process
+// from the worker PoW.
+func (w *worker) isSyncing() bool {
+	return w.syncing.Load()
+}
+
 // close terminates all background threads maintained by the worker.
 // Note the worker does not support being closed multiple times.
 func (w *worker) close() {


### PR DESCRIPTION
If node is stale and far behind its peers, mining is aborted by the signal of Downloader. If mining is aborted, then sealing task won't be submitted to the consensus engine, and thus, dBFT awaiting for sealing task may hang forever in case of multiple block batch processing by Downloader. It may happen because dBFT's block notificaiton channel has buffer size of 2 and block notification processing is managed by the same eventLoop as sealing tasks awaiting. So dBFT blocks notifications processing by sealing task awaiting, and thus, blocks the whole chain from the further sync process:
```
2024-04-18T10:26:44.856+0300	DEBUG	dbft@v0.0.0-20240130131324-6d59675ad370/dbft.go:229	caching message from future	{"height": 6470, "view": 0, "cache": {}}
2024-04-18T10:26:45.264+0300	DEBUG	dbft@v0.0.0-20240130131324-6d59675ad370/dbft.go:214	received message	{"type": "Commit", "from": 4, "height": 6470, "view": 0, "my_height": 1, "my_view": 0}
2024-04-18T10:26:45.265+0300	DEBUG	dbft@v0.0.0-20240130131324-6d59675ad370/dbft.go:229	caching message from future	{"height": 6470, "view": 0, "cache": {}}
INFO [04-18|10:26:50.148] Imported new chain segment               number=192 hash=775270..7b8b06 blocks=192 txs=0 mgas=0.000 elapsed=562.005ms   mgasps=0.000 age=19h32m52s triedirty=0.00B
INFO [04-18|10:26:50.149] New block in the chain                   "dbft index"=1 "chain index"=192 hash=0x77527025ea64a0ceb26235efaf6ddc5430d0e2de15757869da2e90a1c57b8b06 "parent hash"=0xa9cde87fe65f34bf1f40982015e1a7e73b117a80fadf707b0deda67a34855092 primary=3 coinbase=0x1212000000000000000000000000000000000003 "mix digest"=0x23c10fa9c1fae49f6139db9c3ecff715de101c145e56e4d390a16e67d5c32e1b
INFO [04-18|10:26:50.149] Fetching latest sealing proposal         "desired number"=193
INFO [04-18|10:26:50.152] Indexed transactions                     blocks=193 txs=0 tail=0 elapsed=3.786ms
INFO [04-18|10:26:50.770] Imported new chain segment               number=384 hash=a5dac5..02375b blocks=192 txs=0 mgas=0.000 elapsed=472.546ms   mgasps=0.000 age=18h57m12s triedirty=0.00B
INFO [04-18|10:26:51.344] Imported new chain segment               number=576 hash=1d8a8e..3e8def blocks=192 txs=0 mgas=0.000 elapsed=570.798ms   mgasps=0.000 age=18h21m29s triedirty=0.00B
INFO [04-18|10:26:52.221] Imported new chain segment               number=960 hash=6fde0c..d75d78 blocks=384 txs=0 mgas=0.000 elapsed=868.154ms   mgasps=0.000 age=17h10m6s  triedirty=0.00B
INFO [04-18|10:27:07.683] Looking for peers                        peercount=1 tried=1 static=0
```

To fix this problem we have to omit block notifications processing until the node sync process end, i.e. util the moment miner resumes its work.