### PR TITLE
protocols/dbft: verify extensible payloads against extensible whitelist

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1421,6 +1421,19 @@ func (c *DBFT) validatePayload(p *Payload) error {
 	return nil
 }
 
+// IsExtensibleAllowed determines if address is allowed to send extensible payloads
+// (only consensus payloads for now) at the specified height.
+func (c *DBFT) IsExtensibleAllowed(h uint64, u common.Address) bool {
+	// Only validators are included into extensible whitelist for now.
+	validators, err := c.getValidators(&h, nil, nil)
+	if err != nil {
+		return false
+	}
+	n := sort.Search(len(validators), func(i int) bool { return validators[i].Cmp(u) >= 0 })
+	res := n < len(validators)
+	return res
+}
+
 func (c *DBFT) newPayload(ctx *dbft.Context[common.Hash], t dbft.MessageType, msg any) dbft.ConsensusPayload[common.Hash] {
 	var cp = new(Payload)
 	cp.BlockIndex = uint64(ctx.BlockIndex)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -274,8 +274,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.APIBackend.gpo = gasprice.NewOracle(eth.APIBackend, gpoParams)
 
 	var (
-		bft       *dbft.DBFT
-		onPayload func(*dbftproto.Message) error
+		bft                 *dbft.DBFT
+		onPayload           func(*dbftproto.Message) error
+		isExtensibleAllowed func(uint64, common.Address) bool
 	)
 	switch t := eth.engine.(type) {
 	case *dbft.DBFT:
@@ -288,8 +289,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	}
 	if bft != nil {
 		onPayload = bft.OnPayload
+		isExtensibleAllowed = bft.IsExtensibleAllowed
 	}
-	eth.dbftSrv = dbftproto.New(ethapi.NewBlockChainAPI(eth.APIBackend), onPayload)
+	eth.dbftSrv = dbftproto.New(ethapi.NewBlockChainAPI(eth.APIBackend), onPayload, isExtensibleAllowed)
 	if bft != nil {
 		ethAPI := ethapi.NewBlockChainAPI(eth.APIBackend)
 		bft.WithEthAPI(ethAPI)

--- a/eth/protocols/dbft/ledger.go
+++ b/eth/protocols/dbft/ledger.go
@@ -9,11 +9,15 @@ import (
 )
 
 type ledger struct {
-	bc BlockChainAPI
+	bc                  BlockChainAPI
+	isExtensibleAllowed func(height uint64, addr common.Address) bool
 }
 
-func newLedger(bc BlockChainAPI) *ledger {
-	return &ledger{bc: bc}
+func newLedger(bc BlockChainAPI, isExtensibleAllowed func(uint64, common.Address) bool) *ledger {
+	return &ledger{
+		bc:                  bc,
+		isExtensibleAllowed: isExtensibleAllowed,
+	}
 }
 
 func (l *ledger) BlockHeight() uint64 {
@@ -21,6 +25,5 @@ func (l *ledger) BlockHeight() uint64 {
 }
 
 func (l *ledger) IsAddressAllowed(addr common.Address) bool {
-	// Call governance contract here.
-	return true
+	return l.isExtensibleAllowed(l.BlockHeight(), addr)
 }

--- a/eth/protocols/dbft/service.go
+++ b/eth/protocols/dbft/service.go
@@ -7,6 +7,7 @@ package dbft
 import (
 	"sync"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/p2p"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -35,8 +36,8 @@ type Service struct {
 }
 
 // New creates a new instance of [Service].
-func New(bc BlockChainAPI, onPayload func(*Message) error) *Service {
-	poolLedger := newLedger(bc)
+func New(bc BlockChainAPI, onPayload func(*Message) error, isExtensibleAllowed func(uint64, common.Address) bool) *Service {
+	poolLedger := newLedger(bc, isExtensibleAllowed)
 	return &Service{
 		bc:        bc,
 		onPayload: onPayload,


### PR DESCRIPTION
Currently extensible payloads include only consensus payloads, and extensible whitelist includes only validators. This logic may be extended in future to allow additional senders and payload types.

Note that consensus nodes verified consensus payloads before this commit by using OnPayload verification. In other words, this commit makes non-CN nodes verify extensible payloads as far.

Close #240.

@chenquanyu, @txhsl, please review. @songb2 I tested this functionality for both CN and seed nodes under assumption of unchanged CNs. Could you please test the following scenario:
1. Run privnet with stand-by validators.
2. Vote for the new set of validators and wait for the next epoch so that validators list is updated.
3. Check that consensus payloads are handled after new epoch starts. You'll see the following message in logs if something goes wrong: `WARN [07-04|13:24:08.093] can't broadcast consensus message        error="disallowed sender"`.