### PR TITLE
antimev: add `EncryptedTx` transaction type

### DIFF
--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -215,7 +215,7 @@ func (api *ExternalSigner) SignTx(account accounts.Account, tx *types.Transactio
 	switch tx.Type() {
 	case types.LegacyTxType, types.AccessListTxType:
 		args.GasPrice = (*hexutil.Big)(tx.GasPrice())
-	case types.DynamicFeeTxType:
+	case types.DynamicFeeTxType, types.EncryptedTxType:
 		args.MaxFeePerGas = (*hexutil.Big)(tx.GasFeeCap())
 		args.MaxPriorityFeePerGas = (*hexutil.Big)(tx.GasTipCap())
 	default:

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -291,7 +291,8 @@ func New(config Config, chain BlockChain) *LegacyPool {
 // pool, specifically, whether it is a Legacy, AccessList or Dynamic transaction.
 func (pool *LegacyPool) Filter(tx *types.Transaction) bool {
 	switch tx.Type() {
-	case types.LegacyTxType, types.AccessListTxType, types.DynamicFeeTxType:
+	// TODO: Will remove types.EncryptedTxType after tx type testing, EncryptedTx should not be in memory pool
+	case types.LegacyTxType, types.AccessListTxType, types.DynamicFeeTxType, types.EncryptedTxType:
 		return true
 	default:
 		return false
@@ -644,7 +645,8 @@ func (pool *LegacyPool) validateTxBasics(tx *types.Transaction, local bool) erro
 		Accept: 0 |
 			1<<types.LegacyTxType |
 			1<<types.AccessListTxType |
-			1<<types.DynamicFeeTxType,
+			1<<types.DynamicFeeTxType |
+			1<<types.EncryptedTxType, // TODO: Will remove types.EncryptedTxType after tx type testing, EncryptedTx should not be in memory pool
 		MaxSize: txMaxSize,
 		MinTip:  pool.gasTip.Load(),
 	}

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -291,8 +291,7 @@ func New(config Config, chain BlockChain) *LegacyPool {
 // pool, specifically, whether it is a Legacy, AccessList or Dynamic transaction.
 func (pool *LegacyPool) Filter(tx *types.Transaction) bool {
 	switch tx.Type() {
-	// TODO: Will remove types.EncryptedTxType after tx type testing, EncryptedTx should not be in memory pool
-	case types.LegacyTxType, types.AccessListTxType, types.DynamicFeeTxType, types.EncryptedTxType:
+	case types.LegacyTxType, types.AccessListTxType, types.DynamicFeeTxType:
 		return true
 	default:
 		return false
@@ -645,8 +644,7 @@ func (pool *LegacyPool) validateTxBasics(tx *types.Transaction, local bool) erro
 		Accept: 0 |
 			1<<types.LegacyTxType |
 			1<<types.AccessListTxType |
-			1<<types.DynamicFeeTxType |
-			1<<types.EncryptedTxType, // TODO: Will remove types.EncryptedTxType after tx type testing, EncryptedTx should not be in memory pool
+			1<<types.DynamicFeeTxType,
 		MaxSize: txMaxSize,
 		MinTip:  pool.gasTip.Load(),
 	}

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -65,6 +65,8 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	if !opts.Config.IsLondon(head.Number) && tx.Type() == types.DynamicFeeTxType {
 		return fmt.Errorf("%w: type %d rejected, pool not yet in London", core.ErrTxTypeNotSupported, tx.Type())
 	}
+	// TODO: add EncryptedTxType check
+
 	if !opts.Config.IsCancun(head.Number, head.Time) && tx.Type() == types.BlobTxType {
 		return fmt.Errorf("%w: type %d rejected, pool not yet in Cancun", core.ErrTxTypeNotSupported, tx.Type())
 	}

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -65,7 +65,6 @@ func ValidateTransaction(tx *types.Transaction, head *types.Header, signer types
 	if !opts.Config.IsLondon(head.Number) && tx.Type() == types.DynamicFeeTxType {
 		return fmt.Errorf("%w: type %d rejected, pool not yet in London", core.ErrTxTypeNotSupported, tx.Type())
 	}
-	// TODO: add EncryptedTxType check
 
 	if !opts.Config.IsCancun(head.Number, head.Time) && tx.Type() == types.BlobTxType {
 		return fmt.Errorf("%w: type %d rejected, pool not yet in Cancun", core.ErrTxTypeNotSupported, tx.Type())

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -204,7 +204,7 @@ func (r *Receipt) decodeTyped(b []byte) error {
 		return errShortTypedReceipt
 	}
 	switch b[0] {
-	case DynamicFeeTxType, AccessListTxType, BlobTxType:
+	case DynamicFeeTxType, EncryptedTxType, AccessListTxType, BlobTxType:
 		var data receiptRLP
 		err := rlp.DecodeBytes(b[1:], &data)
 		if err != nil {
@@ -312,7 +312,7 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 	}
 	w.WriteByte(r.Type)
 	switch r.Type {
-	case AccessListTxType, DynamicFeeTxType, BlobTxType:
+	case AccessListTxType, DynamicFeeTxType, EncryptedTxType, BlobTxType:
 		rlp.Encode(w, data)
 	default:
 		// For unsupported types, write nothing. Since this is for

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -48,6 +48,8 @@ const (
 	AccessListTxType = 0x01
 	DynamicFeeTxType = 0x02
 	BlobTxType       = 0x03
+
+	EncryptedTxType = 0x7 // EncryptedTx is identical to DynamicFeeTx except for the type field.
 )
 
 // Transaction is an Ethereum transaction.
@@ -203,6 +205,8 @@ func (tx *Transaction) decodeTyped(b []byte) (TxData, error) {
 		inner = new(AccessListTx)
 	case DynamicFeeTxType:
 		inner = new(DynamicFeeTx)
+	case EncryptedTxType:
+		inner = new(EncryptedTx)
 	case BlobTxType:
 		inner = new(BlobTx)
 	default:

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -49,7 +49,7 @@ const (
 	DynamicFeeTxType = 0x02
 	BlobTxType       = 0x03
 
-	EncryptedTxType = 0x7 // EncryptedTx is identical to DynamicFeeTx except for the type field.
+	EncryptedTxType = 0x07 // EncryptedTx is identical to DynamicFeeTx except for the type field.
 )
 
 // Transaction is an Ethereum transaction.

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -319,6 +319,64 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 			}
 		}
 
+	case EncryptedTxType:
+		var itx EncryptedTx
+		inner = &itx
+		if dec.ChainID == nil {
+			return errors.New("missing required field 'chainId' in transaction")
+		}
+		itx.ChainID = (*big.Int)(dec.ChainID)
+		if dec.Nonce == nil {
+			return errors.New("missing required field 'nonce' in transaction")
+		}
+		itx.Nonce = uint64(*dec.Nonce)
+		if dec.To != nil {
+			itx.To = dec.To
+		}
+		if dec.Gas == nil {
+			return errors.New("missing required field 'gas' for txdata")
+		}
+		itx.Gas = uint64(*dec.Gas)
+		if dec.MaxPriorityFeePerGas == nil {
+			return errors.New("missing required field 'maxPriorityFeePerGas' for txdata")
+		}
+		itx.GasTipCap = (*big.Int)(dec.MaxPriorityFeePerGas)
+		if dec.MaxFeePerGas == nil {
+			return errors.New("missing required field 'maxFeePerGas' for txdata")
+		}
+		itx.GasFeeCap = (*big.Int)(dec.MaxFeePerGas)
+		if dec.Value == nil {
+			return errors.New("missing required field 'value' in transaction")
+		}
+		itx.Value = (*big.Int)(dec.Value)
+		if dec.Input == nil {
+			return errors.New("missing required field 'input' in transaction")
+		}
+		itx.Data = *dec.Input
+		if dec.AccessList != nil {
+			itx.AccessList = *dec.AccessList
+		}
+
+		// signature R
+		if dec.R == nil {
+			return errors.New("missing required field 'r' in transaction")
+		}
+		itx.R = (*big.Int)(dec.R)
+		// signature S
+		if dec.S == nil {
+			return errors.New("missing required field 's' in transaction")
+		}
+		itx.S = (*big.Int)(dec.S)
+		// signature V
+		itx.V, err = dec.yParityValue()
+		if err != nil {
+			return err
+		}
+		if itx.V.Sign() != 0 || itx.R.Sign() != 0 || itx.S.Sign() != 0 {
+			if err := sanityCheckSignature(itx.V, itx.R, itx.S, false); err != nil {
+				return err
+			}
+		}
 	case BlobTxType:
 		var itx BlobTx
 		inner = &itx

--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -125,6 +125,22 @@ func (tx *Transaction) MarshalJSON() ([]byte, error) {
 		yparity := itx.V.Uint64()
 		enc.YParity = (*hexutil.Uint64)(&yparity)
 
+	case *EncryptedTx:
+		enc.ChainID = (*hexutil.Big)(itx.ChainID)
+		enc.Nonce = (*hexutil.Uint64)(&itx.Nonce)
+		enc.To = tx.To()
+		enc.Gas = (*hexutil.Uint64)(&itx.Gas)
+		enc.MaxFeePerGas = (*hexutil.Big)(itx.GasFeeCap)
+		enc.MaxPriorityFeePerGas = (*hexutil.Big)(itx.GasTipCap)
+		enc.Value = (*hexutil.Big)(itx.Value)
+		enc.Input = (*hexutil.Bytes)(&itx.Data)
+		enc.AccessList = &itx.AccessList
+		enc.V = (*hexutil.Big)(itx.V)
+		enc.R = (*hexutil.Big)(itx.R)
+		enc.S = (*hexutil.Big)(itx.S)
+		yparity := itx.V.Uint64()
+		enc.YParity = (*hexutil.Uint64)(&yparity)
+
 	case *BlobTx:
 		enc.ChainID = (*hexutil.Big)(itx.ChainID.ToBig())
 		enc.Nonce = (*hexutil.Uint64)(&itx.Nonce)

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -256,7 +256,7 @@ func NewLondonSigner(chainId *big.Int) Signer {
 }
 
 func (s londonSigner) Sender(tx *Transaction) (common.Address, error) {
-	if tx.Type() != DynamicFeeTxType {
+	if tx.Type() != DynamicFeeTxType && tx.Type() != EncryptedTxType {
 		return s.eip2930Signer.Sender(tx)
 	}
 	V, R, S := tx.RawSignatureValues()
@@ -292,7 +292,7 @@ func (s londonSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big
 // Hash returns the hash to be signed by the sender.
 // It does not uniquely identify the transaction.
 func (s londonSigner) Hash(tx *Transaction) common.Hash {
-	if tx.Type() != DynamicFeeTxType {
+	if tx.Type() != DynamicFeeTxType && tx.Type() != EncryptedTxType {
 		return s.eip2930Signer.Hash(tx)
 	}
 	return prefixedRlpHash(

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -275,18 +275,28 @@ func (s londonSigner) Equal(s2 Signer) bool {
 }
 
 func (s londonSigner) SignatureValues(tx *Transaction, sig []byte) (R, S, V *big.Int, err error) {
-	txdata, ok := tx.inner.(*DynamicFeeTx)
-	if !ok {
+	switch txdata := tx.inner.(type) {
+	case *DynamicFeeTx:
+		// Check that chain ID of tx matches the signer. We also accept ID zero here,
+		// because it indicates that the chain ID was not specified in the tx.
+		if txdata.ChainID.Sign() != 0 && txdata.ChainID.Cmp(s.chainId) != 0 {
+			return nil, nil, nil, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, txdata.ChainID, s.chainId)
+		}
+		R, S, _ = decodeSignature(sig)
+		V = big.NewInt(int64(sig[64]))
+		return R, S, V, nil
+	case *EncryptedTx:
+		// Check that chain ID of tx matches the signer. We also accept ID zero here,
+		// because it indicates that the chain ID was not specified in the tx.
+		if txdata.ChainID.Sign() != 0 && txdata.ChainID.Cmp(s.chainId) != 0 {
+			return nil, nil, nil, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, txdata.ChainID, s.chainId)
+		}
+		R, S, _ = decodeSignature(sig)
+		V = big.NewInt(int64(sig[64]))
+		return R, S, V, nil
+	default:
 		return s.eip2930Signer.SignatureValues(tx, sig)
 	}
-	// Check that chain ID of tx matches the signer. We also accept ID zero here,
-	// because it indicates that the chain ID was not specified in the tx.
-	if txdata.ChainID.Sign() != 0 && txdata.ChainID.Cmp(s.chainId) != 0 {
-		return nil, nil, nil, fmt.Errorf("%w: have %d want %d", ErrInvalidChainId, txdata.ChainID, s.chainId)
-	}
-	R, S, _ = decodeSignature(sig)
-	V = big.NewInt(int64(sig[64]))
-	return R, S, V, nil
 }
 
 // Hash returns the hash to be signed by the sender.

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -508,6 +508,7 @@ func TestYParityJSONUnmarshalling(t *testing.T) {
 	for _, txType := range []uint64{
 		AccessListTxType,
 		DynamicFeeTxType,
+		EncryptedTxType,
 		BlobTxType,
 	} {
 		txType := txType

--- a/core/types/tx_encrypted.go
+++ b/core/types/tx_encrypted.go
@@ -1,0 +1,125 @@
+// Copyright 2021 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package types
+
+import (
+	"bytes"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// EncryptedTx represents an Encrypted neox transaction. Identical to DynamicFeeTx except for the txType() method
+type EncryptedTx struct {
+	ChainID    *big.Int
+	Nonce      uint64
+	GasTipCap  *big.Int // a.k.a. maxPriorityFeePerGas
+	GasFeeCap  *big.Int // a.k.a. maxFeePerGas
+	Gas        uint64
+	To         *common.Address `rlp:"nil"` // nil means contract creation
+	Value      *big.Int
+	Data       []byte
+	AccessList AccessList
+
+	// Signature values
+	V *big.Int `json:"v" gencodec:"required"`
+	R *big.Int `json:"r" gencodec:"required"`
+	S *big.Int `json:"s" gencodec:"required"`
+}
+
+// copy creates a deep copy of the transaction data and initializes all fields.
+func (tx *EncryptedTx) copy() TxData {
+	cpy := &DynamicFeeTx{
+		Nonce: tx.Nonce,
+		To:    copyAddressPtr(tx.To),
+		Data:  common.CopyBytes(tx.Data),
+		Gas:   tx.Gas,
+		// These are copied below.
+		AccessList: make(AccessList, len(tx.AccessList)),
+		Value:      new(big.Int),
+		ChainID:    new(big.Int),
+		GasTipCap:  new(big.Int),
+		GasFeeCap:  new(big.Int),
+		V:          new(big.Int),
+		R:          new(big.Int),
+		S:          new(big.Int),
+	}
+	copy(cpy.AccessList, tx.AccessList)
+	if tx.Value != nil {
+		cpy.Value.Set(tx.Value)
+	}
+	if tx.ChainID != nil {
+		cpy.ChainID.Set(tx.ChainID)
+	}
+	if tx.GasTipCap != nil {
+		cpy.GasTipCap.Set(tx.GasTipCap)
+	}
+	if tx.GasFeeCap != nil {
+		cpy.GasFeeCap.Set(tx.GasFeeCap)
+	}
+	if tx.V != nil {
+		cpy.V.Set(tx.V)
+	}
+	if tx.R != nil {
+		cpy.R.Set(tx.R)
+	}
+	if tx.S != nil {
+		cpy.S.Set(tx.S)
+	}
+	return cpy
+}
+
+// accessors for innerTx.
+func (tx *EncryptedTx) txType() byte           { return EncryptedTxType }
+func (tx *EncryptedTx) chainID() *big.Int      { return tx.ChainID }
+func (tx *EncryptedTx) accessList() AccessList { return tx.AccessList }
+func (tx *EncryptedTx) data() []byte           { return tx.Data }
+func (tx *EncryptedTx) gas() uint64            { return tx.Gas }
+func (tx *EncryptedTx) gasFeeCap() *big.Int    { return tx.GasFeeCap }
+func (tx *EncryptedTx) gasTipCap() *big.Int    { return tx.GasTipCap }
+func (tx *EncryptedTx) gasPrice() *big.Int     { return tx.GasFeeCap }
+func (tx *EncryptedTx) value() *big.Int        { return tx.Value }
+func (tx *EncryptedTx) nonce() uint64          { return tx.Nonce }
+func (tx *EncryptedTx) to() *common.Address    { return tx.To }
+
+func (tx *EncryptedTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
+	if baseFee == nil {
+		return dst.Set(tx.GasFeeCap)
+	}
+	tip := dst.Sub(tx.GasFeeCap, baseFee)
+	if tip.Cmp(tx.GasTipCap) > 0 {
+		tip.Set(tx.GasTipCap)
+	}
+	return tip.Add(tip, baseFee)
+}
+
+func (tx *EncryptedTx) rawSignatureValues() (v, r, s *big.Int) {
+	return tx.V, tx.R, tx.S
+}
+
+func (tx *EncryptedTx) setSignatureValues(chainID, v, r, s *big.Int) {
+	tx.ChainID, tx.V, tx.R, tx.S = chainID, v, r, s
+}
+
+func (tx *EncryptedTx) encode(b *bytes.Buffer) error {
+	return rlp.Encode(b, tx)
+}
+
+func (tx *EncryptedTx) decode(input []byte) error {
+	return rlp.DecodeBytes(input, tx)
+}

--- a/core/types/tx_encrypted.go
+++ b/core/types/tx_encrypted.go
@@ -16,110 +16,16 @@
 
 package types
 
-import (
-	"bytes"
-	"math/big"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/rlp"
-)
-
 // EncryptedTx represents an Encrypted neox transaction. Identical to DynamicFeeTx except for the txType() method
 type EncryptedTx struct {
-	ChainID    *big.Int
-	Nonce      uint64
-	GasTipCap  *big.Int // a.k.a. maxPriorityFeePerGas
-	GasFeeCap  *big.Int // a.k.a. maxFeePerGas
-	Gas        uint64
-	To         *common.Address `rlp:"nil"` // nil means contract creation
-	Value      *big.Int
-	Data       []byte
-	AccessList AccessList
-
-	// Signature values
-	V *big.Int `json:"v" gencodec:"required"`
-	R *big.Int `json:"r" gencodec:"required"`
-	S *big.Int `json:"s" gencodec:"required"`
+	DynamicFeeTx
 }
 
 // copy creates a deep copy of the transaction data and initializes all fields.
 func (tx *EncryptedTx) copy() TxData {
-	cpy := &DynamicFeeTx{
-		Nonce: tx.Nonce,
-		To:    copyAddressPtr(tx.To),
-		Data:  common.CopyBytes(tx.Data),
-		Gas:   tx.Gas,
-		// These are copied below.
-		AccessList: make(AccessList, len(tx.AccessList)),
-		Value:      new(big.Int),
-		ChainID:    new(big.Int),
-		GasTipCap:  new(big.Int),
-		GasFeeCap:  new(big.Int),
-		V:          new(big.Int),
-		R:          new(big.Int),
-		S:          new(big.Int),
-	}
-	copy(cpy.AccessList, tx.AccessList)
-	if tx.Value != nil {
-		cpy.Value.Set(tx.Value)
-	}
-	if tx.ChainID != nil {
-		cpy.ChainID.Set(tx.ChainID)
-	}
-	if tx.GasTipCap != nil {
-		cpy.GasTipCap.Set(tx.GasTipCap)
-	}
-	if tx.GasFeeCap != nil {
-		cpy.GasFeeCap.Set(tx.GasFeeCap)
-	}
-	if tx.V != nil {
-		cpy.V.Set(tx.V)
-	}
-	if tx.R != nil {
-		cpy.R.Set(tx.R)
-	}
-	if tx.S != nil {
-		cpy.S.Set(tx.S)
-	}
-	return cpy
+	dcp, _ := tx.DynamicFeeTx.copy().(*DynamicFeeTx)
+	return &EncryptedTx{DynamicFeeTx: *dcp}
 }
 
 // accessors for innerTx.
-func (tx *EncryptedTx) txType() byte           { return EncryptedTxType }
-func (tx *EncryptedTx) chainID() *big.Int      { return tx.ChainID }
-func (tx *EncryptedTx) accessList() AccessList { return tx.AccessList }
-func (tx *EncryptedTx) data() []byte           { return tx.Data }
-func (tx *EncryptedTx) gas() uint64            { return tx.Gas }
-func (tx *EncryptedTx) gasFeeCap() *big.Int    { return tx.GasFeeCap }
-func (tx *EncryptedTx) gasTipCap() *big.Int    { return tx.GasTipCap }
-func (tx *EncryptedTx) gasPrice() *big.Int     { return tx.GasFeeCap }
-func (tx *EncryptedTx) value() *big.Int        { return tx.Value }
-func (tx *EncryptedTx) nonce() uint64          { return tx.Nonce }
-func (tx *EncryptedTx) to() *common.Address    { return tx.To }
-
-func (tx *EncryptedTx) effectiveGasPrice(dst *big.Int, baseFee *big.Int) *big.Int {
-	if baseFee == nil {
-		return dst.Set(tx.GasFeeCap)
-	}
-	tip := dst.Sub(tx.GasFeeCap, baseFee)
-	if tip.Cmp(tx.GasTipCap) > 0 {
-		tip.Set(tx.GasTipCap)
-	}
-	return tip.Add(tip, baseFee)
-}
-
-func (tx *EncryptedTx) rawSignatureValues() (v, r, s *big.Int) {
-	return tx.V, tx.R, tx.S
-}
-
-func (tx *EncryptedTx) setSignatureValues(chainID, v, r, s *big.Int) {
-	tx.ChainID, tx.V, tx.R, tx.S = chainID, v, r, s
-}
-
-func (tx *EncryptedTx) encode(b *bytes.Buffer) error {
-	return rlp.Encode(b, tx)
-}
-
-func (tx *EncryptedTx) decode(input []byte) error {
-	return rlp.DecodeBytes(input, tx)
-}
+func (tx *EncryptedTx) txType() byte { return EncryptedTxType }

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -274,7 +274,7 @@ func (t *Transaction) GasPrice(ctx context.Context) hexutil.Big {
 		return hexutil.Big{}
 	}
 	switch tx.Type() {
-	case types.DynamicFeeTxType:
+	case types.DynamicFeeTxType, types.EncryptedTxType:
 		if block != nil {
 			if baseFee, _ := block.BaseFeePerGas(ctx); baseFee != nil {
 				// price = min(gasTipCap + baseFee, gasFeeCap)
@@ -312,7 +312,7 @@ func (t *Transaction) MaxFeePerGas(ctx context.Context) *hexutil.Big {
 		return nil
 	}
 	switch tx.Type() {
-	case types.DynamicFeeTxType, types.BlobTxType:
+	case types.DynamicFeeTxType, types.EncryptedTxType, types.BlobTxType:
 		return (*hexutil.Big)(tx.GasFeeCap())
 	default:
 		return nil
@@ -325,7 +325,7 @@ func (t *Transaction) MaxPriorityFeePerGas(ctx context.Context) *hexutil.Big {
 		return nil
 	}
 	switch tx.Type() {
-	case types.DynamicFeeTxType, types.BlobTxType:
+	case types.DynamicFeeTxType, types.EncryptedTxType, types.BlobTxType:
 		return (*hexutil.Big)(tx.GasTipCap())
 	default:
 		return nil

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1451,7 +1451,7 @@ func newRPCTransaction(tx *types.Transaction, blockHash common.Hash, blockNumber
 		result.ChainID = (*hexutil.Big)(tx.ChainId())
 		result.YParity = &yparity
 
-	case types.DynamicFeeTxType:
+	case types.DynamicFeeTxType, types.EncryptedTxType:
 		al := tx.AccessList()
 		yparity := hexutil.Uint64(v.Sign())
 		result.Accesses = &al

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -355,6 +355,95 @@ func allTransactionTypes(addr common.Address, config *params.ChainConfig) []txDa
 				"s": "0x7626abc15834f391a117c63450047309dbf84c5ce3e8e609b607062641e2de43",
 				"yParity": "0x0"
 			}`,
+		}, {
+			Tx: &types.EncryptedTx{
+				DynamicFeeTx: types.DynamicFeeTx{
+					ChainID:   config.ChainID,
+					Nonce:     5,
+					GasTipCap: big.NewInt(6),
+					GasFeeCap: big.NewInt(9),
+					Gas:       7,
+					To:        &addr,
+					Value:     big.NewInt(8),
+					Data:      []byte{0, 1, 2, 3, 4},
+					AccessList: types.AccessList{
+						types.AccessTuple{
+							Address:     common.Address{0x2},
+							StorageKeys: []common.Hash{types.EmptyRootHash},
+						},
+					},
+					V: big.NewInt(32),
+					R: big.NewInt(10),
+					S: big.NewInt(11),
+				}},
+			Want: `{
+				"blockHash": null,
+				"blockNumber": null,
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x9",
+				"maxFeePerGas": "0x9",
+				"maxPriorityFeePerGas": "0x6",
+				"hash": "0x6942f8a24cc15fb0c382e0167f44cdd485e9361176f06ddb1a5a696304d7bd34",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": "0xdead000000000000000000000000000000000000",
+				"transactionIndex": null,
+				"value": "0x8",
+				"type": "0x7",
+				"accessList": [
+					{
+						"address": "0x0200000000000000000000000000000000000000",
+						"storageKeys": [
+							"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421"
+						]
+					}
+				],
+				"chainId": "0x539",
+				"v": "0x1",
+				"r": "0x465ab239d3f8c23abcef068d3f5f8e7802a98064c0bbddb27e2bc6fa91785003",
+				"s": "0x5a7dbc10aaeb09b4971ebe3a6db561e0af78180371fd2a7a8e73977948719ef0",
+				"yParity": "0x1"
+			}`,
+		}, {
+			Tx: &types.EncryptedTx{
+				DynamicFeeTx: types.DynamicFeeTx{
+					ChainID:    config.ChainID,
+					Nonce:      5,
+					GasTipCap:  big.NewInt(6),
+					GasFeeCap:  big.NewInt(9),
+					Gas:        7,
+					To:         nil,
+					Value:      big.NewInt(8),
+					Data:       []byte{0, 1, 2, 3, 4},
+					AccessList: types.AccessList{},
+					V:          big.NewInt(32),
+					R:          big.NewInt(10),
+					S:          big.NewInt(11),
+				},
+			},
+			Want: `{
+				"blockHash": null,
+				"blockNumber": null,
+				"from": "0x71562b71999873db5b286df957af199ec94617f7",
+				"gas": "0x7",
+				"gasPrice": "0x9",
+				"maxFeePerGas": "0x9",
+				"maxPriorityFeePerGas": "0x6",
+				"hash": "0x3f8604e85fc021595c19a2d3f39384552815f7e2f073056eb211e77503377b75",
+				"input": "0x0001020304",
+				"nonce": "0x5",
+				"to": null,
+				"transactionIndex": null,
+				"value": "0x8",
+				"type": "0x7",
+				"accessList": [],
+				"chainId": "0x539",
+				"v": "0x1",
+				"r": "0x53a1209cd7bb645a1a584680a6c32fc7fd3c511ec9c76f98637f7cd959b8eaa5",
+				"s": "0x4a7f2079e6863e9da526f3b167d507e23626ad695abc2d63e93e1d374df8f85f",
+				"yParity": "0x1"
+			}`,
 		},
 	}
 }


### PR DESCRIPTION
`EncryptedTx` is exactly the same as `DynamicFeeTx` except for the type field. Transaction of this type will be encrypted into the data field of the normal GAS transfer transaction to the GovReward contract.