### PR TITLE
rpc: update fee estimation RPCs to support EIP-1559 tools e.g. MetaMask

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -374,11 +374,25 @@ func (b *EthAPIBackend) SuggestGasTipCap(ctx context.Context) (*big.Int, error) 
 		return nil, err
 	}
 	minGasTipCap := stateDb.GetState(systemcontracts.PolicyProxyHash, systemcontracts.GetMinGasTipCapStateHash()).Big()
-	return cmath.BigMax(suggestTipCap, minGasTipCap), nil
+	denom := new(big.Int).SetUint64(b.eth.blockchain.Config().BaseFeeChangeDenominator())
+	return cmath.BigMax(suggestTipCap, minGasTipCap.Add(minGasTipCap, new(big.Int).Div(minGasTipCap, denom))), nil
 }
 
 func (b *EthAPIBackend) FeeHistory(ctx context.Context, blockCount uint64, lastBlock rpc.BlockNumber, rewardPercentiles []float64) (firstBlock *big.Int, reward [][]*big.Int, baseFee []*big.Int, gasUsedRatio []float64, err error) {
-	return b.gpo.FeeHistory(ctx, blockCount, lastBlock, rewardPercentiles)
+	oldestBlock, reward, baseFee, gasUsedRatio, err := b.gpo.FeeHistory(ctx, blockCount, lastBlock, rewardPercentiles)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	suggestGasTipCap, err := b.SuggestGasTipCap(ctx)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	for i, r := range reward {
+		for j, v := range r {
+			reward[i][j] = cmath.BigMax(suggestGasTipCap, v)
+		}
+	}
+	return oldestBlock, reward, baseFee, gasUsedRatio, nil
 }
 
 func (b *EthAPIBackend) ChainDb() ethdb.Database {


### PR DESCRIPTION
Close #187, After #166.

As mentioned in https://github.com/bane-labs/go-ethereum/pull/6#discussion_r1565128962, our price model (fixed `baseFee` + minimum `effectiveGasTip`) will touch off RPC errors in MetaMask. Because it analyses `eth_feeHistory` directly and suggests a `GasTipCap` lower than we expected. This fallback is removed in [MetaMask/core](https://github.com/MetaMask/core), but not yet the extension.

To prevent this kind of issues in similar tools and libraries, this PR increases `suggestGasTipCap` to 112.5% of the Policy limit, and sets it as the minimum return value of `eth_feeHistory` as well. (The corresponding multiplier of MetaMask ranges from 0.94 to 0.98, which is confusing but meanwhile the fact).

The 12.5% increase in `suggestGasTipCap` will allow us to perform a 12.5% increase in gas tip Policy without rejecting existing transactions in txpool. As for `baseFee`, a 100% increase is allowed with https://github.com/bane-labs/go-ethereum/blob/bane-main/accounts/abi/bind/base.go#L282.

I know it seems much more correct to return the minimum `effectiveGasTip` in `eth_feeHistory` instead of 112.5% of it, but MetaMask doesn't work with it. :(