### PR TITLE
systemcontract: fix the issue of clearing the vote after voting is passed

### DIFF
--- a/contracts/solidity/base/GovernanceVote.sol
+++ b/contracts/solidity/base/GovernanceVote.sol
@@ -6,52 +6,72 @@ import {IGovReward} from "../interfaces/IGovReward.sol";
 
 abstract contract GovernanceVote {
     // events for voting
-    event Vote(address indexed voter, bytes32 indexed methodKey, bytes32 paramKey);
+    event Vote(
+        address indexed voter,
+        bytes32 indexed methodKey,
+        bytes32 paramKey
+    );
     event VotePass(bytes32 indexed methodKey, bytes32 paramKey);
 
     // governance reward contact
-    address public constant govReward =
+    address public constant GOV_REWARD =
         0x1212000000000000000000000000000000000003;
 
-    // vote mapping, method key -> (user address -> param key)
-    mapping(bytes32 => mapping(address => bytes32)) private voteMap;
+    struct VoteInfo {
+        // vote mapping, user address -> param key
+        mapping(address voter => bytes32) values;
+        // voter, used for clearing vote after voting is passed
+        address[] voters;
+    }
+
+    // vote mapping, method key -> voteInfo
+    mapping(bytes32 => VoteInfo) private voteMap;
 
     modifier needVote(bytes32 methodKey, bytes32 paramKey) {
-        address[] memory miners = IGovReward(govReward).getMiners();
+        address[] memory miners = IGovReward(GOV_REWARD).getMiners();
         if (!_contains(miners, msg.sender)) revert Errors.NotMiner();
-
         // update vote map
         _vote(methodKey, paramKey);
-
         // check vote, if not pass just return
-        uint length = miners.length;
-        uint validVotes = 0;
-        for (uint i = 0; i < length; i++) {
-            if (voteMap[methodKey][miners[i]] == paramKey) {
-                validVotes++;
-            }
+        if (!_checkVote(methodKey, paramKey, miners)) {
+            return;
         }
-        if (validVotes < (length + 1) / 2) return;
-
-        // clear vote
         emit VotePass(methodKey, paramKey);
+        // clear vote
         _clearVote(methodKey);
-
         // execute method
         _;
     }
 
     function _vote(bytes32 methodKey, bytes32 paramKey) internal {
-        voteMap[methodKey][msg.sender] = paramKey;
+        if (voteMap[methodKey].values[msg.sender] == bytes32(0)) {
+            voteMap[methodKey].voters.push(msg.sender);
+        }
+        voteMap[methodKey].values[msg.sender] = paramKey;
         emit Vote(msg.sender, methodKey, paramKey);
     }
 
     function _clearVote(bytes32 methodKey) internal {
-        address[] memory voters = IGovReward(govReward).getMiners();
-        uint length = voters.length;
-        for (uint i; i < length; i++) {
-            delete voteMap[methodKey][voters[i]];
+        address[] memory voters = voteMap[methodKey].voters;
+        for (uint i; i < voters.length; i++) {
+            delete voteMap[methodKey].values[voters[i]];
         }
+        // this will not clear the mapping in VoteInfo, so we need the above code
+        delete voteMap[methodKey];
+    }
+
+    function _checkVote(
+        bytes32 methodKey,
+        bytes32 paramKey,
+        address[] memory voters
+    ) internal view returns (bool isPass) {
+        uint votedCount;
+        for (uint i; i < voters.length; i++) {
+            if (voteMap[methodKey].values[voters[i]] == paramKey) {
+                votedCount++;
+            }
+        }
+        return votedCount >= (voters.length + 1) / 2;
     }
 
     function _contains(


### PR DESCRIPTION
Close #228 
This PR will change the storage structure of `GovernanceVote`, but this is compatible with the testnet. Tested on remix, the mapping in the first slot of the struct will remain in the same slot as the mapping of mapping.