### PR TITLE
systemcontract: disable implementation contract initializer

### DIFF
--- a/contracts/solidity/base/GovProxyUpgradeable.sol
+++ b/contracts/solidity/base/GovProxyUpgradeable.sol
@@ -13,6 +13,11 @@ abstract contract GovProxyUpgradeable is UUPSUpgradeable {
         _;
     }
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     function _authorizeUpgrade(
         address newImplementation
     ) internal virtual override onlyAdmin {}

--- a/contracts/solidity/test/MockGovProxyUpgradeable.sol
+++ b/contracts/solidity/test/MockGovProxyUpgradeable.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {GovProxyUpgradeable} from "../base/GovProxyUpgradeable.sol";
+
+contract MockGovProxyUpgradeable is GovProxyUpgradeable {
+    function initialize() external initializer {}
+
+    function reinitialize() external reinitializer(1) {}
+}

--- a/contracts/test/GovProxyUpgradeable.ts
+++ b/contracts/test/GovProxyUpgradeable.ts
@@ -1,0 +1,28 @@
+import { ethers } from "hardhat";
+import { expect } from "chai";
+
+describe("GovProxyUpgradeable", function () {
+    it("Should prevent implementation contract from initialization", async function () {
+        const mockGovProxyUpgradeable = await ethers.deployContract("MockGovProxyUpgradeable");
+        await expect(mockGovProxyUpgradeable.initialize()).to.be.reverted;
+        expect(
+            await ethers.provider.send("eth_getStorageAt", [
+                await mockGovProxyUpgradeable.getAddress(),
+                "0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00",
+                "latest"]
+            )
+        ).to.eq("0x000000000000000000000000000000000000000000000000ffffffffffffffff");
+    });
+
+    it("Should prevent implementation contract from reinitialization", async function () {
+        const mockGovProxyUpgradeable = await ethers.deployContract("MockGovProxyUpgradeable");
+        await expect(mockGovProxyUpgradeable.reinitialize()).to.be.reverted;
+        expect(
+            await ethers.provider.send("eth_getStorageAt", [
+                await mockGovProxyUpgradeable.getAddress(),
+                "0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00",
+                "latest"]
+            )
+        ).to.eq("0x000000000000000000000000000000000000000000000000ffffffffffffffff");
+    });
+});


### PR DESCRIPTION
Close #257.

We don't have `initializer` or `reinitializer` thing in our system contracts, so there is no risk without this fix. This modification is just following the suggested coding manners from OpenZeppelin.