### PR TITLE
params: start v0.2.2 cycle

### DIFF
--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 0        // Major version component of the current release
-	VersionMinor = 2        // Minor version component of the current release
-	VersionPatch = 1        // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 0          // Major version component of the current release
+	VersionMinor = 2          // Minor version component of the current release
+	VersionPatch = 2          // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
Start v0.2.2 that is aimed to be compatible with v0.2.1 released for MainNet launch. If there are some urgent fixes need to be applied at the top of v0.2.1 for MainNet launch, we can add them into this release. If not, then the next v0.3.0 cycle will be started for major anti-MEV protocol changes. I haven't created a designated milestone for v0.2.2 since there are no known bugs right now.

@txhsl, @chenquanyu, please consider this message.