### PR TITLE
dBFT: properly track chain downloader events

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -43,6 +43,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/systemcontracts"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/eth/downloader"
 	dbftproto "github.com/ethereum/go-ethereum/eth/protocols/dbft"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/event"
@@ -180,9 +181,12 @@ type DBFT struct {
 	// various chain/mempool events and subscription management:
 	chainHeadSub    event.Subscription
 	chainHeadEvents chan core.ChainHeadEvent
-	// minerInterrupted is the callback indicating whether miner is temporary interrupted
-	// due to the node sync.
-	minerInterrupted func() bool
+	// mux is a subscriptions dispatcher for various chain events including chain
+	// downloader events. Downloader events are used to track miner's state since
+	// miner work may be temporary suspended due to the node sync.
+	mux *event.TypeMux
+	// syncing indicates whether the node is still syncing.
+	syncing atomic.Bool
 
 	config *params.DBFTConfig // Consensus engine configuration parameters
 
@@ -705,10 +709,11 @@ func (c *DBFT) WithRequestTxs(f func(hashed []common.Hash)) {
 	c.requestTxs = f
 }
 
-// WithMinerInterrupted sets callback to indicate whether miner is interrupted due
-// to the ongoing node sync process.
-func (c *DBFT) WithMinerInterrupted(f func() bool) {
-	c.minerInterrupted = f
+// WithMux sets subscriptions dispatcher service to provide a way for dBFT to watch
+// over chain downloader progress. It's needed because miner work is suspended during
+// the ongoing node sync process.
+func (c *DBFT) WithMux(mux *event.TypeMux) {
+	c.mux = mux
 }
 
 // WithTxPool initializes transaction pool API for DBFT interactions with memory pool
@@ -1234,6 +1239,21 @@ func (c *DBFT) waitForNewSealingProposal(desiredHeight uint64, updateContext boo
 func (c *DBFT) eventLoop() {
 	c.eventLoopStarted.Store(true)
 	log.Info("dBFT event loop started")
+
+	// Track of the downloader events to be in sync with miner's status since miner's
+	// work is suspended during the initial chain sync. Please be aware that this is
+	// a one shot type of update loop. It's entered once and as soon as `Done` has
+	// been broadcasted the events are unregistered and the loop is exited. This to
+	// prevent a major security vuln where external parties can DOS you with blocks
+	// and halt your dBFT operation for as long as the DOS continues.
+	downloaderEvents := c.mux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{})
+	defer func() {
+		if !downloaderEvents.Closed() {
+			downloaderEvents.Unsubscribe()
+		}
+	}()
+	dlEventCh := downloaderEvents.Chan()
+
 events:
 	for {
 		oldView := c.dbft.ViewNumber
@@ -1293,6 +1313,43 @@ events:
 					"error", err.Error())
 			}
 			break events
+		case ev := <-dlEventCh:
+			if ev == nil {
+				// Unsubscription done, stop listening.
+				dlEventCh = nil
+				continue
+			}
+			switch ev.Data.(type) {
+			case downloader.StartEvent:
+				c.syncing.Store(true)
+
+			case downloader.FailedEvent:
+				c.syncing.Store(false)
+
+				latest := c.chain.CurrentHeader()
+				err := c.handleChainBlock(latest)
+				if err != nil {
+					log.Warn("Failed to handle latest chain block",
+						"index", latest.Number.Uint64(),
+						"err", err.Error())
+					break events
+				}
+
+			case downloader.DoneEvent:
+				c.syncing.Store(false)
+
+				// Stop reacting to downloader events.
+				downloaderEvents.Unsubscribe()
+
+				latest := c.chain.CurrentHeader()
+				err := c.handleChainBlock(latest)
+				if err != nil {
+					log.Warn("Failed to handle latest chain block",
+						"index", latest.Number.Uint64(),
+						"err", err.Error())
+					break events
+				}
+			}
 		}
 		// Always process block event if there is any, we can add one above or external
 		// services can add several blocks during message processing.
@@ -1452,7 +1509,11 @@ func (c *DBFT) handleChainBlock(h *types.Header) error {
 	// A short path if miner is not active and the node is in the process of block
 	// sync. In this case dBFT can't react properly on the newcoming blocks since no
 	// sealing task is expected from miner.
-	if c.minerInterrupted() {
+	if c.syncing.Load() {
+		log.Info("Skipping dBFT block callback due to sync",
+			"block index", h.Number.Int64(),
+			"dbft index", c.dbft.BlockIndex,
+		)
 		return nil
 	}
 

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -722,17 +722,16 @@ func (c *DBFT) WithTxPool(pool txPool) {
 // or from consensus. It must be called strictly after new block persist since
 // NextConsensus calculation depends on the storage state. It also clears all
 // BlockQueue tasks up to the accepted block height.
-func (c *DBFT) postBlock(b *types.Block) {
-	if c.lastIndex < b.NumberU64() {
-		h := b.Header()
-
+func (c *DBFT) postBlock(h *types.Header) {
+	num := h.Number.Uint64()
+	if c.lastIndex < num {
 		c.lastTimestamp = h.Time
 		c.lastIndex = h.Number.Uint64()
-		c.lastBlockHash = b.Hash()
+		c.lastBlockHash = h.Hash()
 		c.lastBlockSealHash = HonestSealHash(h)
 		c.lastBlockExtra = h.Extra
 
-		c.blockQueue.ClearStaleTasks(b.NumberU64())
+		c.blockQueue.ClearStaleTasks(num)
 	}
 }
 
@@ -1189,8 +1188,8 @@ func (c *DBFT) waitForNewSealingProposal(desiredHeight uint64, updateContext boo
 		log.Info("New chain segment detected",
 			"dBFT latest block index", c.lastIndex,
 			"sealing proposal index", b.NumberU64())
-		ltstBlock := c.chain.GetBlockByNumber(b.NumberU64() - 1)
-		c.postBlock(ltstBlock)
+		ltstHeader := c.chain.GetHeaderByNumber(b.NumberU64() - 1)
+		c.postBlock(ltstHeader)
 	}
 
 	if b.ParentHash().Cmp(c.lastBlockHash) != 0 {
@@ -1279,7 +1278,7 @@ events:
 		case tx := <-c.txs:
 			c.dbft.OnTransaction(&Transaction{Tx: tx})
 		case b := <-c.chainHeadEvents:
-			err := c.handleChainBlock(b.Block)
+			err := c.handleChainBlock(b.Block.Header())
 			if err != nil {
 				log.Warn("Failed to handle chain block",
 					"index", b.Block.NumberU64(),
@@ -1307,7 +1306,7 @@ events:
 			}
 		}
 		if latestBlock.Block != nil {
-			err := c.handleChainBlock(latestBlock.Block)
+			err := c.handleChainBlock(latestBlock.Block.Header())
 			if err != nil {
 				log.Warn("Failed to handle latest chain block",
 					"index", latestBlock.Block.NumberU64(),
@@ -1449,7 +1448,7 @@ func (c *DBFT) newPayload(ctx *dbft.Context[common.Hash], t dbft.MessageType, ms
 	return cp
 }
 
-func (c *DBFT) handleChainBlock(b *types.Block) error {
+func (c *DBFT) handleChainBlock(h *types.Header) error {
 	// A short path if miner is not active and the node is in the process of block
 	// sync. In this case dBFT can't react properly on the newcoming blocks since no
 	// sealing task is expected from miner.
@@ -1458,16 +1457,16 @@ func (c *DBFT) handleChainBlock(b *types.Block) error {
 	}
 
 	// We can get our own block here, so check for index.
-	if uint32(b.Number().Uint64()) >= c.dbft.BlockIndex {
+	if uint32(h.Number.Uint64()) >= c.dbft.BlockIndex {
 		log.Info("New block in the chain",
 			"dbft index", c.dbft.BlockIndex,
 			"chain index", c.chain.CurrentBlock().Number.Uint64(),
-			"hash", b.Hash().String(),
-			"parent hash", b.ParentHash().String(),
-			"primary", b.Primary(),
-			"coinbase", b.Coinbase(),
-			"mix digest", b.MixDigest().String())
-		c.postBlock(b)
+			"hash", h.Hash().String(),
+			"parent hash", h.ParentHash.String(),
+			"primary", h.Primary(),
+			"coinbase", h.Coinbase,
+			"mix digest", h.MixDigest.String())
+		c.postBlock(h)
 
 		err := c.waitForNewSealingProposal(c.lastIndex+1, false)
 		if err != nil {

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -298,7 +298,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		bft.WithBroadcast(eth.dbftSrv.BroadcastMessage)
 		bft.WithTxPool(eth.TxPool())
 		bft.WithRequestTxs(eth.handler.BroadcastRequestTxs)
-		bft.WithMinerInterrupted(eth.miner.Syncing)
+		bft.WithMux(eth.EventMux())
 	}
 
 	// Setup DNS discovery iterators.


### PR DESCRIPTION
dBFT should be aware of chain downloader operations since it may stop its work once miner is suspended and there's no trigger to resume dBFT's work once miner operation is resumed. Note that, following miner behaviour, downloader events subscription is one-off and aimed to track only the initial downloader attempt to sync.

Close #265.

Newly-joined CN logs before the bug is fixed:
```
INFO [07-16|12:17:01.524] Initializing BFT consensus               account=0x351FbbaE28a159c7Ff2884Bef497d24ADF003DA4
INFO [07-16|12:17:01.524] Snap sync complete, auto disabling
INFO [07-16|12:17:01.524] Fetching latest sealing proposal         "desired number"=1
INFO [07-16|12:17:01.524] Commit new sealing work                  number=1 sealhash=cfea25..206fb0 "parent hash"=209739..d8931f etherbase=0x1212000000000000000000000000000000000003 txs=0 gas=0 fees=0 elapsed="187.034µs"
INFO [07-16|12:17:02.525] Sealing proposal updated                 number=1 sealhash=cfea25..206fb0 "parent hash"=209739..d8931f txs=0
INFO [07-16|12:17:02.525] Starting dBFT engine                     "last height"=0 "last timestamp"=0
2024-07-16T12:17:02.526+0300    INFO    dbft@v0.2.0/dbft.go:107 initializing dbft       {"height": 1, "view": 0, "index": -1, "role": "WatchOnly"}
INFO [07-16|12:17:02.526] dBFT event loop started
2024-07-16T12:17:02.772+0300    DEBUG   dbft@v0.2.0/dbft.go:214 received message        {"type": "PrepareRequest", "from": 3, "height": 39, "view": 0, "my_height": 1, "my_view": 0}
2024-07-16T12:17:02.772+0300    DEBUG   dbft@v0.2.0/dbft.go:229 caching message from future     {"height": 39, "view": 0, "cache": null}
2024-07-16T12:17:02.776+0300    DEBUG   dbft@v0.2.0/dbft.go:214 received message        {"type": "PrepareResponse", "from": 1, "height": 39, "view": 0, "my_height": 1, "my_view": 0}

... <- some messages cached

16|12:17:02.862] Block synchronisation started
INFO [07-16|12:17:02.862] Mining aborted due to sync
INFO [07-16|12:17:02.898] Imported new chain segment               number=7 hash=793639..f6d9e8 blocks=7 txs=0 mgas=0.000 elapsed=25.458ms    mgasps=0.000 age=3m35s    triedirty=0.00B
INFO [07-16|12:17:02.899] Skipping new block since miner is interrupted "block index"=7 "dbft index"=1
INFO [07-16|12:17:02.900] Indexed transactions                     blocks=8 txs=0 tail=0 elapsed=1.357ms
INFO [07-16|12:17:02.971] Imported new chain segment               number=39 hash=7e5a71..b2a725 blocks=32 txs=8 mgas=1.134 elapsed=71.527ms    mgasps=15.847 snapdiffs=3.67KiB triedirty=32.41KiB
INFO [07-16|12:17:02.971] Skipping new block since miner is interrupted "block index"=39 "dbft index"=1
INFO [07-16|12:17:02.972] Commit new sealing work                  number=40 sealhash=ccd2e9..ba93a8 "parent hash"=7e5a71..b2a725 etherbase=0x1212000000000000000000000000000000000003 txs=0 gas=0 fees=0 elapsed="675.61µs"
2024-07-16T12:17:12.781+0300    DEBUG   dbft@v0.2.0/dbft.go:214 received message        {"type": "RecoveryRequest", "from": 3, "height": 40, "view": 0, "my_height": 1, "my_view": 0}
2024-07-16T12:17:12.781+0300    DEBUG   dbft@v0.2.0/dbft.go:229 caching message from future     {"height": 40, "view": 0, "cache": null}
2024-07-16T12:17:12.782+0300    DEBUG   dbft@v0.2.0/dbft.go:214 received message        {"type": "RecoveryRequest", "from": 2, "height": 40, "view": 0, "my_height": 1, "my_view": 0}
2024-07-16T12:17:12.782+0300    DEBUG   dbft@v0.2.0/dbft.go:229 caching message from future     {"height": 40, "view": 0, "cache": {}}
2024-07-16T12:17:12.783+0300    DEBUG   dbft@v0.2.0/dbft.go:214 received message        {"type": "RecoveryRequest", "from": 1, "height": 40, "view": 0, "my_height": 1, "my_view": 0}
2024-07-16T12:17:12.783+0300    DEBUG   dbft@v0.2.0/dbft.go:229 caching message from future     {"height": 40, "view": 0, "cache": {}}
2024-07-16T12:17:12.783+0300    DEBUG   dbft@v0.2.0/dbft.go:214 received message        {"type": "RecoveryRequest", "from": 3, "height": 40, "view": 0, "my_height": 1, "my_view": 0}
2024-07-16T12:17:12.783+0300    DEBUG   dbft@v0.2.0/dbft.go:229 caching message from future     {"height": 40, "view": 0, "cache": {}}

... <- here goes endless message caching in case of the number of new CNs > M, dBFT never updates its height because miner operation is interrupted

```

And here are logs of the same node after the bug is fixed, so fresh miner proposal is fetched immediately after chain sync ends:

```
INFO [07-16|13:42:13.296] Initializing BFT consensus               account=0x351FbbaE28a159c7Ff2884Bef497d24ADF003DA4
INFO [07-16|13:42:13.296] Snap sync complete, auto disabling
INFO [07-16|13:42:13.296] Fetching latest sealing proposal         "desired number"=1
INFO [07-16|13:42:13.296] Commit new sealing work                  number=1 sealhash=5659e8..8d8c66 "parent hash"=209739..d8931f etherbase=0x1212000000000000000000000000000000000003 txs=0 gas=0 fees=0 elapsed="189.63µs"
INFO [07-16|13:42:14.297] Sealing proposal updated                 number=1 sealhash=5659e8..8d8c66 "parent hash"=209739..d8931f txs=0
INFO [07-16|13:42:14.297] Starting dBFT engine                     "last height"=0 "last timestamp"=0
2024-07-16T13:42:14.298+0300    INFO    dbft@v0.2.0/dbft.go:107 initializing dbft       {"height": 1, "view": 0, "index": -1, "role": "WatchOnly"}
INFO [07-16|13:42:14.298] dBFT event loop started
INFO [07-16|13:42:14.636] Block synchronisation started
INFO [07-16|13:42:14.637] Mining aborted due to sync
INFO [07-16|13:42:14.692] Imported new chain segment               number=9 hash=423246..d41614 blocks=9 txs=0 mgas=0.000 elapsed=43.097ms   mgasps=0.000 age=2m53s     triedirty=0.00B
INFO [07-16|13:42:14.692] Skipping dBFT block callback due to sync "block index"=9 "dbft index"=1
INFO [07-16|13:42:14.694] Indexed transactions                     blocks=10 txs=0 tail=0 elapsed=1.561ms
INFO [07-16|13:42:14.770] Imported new chain segment               number=35 hash=3302d8..4843d5 blocks=26 txs=8 mgas=1.134 elapsed=77.837ms   mgasps=14.563 snapdiffs=3.62KiB triedirty=31.95KiB
INFO [07-16|13:42:14.771] Skipping dBFT block callback due to sync "block index"=35 "dbft index"=1
INFO [07-16|13:42:14.771] New block in the chain                   "dbft index"=1 "chain index"=35 hash=0x3302d8507f819adfda0d785be5777efd95caa311dd3eaa834b255b373c4843d5 "parent hash"=0xa69d5ddd92f7b55d7f5741ff2d7f26efd7bb13276dbeaa376c9809cfd5f0c6d9 primary=3 coinbase=0x1212000000000000000000000000000000000003 "mix digest"=0xf56df5fa6d4dbb0c9eb1a93aa4cf9a4d3a869d142fd0d632231c9a269c7d4f12
INFO [07-16|13:42:14.771] Fetching latest sealing proposal         "desired number"=36
INFO [07-16|13:42:14.773] Commit new sealing work                  number=36 sealhash=1a9515..c2aa06 "parent hash"=3302d8..4843d5 etherbase=0x1212000000000000000000000000000000000003 txs=0 gas=0 fees=0 elapsed=1.988ms
INFO [07-16|13:42:14.773] Commit new sealing work                  number=36 sealhash=1a9515..c2aa06 "parent hash"=3302d8..4843d5 etherbase=0x1212000000000000000000000000000000000003 txs=0 gas=0 fees=0 elapsed="385.899µs"
INFO [07-16|13:42:15.771] Sealing proposal updated                 number=36 sealhash=1a9515..c2aa06 "parent hash"=3302d8..4843d5 txs=0
2024-07-16T13:42:15.772+0300    INFO    dbft@v0.2.0/dbft.go:107 initializing dbft       {"height": 36, "view": 0, "index": 0, "role": "Primary"}
2024-07-16T13:42:15.772+0300    DEBUG   dbft@v0.2.0/dbft.go:608 reset timer     {"h": 36, "v": 0, "delay": "5s"}
2024-07-16T13:42:20.774+0300    DEBUG   dbft@v0.2.0/dbft.go:185 timeout {"height": 36, "view": 0}
2024-07-16T13:42:20.775+0300    DEBUG   dbft@v0.2.0/send.go:8   broadcasting message    {"type": "PrepareRequest", "height": 36, "view": 0}
2024-07-16T13:42:20.776+0300    INFO    dbft@v0.2.0/send.go:35  sending PrepareRequest  {"height": 36, "view": 0}
2024-07-16T13:42:20.776+0300    DEBUG   dbft@v0.2.0/dbft.go:608 reset timer     {"h": 36, "v": 0, "delay": "5s"}
2024-07-16T13:42:20.776+0300    DEBUG   dbft@v0.2.0/check.go:28 check preparations      {"hasReq": true, "count": 1, "M": 3}
```

@txhsl, please review. @songb2, @moonpyt I tested locally with one new CN, it properly updates dBFT context once the node is synced with the network; you may test it with your scenario when all CNs are replaced by the new ones.