### PR TITLE
workflows: migrate to self-hosted runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,14 @@ on:
         description: 'Ref to build geth [default: latest bane-main; examples: v0.92.0, 0a4ff9d3e4a9ab432fd5812eb18c98e03b5a7432]'
         required: false
         default: ''
+      upload_geth:
+        description: 'Upload Geth binary artifact [default: false; examples: true, false]'
+        required: false
+        default: 'false'
+      upload_alltools:
+        description: 'Upload Alltools binary artifacts [default: false; examples: true, false]'
+        required: false
+        default: 'false'
       push_image:
         description: 'Push images to DockerHub [default: false; examples: true, false]'
         required: false
@@ -62,7 +70,7 @@ jobs:
           mv ./build/bin/ ./build/alltools-${{ matrix.os.bin-name }}-${{ matrix.arch }}
 
       - name: Upload Geth artifact
-        if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_geth == 'true') }}
         uses: actions/upload-artifact@v4
         with:
           name: geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}
@@ -70,7 +78,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload Alltools artifact
-        if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_alltools == 'true') }}
         uses: actions/upload-artifact@v4
         with:
           name: alltools-${{ matrix.os.bin-name }}-${{ matrix.arch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,11 +33,11 @@ on:
 jobs:
   build_cli:
     name: Build geth and services
-    runs-on: ${{matrix.os.name}}
+    runs-on: [self-hosted, linux, x64]
     strategy:
       matrix:
-        os: [{ name: ubuntu-22.04, bin-name: linux }, { name: macos-12, bin-name: darwin }]
-        arch: [amd64, arm64]
+        os: [{ name: "[self-hosted, linux, x64]", bin-name: linux }]
+        arch: [amd64]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,6 +88,7 @@ jobs:
   build_image:
     name: Build and push Docker image
     runs-on: ubuntu-22.04
+    if: false
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Tired of failing jobs, let's use `runner1` until we make this repo public. Need to wait until all jobs are passed before the merge.