### PR TITLE
antimev: allow skip nonce by 1 for encryption external tx

### DIFF
--- a/core/encryption/encryption.go
+++ b/core/encryption/encryption.go
@@ -2,15 +2,14 @@ package encryption
 
 import (
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/systemcontracts"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-const ENC_RECEIVER = "0x1212000000000000000000000000000000000003"
-
 func IsEncReceiver(to *common.Address) bool {
-	return to != nil && *(to) == common.HexToAddress(ENC_RECEIVER)
+	return to != nil && *(to) == systemcontracts.GovernanceRewardHash
 }
 
 func IsEncTx(tx *types.Transaction) bool {
-	return tx != nil && tx.To() != nil && *(tx.To()) == common.HexToAddress(ENC_RECEIVER)
+	return tx != nil && IsEncReceiver(tx.To())
 }

--- a/core/encryption/encryption.go
+++ b/core/encryption/encryption.go
@@ -1,0 +1,16 @@
+package encryption
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+const ENC_RECEIVER = "0x1212000000000000000000000000000000000003"
+
+func IsEncReceiver(to *common.Address) bool {
+	return to != nil && *(to) == common.HexToAddress(ENC_RECEIVER)
+}
+
+func IsEncTx(tx *types.Transaction) bool {
+	return tx != nil && tx.To() != nil && *(tx.To()) == common.HexToAddress(ENC_RECEIVER)
+}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	cmath "github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/core/encryption"
 	"github.com/ethereum/go-ethereum/core/systemcontracts"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -278,7 +279,8 @@ func (st *StateTransition) preCheck() error {
 	if !msg.SkipAccountChecks {
 		// Make sure this transaction's nonce is correct.
 		stNonce := st.state.GetNonce(msg.From)
-		if msgNonce := msg.Nonce; stNonce < msgNonce {
+		// add encryption external tx check
+		if msgNonce := msg.Nonce; stNonce < msgNonce && !(encryption.IsEncReceiver(msg.To) && stNonce+1 == msgNonce) {
 			return fmt.Errorf("%w: address %v, tx: %d state: %d", ErrNonceTooHigh,
 				msg.From.Hex(), msgNonce, stNonce)
 		} else if stNonce > msgNonce {
@@ -445,7 +447,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		ret, _, st.gasRemaining, vmerr = st.evm.Create(sender, msg.Data, st.gasRemaining, value)
 	} else {
 		// Increment the nonce for the next transaction
-		st.state.SetNonce(msg.From, st.state.GetNonce(sender.Address())+1)
+		st.state.SetNonce(msg.From, st.msg.Nonce+1)
 		ret, st.gasRemaining, vmerr = st.evm.Call(sender, st.to(), msg.Data, st.gasRemaining, value)
 	}
 

--- a/core/systemcontracts/contracts.go
+++ b/core/systemcontracts/contracts.go
@@ -30,6 +30,8 @@ var (
 	PolicyProxyHash = common.HexToAddress("0x1212000000000000000000000000000000000002")
 	// PolicyABI is a compiled ABI of Policy contract.
 	PolicyABI abi.ABI
+	// GovernanceRewardHash is a contract hash used to receive governance rewards.
+	GovernanceRewardHash = common.HexToAddress("0x1212000000000000000000000000000000000003")
 )
 
 func init() {

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/prque"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/encryption"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -1714,7 +1715,8 @@ func (pool *LegacyPool) demoteUnexecutables() {
 			localGauge.Dec(int64(len(olds) + len(drops) + len(invalids)))
 		}
 		// If there's a gap in front, alert (should never happen) and postpone all transactions
-		if list.Len() > 0 && list.txs.Get(nonce) == nil {
+		// Skip the gap if an encrypt external tx is at nonce+1
+		if list.Len() > 0 && list.txs.Get(nonce) == nil && (!encryption.IsEncTx(list.txs.Get(nonce + 1))) {
 			gapped := list.Cap(0)
 			for _, tx := range gapped {
 				hash := tx.Hash()

--- a/core/txpool/legacypool/list.go
+++ b/core/txpool/legacypool/list.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/encryption"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -209,7 +210,12 @@ func (m *sortedMap) Remove(nonce uint64) bool {
 // happen but better to be self correcting than failing!
 func (m *sortedMap) Ready(start uint64) types.Transactions {
 	// Short circuit if no transactions are available
-	if m.index.Len() == 0 || (*m.index)[0] > start {
+	if m.index.Len() == 0 {
+		return nil
+	}
+	// Check first nonce
+	isEncTx := encryption.IsEncTx(m.items[(*m.index)[0]])
+	if ((*m.index)[0] > start && !isEncTx) || ((*m.index)[0] > start+1 && isEncTx) {
 		return nil
 	}
 	// Otherwise start accumulating incremental transactions
@@ -218,6 +224,10 @@ func (m *sortedMap) Ready(start uint64) types.Transactions {
 		ready = append(ready, m.items[next])
 		delete(m.items, next)
 		heap.Pop(m.index)
+		// Check if next tx is encrypt external tx and nonce is next +2, increase next by 1 first
+		if m.index.Len() > 0 && encryption.IsEncTx(m.items[(*m.index)[0]]) && (*m.index)[0] == next+2 {
+			next++
+		}
 	}
 	m.cacheMu.Lock()
 	m.cache = nil


### PR DESCRIPTION
For antimev, the encryption external transaction will be a normal transfer to GovReward contract with encrypted internal transaction in data. We need to allow encryption external transaction can skip nonce by 1 to execute encrypted internal transaction first to support browser wallet plugin like metamask.

Close this PR as we decided to use the same nonce for both the envelope and the encrypted transaction, and only one of them will be on-chain.