### PR TITLE
systemcontract: change register fee and exit fee rate

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -68,13 +68,13 @@ An EOA account is allowed to become a candidate only after successful registrati
 
 1. Registrant invokes `registerCandidate(uint shareRate)` of `0x1212000000000000000000000000000000000001` as message sender;
 2. Registrant is an EOA account and not yet a candidate;
-3. Put `20000 GAS` deposit `value` along with the transaction as registration fee;
+3. Put `2000 GAS` (mainnet) or `20000 GAS` (testnet) deposit `value` along with the transaction as registration fee;
 4. Provide a `shareRate` ranges from `0` to `1000` in parameters, which is a distribution ratio in thousandths. It determines how many rewards of the total that voters can share, and can not be changed until the candidate exits;
 5. (optional) Withdraw past deposits if it has registered and exited before.
 
 If all conditions are met, the new candidate will be added to the candidate list. Only registered candidates can receive votes to be elected as a consensus node.
 
-A candidate can exit without any permission, but it requires 2 epochs to pass until the candidate is allowed to withdraw its registeration deposit. During this period, the candidate can't receive any votes or become a consensus node, but voters can revoke their votes and choose other candidates to share rewards. As a prevention of malicious resources occupation, `5%` of the deposited registration fee will be charged by Governance when a candidate tries to exit and claim back.
+A candidate can exit without any permission, but it requires 2 epochs to pass until the candidate is allowed to withdraw its registeration deposit. During this period, the candidate can't receive any votes or become a consensus node, but voters can revoke their votes and choose other candidates to share rewards. As a prevention of malicious resources occupation, `1000 GAS` will be charged by Governance when a candidate tries to exit and claim back.
 
 ### Election
 

--- a/contracts/solidity/Governance.sol
+++ b/contracts/solidity/Governance.sol
@@ -21,7 +21,7 @@ contract Governance is IGovernance, ReentrancyGuard, GovProxyUpgradeable {
     address public constant SYS_CALL =
         0xffffFFFfFFffffffffffffffFfFFFfffFFFfFFfE;
     uint public constant SCALE_FACTOR = 10 ** 18;
-    uint public constant EXIT_FEE_RATE = 5;
+    uint public constant EXIT_FEE_RATE = 50;
 
     uint public consensusSize;
     // the min balance for voting

--- a/contracts/test/Governance.ts
+++ b/contracts/test/Governance.ts
@@ -274,7 +274,7 @@ describe("Governance", function () {
 
             await expect(
                 await Governance.connect(candidate1).withdrawRegisterFee()
-            ).to.changeEtherBalance(candidate1, REGISTER_FEE * 95n / 100n);
+            ).to.changeEtherBalance(candidate1, REGISTER_FEE * 50n / 100n);
         });
 
         it("Should emit an event when a candidate withdraw register fee", async function () {


### PR DESCRIPTION
Relate #247, #236 and #271.

Increase the exit fee rate from 5% to 50%, but decrease the register fee from 20000 GAS to 2000 GAS, which is suggested by @steven1227 for mainnet configuration.

NOTE: Genesis allocation is not updated here.