### PR TITLE
Skip dBFT extensible verification during first node sync

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -185,7 +185,9 @@ type DBFT struct {
 	// downloader events. Downloader events are used to track miner's state since
 	// miner work may be temporary suspended due to the node sync.
 	mux *event.TypeMux
-	// syncing indicates whether the node is still syncing.
+	// syncing indicates whether the node is still syncing. This variable is updated
+	// irrespectively from the engine activity, and thus, may be relied on even when
+	// dBFT engine is not started.
 	syncing atomic.Bool
 
 	config *params.DBFTConfig // Consensus engine configuration parameters
@@ -712,6 +714,47 @@ func (c *DBFT) WithRequestTxs(f func(hashed []common.Hash)) {
 // the ongoing node sync process.
 func (c *DBFT) WithMux(mux *event.TypeMux) {
 	c.mux = mux
+
+	go c.syncWatcher()
+}
+
+// syncWatcher is a standalone loop aimed to be active irrespectively of dBFT engine
+// activity. It tracks the first chain sync attempt till its end.
+func (c *DBFT) syncWatcher() {
+	downloaderEvents := c.mux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{})
+	defer func() {
+		if !downloaderEvents.Closed() {
+			downloaderEvents.Unsubscribe()
+		}
+	}()
+	dlEventCh := downloaderEvents.Chan()
+
+events:
+	for {
+		select {
+		case <-c.quit:
+			break events
+		case ev := <-dlEventCh:
+			if ev == nil {
+				// Unsubscription done, stop listening.
+				dlEventCh = nil
+				break events
+			}
+			switch ev.Data.(type) {
+			case downloader.StartEvent:
+				c.syncing.Store(true)
+
+			case downloader.FailedEvent:
+				c.syncing.Store(false)
+
+			case downloader.DoneEvent:
+				c.syncing.Store(false)
+
+				// Stop reacting to downloader events.
+				downloaderEvents.Unsubscribe()
+			}
+		}
+	}
 }
 
 // WithTxPool initializes transaction pool API for DBFT interactions with memory pool
@@ -1244,7 +1287,7 @@ func (c *DBFT) eventLoop() {
 	// been broadcasted the events are unregistered and the loop is exited. This to
 	// prevent a major security vuln where external parties can DOS you with blocks
 	// and halt your dBFT operation for as long as the DOS continues.
-	downloaderEvents := c.mux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{})
+	downloaderEvents := c.mux.Subscribe(downloader.DoneEvent{}, downloader.FailedEvent{})
 	defer func() {
 		if !downloaderEvents.Closed() {
 			downloaderEvents.Unsubscribe()
@@ -1296,7 +1339,7 @@ events:
 		case tx := <-c.txs:
 			c.dbft.OnTransaction(&Transaction{Tx: tx})
 		case b := <-c.chainHeadEvents:
-			err := c.handleChainBlock(b.Block.Header())
+			err := c.handleChainBlock(b.Block.Header(), true)
 			if err != nil {
 				log.Warn("Failed to handle chain block",
 					"index", b.Block.NumberU64(),
@@ -1318,14 +1361,9 @@ events:
 				continue
 			}
 			switch ev.Data.(type) {
-			case downloader.StartEvent:
-				c.syncing.Store(true)
-
 			case downloader.FailedEvent:
-				c.syncing.Store(false)
-
 				latest := c.chain.CurrentHeader()
-				err := c.handleChainBlock(latest)
+				err := c.handleChainBlock(latest, false)
 				if err != nil {
 					log.Warn("Failed to handle latest chain block",
 						"index", latest.Number.Uint64(),
@@ -1334,13 +1372,11 @@ events:
 				}
 
 			case downloader.DoneEvent:
-				c.syncing.Store(false)
-
 				// Stop reacting to downloader events.
 				downloaderEvents.Unsubscribe()
 
 				latest := c.chain.CurrentHeader()
-				err := c.handleChainBlock(latest)
+				err := c.handleChainBlock(latest, false)
 				if err != nil {
 					log.Warn("Failed to handle latest chain block",
 						"index", latest.Number.Uint64(),
@@ -1361,7 +1397,7 @@ events:
 			}
 		}
 		if latestBlock.Block != nil {
-			err := c.handleChainBlock(latestBlock.Block.Header())
+			err := c.handleChainBlock(latestBlock.Block.Header(), true)
 			if err != nil {
 				log.Warn("Failed to handle latest chain block",
 					"index", latestBlock.Block.NumberU64(),
@@ -1503,11 +1539,11 @@ func (c *DBFT) newPayload(ctx *dbft.Context[common.Hash], t dbft.MessageType, ms
 	return cp
 }
 
-func (c *DBFT) handleChainBlock(h *types.Header) error {
+func (c *DBFT) handleChainBlock(h *types.Header, checkForSync bool) error {
 	// A short path if miner is not active and the node is in the process of block
 	// sync. In this case dBFT can't react properly on the newcoming blocks since no
 	// sealing task is expected from miner.
-	if c.syncing.Load() {
+	if checkForSync && c.syncing.Load() {
 		log.Info("Skipping dBFT block callback due to sync",
 			"block index", h.Number.Int64(),
 			"dbft index", c.dbft.BlockIndex,

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1517,19 +1517,21 @@ func (c *DBFT) validatePayload(p *Payload) error {
 
 // IsExtensibleAllowed determines if address is allowed to send extensible payloads
 // (only consensus payloads for now) at the specified height.
-func (c *DBFT) IsExtensibleAllowed(h uint64, u common.Address) bool {
+func (c *DBFT) IsExtensibleAllowed(h uint64, u common.Address) error {
 	// Can't verify extensible sender if the node has an outdated state.
 	if c.syncing.Load() {
-		return true
+		return dbftproto.ErrSyncing
 	}
 	// Only validators are included into extensible whitelist for now.
 	validators, err := c.getValidators(&h, nil, nil)
 	if err != nil {
-		return false
+		return fmt.Errorf("failed to get validators: %w", err)
 	}
 	n := sort.Search(len(validators), func(i int) bool { return validators[i].Cmp(u) >= 0 })
-	res := n < len(validators)
-	return res
+	if n >= len(validators) {
+		return fmt.Errorf("address is not a validator")
+	}
+	return nil
 }
 
 func (c *DBFT) newPayload(ctx *dbft.Context[common.Hash], t dbft.MessageType, msg any) dbft.ConsensusPayload[common.Hash] {

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1518,6 +1518,10 @@ func (c *DBFT) validatePayload(p *Payload) error {
 // IsExtensibleAllowed determines if address is allowed to send extensible payloads
 // (only consensus payloads for now) at the specified height.
 func (c *DBFT) IsExtensibleAllowed(h uint64, u common.Address) bool {
+	// Can't verify extensible sender if the node has an outdated state.
+	if c.syncing.Load() {
+		return true
+	}
 	// Only validators are included into extensible whitelist for now.
 	validators, err := c.getValidators(&h, nil, nil)
 	if err != nil {

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1446,6 +1446,10 @@ func (c *DBFT) OnPayload(cp *dbftproto.Message) error {
 		log.Debug("Skip dBFT payload handling: dbft is inactive or not started yet", "hash", cp.Hash())
 		return nil
 	}
+	if c.syncing.Load() {
+		log.Debug("Skip dBFT payload handling due to sync", "hash", cp.Hash())
+		return nil
+	}
 
 	p := payloadFromMessage(cp)
 	// decode payload data into message

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -276,7 +276,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	var (
 		bft                 *dbft.DBFT
 		onPayload           func(*dbftproto.Message) error
-		isExtensibleAllowed func(uint64, common.Address) bool
+		isExtensibleAllowed func(uint64, common.Address) error
 	)
 	switch t := eth.engine.(type) {
 	case *dbft.DBFT:

--- a/eth/protocols/dbft/handler.go
+++ b/eth/protocols/dbft/handler.go
@@ -34,6 +34,10 @@ const (
 	maxMessageSize = 4 * 1024 * 1024
 )
 
+// ErrSyncing is returned when operation can't be performed due to the fact that
+// the node is in the process of chain sync.
+var ErrSyncing = errors.New("node is syncing")
+
 var (
 	errMsgTooLarge    = errors.New("message too long")
 	errDecode         = errors.New("invalid message")

--- a/eth/protocols/dbft/ledger.go
+++ b/eth/protocols/dbft/ledger.go
@@ -10,10 +10,10 @@ import (
 
 type ledger struct {
 	bc                  BlockChainAPI
-	isExtensibleAllowed func(height uint64, addr common.Address) bool
+	isExtensibleAllowed func(height uint64, addr common.Address) error
 }
 
-func newLedger(bc BlockChainAPI, isExtensibleAllowed func(uint64, common.Address) bool) *ledger {
+func newLedger(bc BlockChainAPI, isExtensibleAllowed func(uint64, common.Address) error) *ledger {
 	return &ledger{
 		bc:                  bc,
 		isExtensibleAllowed: isExtensibleAllowed,
@@ -24,6 +24,6 @@ func (l *ledger) BlockHeight() uint64 {
 	return uint64(l.bc.BlockNumber())
 }
 
-func (l *ledger) IsAddressAllowed(addr common.Address) bool {
+func (l *ledger) IsAddressAllowed(addr common.Address) error {
 	return l.isExtensibleAllowed(l.BlockHeight(), addr)
 }

--- a/eth/protocols/dbft/pool.go
+++ b/eth/protocols/dbft/pool.go
@@ -14,7 +14,7 @@ import (
 // Ledger is enough of Blockchain to satisfy Pool.
 type Ledger interface {
 	BlockHeight() uint64
-	IsAddressAllowed(common.Address) bool
+	IsAddressAllowed(common.Address) error
 }
 
 // Pool represents a pool of extensible payloads.
@@ -90,8 +90,13 @@ func (p *Pool) verify(m *Message) (bool, error) {
 		}
 		return false, errInvalidHeight
 	}
-	if !p.chain.IsAddressAllowed(m.Sender) {
-		return false, errDisallowedSender
+	err = p.chain.IsAddressAllowed(m.Sender)
+	if err != nil {
+		// There's no reliable way to check sender for syncing node.
+		if errors.Is(err, ErrSyncing) {
+			return false, nil
+		}
+		return false, err
 	}
 	return true, nil
 }
@@ -120,7 +125,7 @@ func (p *Pool) RemoveStale(index uint64) {
 			old := elem
 			elem = elem.Next()
 
-			if m.ValidBlockEnd <= index || !p.chain.IsAddressAllowed(m.Sender) {
+			if m.ValidBlockEnd <= index || p.chain.IsAddressAllowed(m.Sender) != nil {
 				delete(p.verified, h)
 				lst.Remove(old)
 				continue

--- a/eth/protocols/dbft/service.go
+++ b/eth/protocols/dbft/service.go
@@ -36,7 +36,7 @@ type Service struct {
 }
 
 // New creates a new instance of [Service].
-func New(bc BlockChainAPI, onPayload func(*Message) error, isExtensibleAllowed func(uint64, common.Address) bool) *Service {
+func New(bc BlockChainAPI, onPayload func(*Message) error, isExtensibleAllowed func(uint64, common.Address) error) *Service {
 	poolLedger := newLedger(bc, isExtensibleAllowed)
 	return &Service{
 		bc:        bc,


### PR DESCRIPTION
Close #296.

Testnet sync passes as expected, without unwanted peers disconnections for both dBFT-enabled and dBFT-disabled nodes. There are still a couple of "Can't validate payload" messages in the start of the node functioning, but it happens because Downloader does not start its work immediately after the node start.

<details>
  <summary>T4 CN sync logs</summary>

```
anna@kiwi:~/Documents/GitProjects/bane-labs/go-ethereum$ cat nodes_t4/node1/node.log 
INFO [08-15|16:40:09.959] Enabling metrics collection
INFO [08-15|16:40:09.959] Enabling stand-alone metrics HTTP endpoint address=0.0.0.0:6060
INFO [08-15|16:40:09.959] Starting metrics server                  addr=http://0.0.0.0:6060/debug/metrics
INFO [08-15|16:40:09.959] Maximum peer count                       ETH=30 total=30
INFO [08-15|16:40:09.960] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [08-15|16:40:09.962] Enabling recording of key preimages since archive mode is used
WARN [08-15|16:40:09.962] Disabled transaction unindexing for archive node
INFO [08-15|16:40:09.962] Set global gas cap                       cap=50,000,000
INFO [08-15|16:40:09.963] Initializing the KZG library             backend=gokzg
INFO [08-15|16:40:09.990] Allocated trie memory caches             clean=307.00MiB dirty=0.00B
INFO [08-15|16:40:09.990] Using pebble as the backing database
INFO [08-15|16:40:09.990] Allocated cache and file handles         database=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/nodes_t4/node1/geth/chaindata cache=512.00MiB handles=524,288
INFO [08-15|16:40:10.002] Opened ancient database                  database=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/nodes_t4/node1/geth/chaindata/ancient/chain readonly=false
INFO [08-15|16:40:10.002] State scheme set to already existing     scheme=hash
INFO [08-15|16:40:10.005] Initialising Ethereum protocol           network=12,227,332 dbversion=<nil>
INFO [08-15|16:40:10.007] 
INFO [08-15|16:40:10.007] ---------------------------------------------------------------------------------------------------------------------------------------------------------
INFO [08-15|16:40:10.007] Chain ID:  12227332 (unknown)
INFO [08-15|16:40:10.007] Consensus: dBFT (proof-of-authority)
INFO [08-15|16:40:10.007] 
INFO [08-15|16:40:10.008] Pre-Merge hard forks (block based):
INFO [08-15|16:40:10.008]  - Homestead:                   #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/homestead.md)
INFO [08-15|16:40:10.008]  - Tangerine Whistle (EIP 150): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/tangerine-whistle.md)
INFO [08-15|16:40:10.008]  - Spurious Dragon/1 (EIP 155): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md)
INFO [08-15|16:40:10.008]  - Spurious Dragon/2 (EIP 158): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md)
INFO [08-15|16:40:10.008]  - Byzantium:                   #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/byzantium.md)
INFO [08-15|16:40:10.008]  - Constantinople:              #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/constantinople.md)
INFO [08-15|16:40:10.008]  - Petersburg:                  #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/petersburg.md)
INFO [08-15|16:40:10.008]  - Istanbul:                    #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/istanbul.md)
INFO [08-15|16:40:10.008]  - Muir Glacier:                #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/muir-glacier.md)
INFO [08-15|16:40:10.008]  - Berlin:                      #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/berlin.md)
INFO [08-15|16:40:10.008]  - London:                      #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/london.md)
INFO [08-15|16:40:10.008]  - Arrow Glacier:               #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/arrow-glacier.md)
INFO [08-15|16:40:10.008]  - Gray Glacier:                #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/gray-glacier.md)
INFO [08-15|16:40:10.008] 
INFO [08-15|16:40:10.008] The Merge is not yet available for this network!
INFO [08-15|16:40:10.008]  - Hard-fork specification: https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/paris.md
INFO [08-15|16:40:10.008] 
INFO [08-15|16:40:10.008] Post-Merge hard forks (timestamp based):
INFO [08-15|16:40:10.008]  - Shanghai:                    @0          (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md)
INFO [08-15|16:40:10.008]  - NeoXBurn:                      @0         
INFO [08-15|16:40:10.008] 
INFO [08-15|16:40:10.008] ---------------------------------------------------------------------------------------------------------------------------------------------------------
INFO [08-15|16:40:10.008] 
INFO [08-15|16:40:10.009] Loaded most recent local block           number=0 hash=221f7d..9beb71 td=1 age=55y5mo13h
WARN [08-15|16:40:10.009] Failed to load snapshot                  err="missing or corrupted snapshot"
INFO [08-15|16:40:10.014] Rebuilding state snapshot
INFO [08-15|16:40:10.016] Initialized transaction indexer          range="entire chain"
INFO [08-15|16:40:10.016] Resuming state snapshot generation       root=db2f7e..24e8e9 accounts=0 slots=0 storage=0.00B dangling=0 elapsed=1.763ms
INFO [08-15|16:40:10.024] Generated state snapshot                 accounts=26 slots=70 storage=7.82KiB dangling=0 elapsed=9.975ms
INFO [08-15|16:40:10.062] Gasprice oracle is ignoring threshold set threshold=2
WARN [08-15|16:40:10.063] Engine API enabled                       protocol=eth
WARN [08-15|16:40:10.063] Engine API started but chain not configured for merge yet
INFO [08-15|16:40:10.063] Starting peer-to-peer node               instance=Geth/NSPCC/v0.2.2-unstable-5019c602-20240815/linux-amd64/go1.22.0
INFO [08-15|16:40:10.070] New local node record                    seq=1,723,729,210,068 id=567fac340defe1e6 ip=127.0.0.1 udp=30401 tcp=30401
INFO [08-15|16:40:10.070] Started P2P networking                   self=enode://b310eda4e92dbb2435527e5914e327e8969f0e296cb3007e6c6a415fd3f319681de8c0dc784ab0b9921203587de6a28da84c7f01819a7a3cf2cf4695eaecfc1b@127.0.0.1:30401
INFO [08-15|16:40:10.071] IPC endpoint opened                      url=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/nodes_t4/node1/geth.ipc
INFO [08-15|16:40:10.072] Generated JWT secret                     path=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/nodes_t4/node1/geth/jwtsecret
INFO [08-15|16:40:10.072] HTTP server started                      endpoint=127.0.0.1:8646 auth=false prefix= cors= vhosts=localhost
INFO [08-15|16:40:10.072] WebSocket enabled                        url=ws://127.0.0.1:8762
INFO [08-15|16:40:10.072] HTTP server started                      endpoint=127.0.0.1:8762 auth=true  prefix= cors=localhost vhosts=localhost
INFO [08-15|16:40:10.738] Unlocked account                         address=0x1f719A429B431b9645083F15C3f0d2149fa4A29a
INFO [08-15|16:40:10.738] Legacy pool tip threshold updated        tip=0
INFO [08-15|16:40:10.738] Legacy pool tip threshold updated        tip=1,000,000,000
INFO [08-15|16:40:10.738] Initializing BFT consensus               account=0x1f719A429B431b9645083F15C3f0d2149fa4A29a
INFO [08-15|16:40:10.738] Fetching latest sealing proposal         "desired number"=1
INFO [08-15|16:40:10.738] Commit new sealing work                  number=1 sealhash=5187de..988fa7 "parent hash"=221f7d..9beb71 etherbase=0x1212000000000000000000000000000000000003 txs=0 gas=0 fees=0 elapsed="204.261µs"
INFO [08-15|16:40:11.738] Sealing proposal updated                 number=1 sealhash=5187de..988fa7 "parent hash"=221f7d..9beb71 txs=0
INFO [08-15|16:40:11.738] Starting dBFT engine                     "last height"=0 "last timestamp"=0
2024-08-15T16:40:11.740+0300	INFO	dbft@v0.2.0/dbft.go:107	initializing dbft	{"height": 1, "view": 0, "index": -1, "role": "WatchOnly"}
INFO [08-15|16:40:11.740] dBFT event loop started
INFO [08-15|16:40:12.315] New local node record                    seq=1,723,729,210,069 id=567fac340defe1e6 ip=172.30.218.222 udp=30401 tcp=30401
INFO [08-15|16:40:12.712] NAT mapped port                          proto=TCP extport=30401 intport=30401 interface="UPNP IGDv1-IP1"
INFO [08-15|16:40:13.325] NAT mapped alternative port              proto=UDP extport=54095 intport=30401 interface="UPNP IGDv1-IP1"
INFO [08-15|16:40:13.412] New local node record                    seq=1,723,729,210,070 id=567fac340defe1e6 ip=172.30.218.222 udp=54095 tcp=30401
INFO [08-15|16:40:15.008] Can't validate payload                   hash=b19a79..919cc1 err="message sender is not a validator: expected 0x4Ea2A4697D40247C8Be1F2B9ffa03a0E92DCbACC, got 0x77c6a598E577a507288b14D6Aa976776F519B974"
INFO [08-15|16:40:15.008] Can't validate payload                   hash=b19a79..919cc1 err="message sender is not a validator: expected 0x4Ea2A4697D40247C8Be1F2B9ffa03a0E92DCbACC, got 0x77c6a598E577a507288b14D6Aa976776F519B974"
INFO [08-15|16:40:15.009] Can't validate payload                   hash=984935..1fedea err="message sender is not a validator: expected 0xa2617Fcd447e2932857696c707055F517bBdB2eA, got 0x7dE5b7c69b344bb4e75A39442594753AB1C67078"
INFO [08-15|16:40:15.009] Can't validate payload                   hash=984935..1fedea err="message sender is not a validator: expected 0xa2617Fcd447e2932857696c707055F517bBdB2eA, got 0x7dE5b7c69b344bb4e75A39442594753AB1C67078"
INFO [08-15|16:40:15.010] Can't validate payload                   hash=9113bd..10fa2a err="message sender is not a validator: expected 0x0Fa7E10abC3b4c9DC768f0fA0a043fEb987e2177, got 0x05f1167317c9274FEc85D557c0aDb57f318a3A54"
INFO [08-15|16:40:15.013] Can't validate payload                   hash=e71dbf..330bcd err="message sender is not a validator: expected 0xa51fE05B0183D01607bf48C1718D1168a1c11171, got 0x84a32405966791d077811d4E9f21B43b1E7dd911"
INFO [08-15|16:40:15.013] Can't validate payload                   hash=9113bd..10fa2a err="message sender is not a validator: expected 0x0Fa7E10abC3b4c9DC768f0fA0a043fEb987e2177, got 0x05f1167317c9274FEc85D557c0aDb57f318a3A54"
INFO [08-15|16:40:15.013] Can't validate payload                   hash=b19a79..919cc1 err="message sender is not a validator: expected 0x4Ea2A4697D40247C8Be1F2B9ffa03a0E92DCbACC, got 0x77c6a598E577a507288b14D6Aa976776F519B974"
INFO [08-15|16:40:15.014] Can't validate payload                   hash=e71dbf..330bcd err="message sender is not a validator: expected 0xa51fE05B0183D01607bf48C1718D1168a1c11171, got 0x84a32405966791d077811d4E9f21B43b1E7dd911"
INFO [08-15|16:40:15.015] Can't validate payload                   hash=984935..1fedea err="message sender is not a validator: expected 0xa2617Fcd447e2932857696c707055F517bBdB2eA, got 0x7dE5b7c69b344bb4e75A39442594753AB1C67078"
INFO [08-15|16:40:15.016] Can't validate payload                   hash=9113bd..10fa2a err="message sender is not a validator: expected 0x0Fa7E10abC3b4c9DC768f0fA0a043fEb987e2177, got 0x05f1167317c9274FEc85D557c0aDb57f318a3A54"
INFO [08-15|16:40:15.016] Can't validate payload                   hash=e71dbf..330bcd err="message sender is not a validator: expected 0xa51fE05B0183D01607bf48C1718D1168a1c11171, got 0x84a32405966791d077811d4E9f21B43b1E7dd911"
INFO [08-15|16:40:15.019] Can't validate payload                   hash=ba7f0b..b25ad2 err="message sender is not a validator: expected 0xcBBECa26e89011E32BA25610520B20741b809007, got 0xaea4D663A7a67849056c72E5F1612F67c5f3BC55"
INFO [08-15|16:40:15.022] Can't validate payload                   hash=ba7f0b..b25ad2 err="message sender is not a validator: expected 0xcBBECa26e89011E32BA25610520B20741b809007, got 0xaea4D663A7a67849056c72E5F1612F67c5f3BC55"
INFO [08-15|16:40:15.024] Can't validate payload                   hash=d46740..8f33dc err="message sender is not a validator: expected 0xcBBECa26e89011E32BA25610520B20741b809007, got 0xaea4D663A7a67849056c72E5F1612F67c5f3BC55"
INFO [08-15|16:40:15.030] Can't validate payload                   hash=d46740..8f33dc err="message sender is not a validator: expected 0xcBBECa26e89011E32BA25610520B20741b809007, got 0xaea4D663A7a67849056c72E5F1612F67c5f3BC55"
INFO [08-15|16:40:15.030] Can't validate payload                   hash=ba7f0b..b25ad2 err="message sender is not a validator: expected 0xcBBECa26e89011E32BA25610520B20741b809007, got 0xaea4D663A7a67849056c72E5F1612F67c5f3BC55"
INFO [08-15|16:40:15.031] Can't validate payload                   hash=d46740..8f33dc err="message sender is not a validator: expected 0xcBBECa26e89011E32BA25610520B20741b809007, got 0xaea4D663A7a67849056c72E5F1612F67c5f3BC55"
INFO [08-15|16:40:15.107] Can't validate payload                   hash=a8512c..e599ab err="message sender is not a validator: expected 0xD10f47396dc6c76aD53546158751582D3E2683ef, got 0xd7831Da24B63a0B16423Fb178E6Fb6799b82D2b0"
INFO [08-15|16:40:15.108] Can't validate payload                   hash=a8512c..e599ab err="message sender is not a validator: expected 0xD10f47396dc6c76aD53546158751582D3E2683ef, got 0xd7831Da24B63a0B16423Fb178E6Fb6799b82D2b0"
INFO [08-15|16:40:15.111] Can't validate payload                   hash=a8512c..e599ab err="message sender is not a validator: expected 0xD10f47396dc6c76aD53546158751582D3E2683ef, got 0xd7831Da24B63a0B16423Fb178E6Fb6799b82D2b0"
INFO [08-15|16:40:20.108] Looking for peers                        peercount=0 tried=153 static=0
INFO [08-15|16:40:27.949] Block synchronisation started
INFO [08-15|16:40:27.949] Mining aborted due to sync
INFO [08-15|16:40:30.141] Looking for peers                        peercount=1 tried=98  static=0
INFO [08-15|16:40:31.920] Imported new chain segment               number=192 hash=bc602d..d7576a blocks=192 txs=0 mgas=0.000 elapsed=452.517ms   mgasps=0.000 age=1mo5d1h   triedirty=0.00B
INFO [08-15|16:40:31.920] Skipping dBFT block callback due to sync "block index"=192 "dbft index"=1
INFO [08-15|16:40:31.922] Indexed transactions                     blocks=193 txs=0 tail=0 elapsed=1.935ms
INFO [08-15|16:40:32.775] Imported new chain segment               number=576 hash=dd5e23..a7344c blocks=384 txs=0 mgas=0.000 elapsed=851.538ms   mgasps=0.000 age=1mo5d22m  triedirty=0.00B
INFO [08-15|16:40:32.776] Skipping dBFT block callback due to sync "block index"=576 "dbft index"=1
INFO [08-15|16:40:34.668] Imported new chain segment               number=1728 hash=394b08..4ad143 blocks=1152 txs=0 mgas=0.000 elapsed=1.872s      mgasps=0.000 age=1mo4d20h  triedirty=0.00B
INFO [08-15|16:40:34.668] Skipping dBFT block callback due to sync "block index"=1728 "dbft index"=1
INFO [08-15|16:40:39.410] Imported new chain segment               number=3776 hash=043445..1000c4 blocks=2048 txs=0 mgas=0.000 elapsed=4.732s      mgasps=0.000 age=1mo4d14h  triedirty=0.00B
INFO [08-15|16:40:39.410] Skipping dBFT block callback due to sync "block index"=3776 "dbft index"=1
INFO [08-15|16:40:40.711] Looking for peers                        peercount=1 tried=89  static=0
INFO [08-15|16:40:43.629] Imported new chain segment               number=5824 hash=84ab98..42a040 blocks=2048 txs=0 mgas=0.000 elapsed=4.197s      mgasps=0.000 age=1mo4d8h   triedirty=0.00B
INFO [08-15|16:40:43.629] Skipping dBFT block callback due to sync "block index"=5824 "dbft index"=1
INFO [08-15|16:40:47.724] Imported new chain segment               number=7872 hash=cc0e84..fe2d8b blocks=2048 txs=0 mgas=0.000 elapsed=4.071s      mgasps=0.000 age=1mo4d2h   triedirty=0.00B
INFO [08-15|16:40:47.725] Skipping dBFT block callback due to sync "block index"=7872 "dbft index"=1
INFO [08-15|16:40:51.964] Imported new chain segment               number=9920 hash=a220f4..e97c6e blocks=2048 txs=0 mgas=0.000 elapsed=4.215s      mgasps=0.000 age=1mo3d19h  triedirty=0.00B
INFO [08-15|16:40:51.964] Skipping dBFT block callback due to sync "block index"=9920 "dbft index"=1
INFO [08-15|16:40:56.356] Imported new chain segment               number=11968 hash=88c624..ec1a5a blocks=2048 txs=0 mgas=0.000 elapsed=4.368s      mgasps=0.000 age=1mo3d13h  triedirty=0.00B
INFO [08-15|16:40:56.357] Skipping dBFT block callback due to sync "block index"=11968 "dbft index"=1
INFO [08-15|16:41:00.713] Imported new chain segment               number=14016 hash=6297ec..7cf8c5 blocks=2048 txs=0 mgas=0.000 elapsed=4.324s      mgasps=0.000 age=1mo3d7h   triedirty=0.00B
INFO [08-15|16:41:00.713] Skipping dBFT block callback due to sync "block index"=14016 "dbft index"=1
INFO [08-15|16:41:05.514] Imported new chain segment               number=16064 hash=92981e..97a5bd blocks=2048 txs=0 mgas=0.000 elapsed=4.782s      mgasps=0.000 age=1mo3d56m  triedirty=0.00B
INFO [08-15|16:41:05.514] Skipping dBFT block callback due to sync "block index"=16064 "dbft index"=1
INFO [08-15|16:41:10.273] Imported new chain segment               number=18112 hash=f56dbd..b92385 blocks=2048 txs=0 mgas=0.000 elapsed=4.726s      mgasps=0.000 age=1mo2d18h  triedirty=0.00B
INFO [08-15|16:41:10.273] Skipping dBFT block callback due to sync "block index"=18112 "dbft index"=1
INFO [08-15|16:41:14.768] Imported new chain segment               number=20160 hash=c0c2c1..f4880e blocks=2048 txs=0 mgas=0.000 elapsed=4.459s      mgasps=0.000 age=1mo2d12h  triedirty=0.00B
INFO [08-15|16:41:14.768] Skipping dBFT block callback due to sync "block index"=20160 "dbft index"=1
INFO [08-15|16:41:18.874] Imported new chain segment               number=22208 hash=7dfbaf..a13de4 blocks=2048 txs=0 mgas=0.000 elapsed=4.081s      mgasps=0.000 age=1mo2d6h   triedirty=0.00B
INFO [08-15|16:41:18.874] Skipping dBFT block callback due to sync "block index"=22208 "dbft index"=1
INFO [08-15|16:41:23.399] Imported new chain segment               number=24256 hash=db4f87..ef8e83 blocks=2048 txs=0 mgas=0.000 elapsed=4.498s      mgasps=0.000 age=1mo1d23h  triedirty=0.00B
INFO [08-15|16:41:23.399] Skipping dBFT block callback due to sync "block index"=24256 "dbft index"=1
INFO [08-15|16:41:28.238] Imported new chain segment               number=26304 hash=b4b55b..53da1e blocks=2048 txs=0 mgas=0.000 elapsed=4.813s      mgasps=0.000 age=1mo1d17h  triedirty=0.00B
INFO [08-15|16:41:28.238] Skipping dBFT block callback due to sync "block index"=26304 "dbft index"=1
INFO [08-15|16:41:32.557] Imported new chain segment               number=28352 hash=f1a733..dabb12 blocks=2048 txs=0 mgas=0.000 elapsed=4.293s      mgasps=0.000 age=1mo1d11h  triedirty=0.00B
INFO [08-15|16:41:32.557] Skipping dBFT block callback due to sync "block index"=28352 "dbft index"=1
INFO [08-15|16:41:36.709] Imported new chain segment               number=30400 hash=d0af2c..391711 blocks=2048 txs=2 mgas=0.101 elapsed=4.131s      mgasps=0.024 age=1mo1d5h   snapdiffs=1.77KiB triedirty=0.00B
INFO [08-15|16:41:36.709] Skipping dBFT block callback due to sync "block index"=30400 "dbft index"=1
INFO [08-15|16:41:41.372] Imported new chain segment               number=32448 hash=d9456a..c7f181 blocks=2048 txs=13 mgas=1.221 elapsed=4.642s      mgasps=0.263 age=1mo22h45m snapdiffs=13.75KiB triedirty=0.00B
INFO [08-15|16:41:41.372] Skipping dBFT block callback due to sync "block index"=32448 "dbft index"=1
INFO [08-15|16:41:45.493] Imported new chain segment               number=34496 hash=90fe27..68a73d blocks=2048 txs=13 mgas=8.758 elapsed=4.098s      mgasps=2.137 age=1mo16h28m snapdiffs=25.27KiB triedirty=0.00B
INFO [08-15|16:41:45.494] Skipping dBFT block callback due to sync "block index"=34496 "dbft index"=1
INFO [08-15|16:41:50.149] Imported new chain segment               number=36544 hash=61d41f..b089d6 blocks=2048 txs=21 mgas=1.730 elapsed=4.621s      mgasps=0.374 age=1mo10h12m snapdiffs=43.01KiB triedirty=0.00B
INFO [08-15|16:41:50.149] Skipping dBFT block callback due to sync "block index"=36544 "dbft index"=1
INFO [08-15|16:41:55.462] Imported new chain segment               number=38592 hash=fee3e6..ea3d3c blocks=2048 txs=115 mgas=82.619 elapsed=5.283s      mgasps=15.638 age=1mo3h56m  snapdiffs=154.81KiB triedirty=0.00B
INFO [08-15|16:41:55.462] Skipping dBFT block callback due to sync "block index"=38592 "dbft index"=1
INFO [08-15|16:42:00.170] Imported new chain segment               number=40640 hash=365fb1..ed888d blocks=2048 txs=26  mgas=20.667 elapsed=4.671s      mgasps=4.424  age=4w1d21h   snapdiffs=180.82KiB triedirty=0.00B
INFO [08-15|16:42:00.170] Skipping dBFT block callback due to sync "block index"=40640 "dbft index"=1
INFO [08-15|16:42:04.813] Imported new chain segment               number=42688 hash=7d87a6..92d724 blocks=2048 txs=0   mgas=0.000  elapsed=4.619s      mgasps=0.000  age=4w1d15h   snapdiffs=180.82KiB triedirty=0.00B
INFO [08-15|16:42:04.814] Skipping dBFT block callback due to sync "block index"=42688 "dbft index"=1
INFO [08-15|16:42:09.365] Imported new chain segment               number=44736 hash=2b3244..52fa3a blocks=2048 txs=9   mgas=1.056  elapsed=4.523s      mgasps=0.233  age=4w1d9h    snapdiffs=189.98KiB triedirty=0.00B
INFO [08-15|16:42:09.365] Skipping dBFT block callback due to sync "block index"=44736 "dbft index"=1
INFO [08-15|16:42:14.603] Imported new chain segment               number=46784 hash=72aeba..d607d2 blocks=2048 txs=14  mgas=1.322  elapsed=5.223s      mgasps=0.253  age=4w1d2h    snapdiffs=203.49KiB triedirty=0.00B
INFO [08-15|16:42:14.604] Skipping dBFT block callback due to sync "block index"=46784 "dbft index"=1

...

```  

</details>
<details>
  <summary>T4 seed sync logs</summary>

```
anna@kiwi:~/Documents/GitProjects/bane-labs/go-ethereum$ cat nodes_t4/node1/node.log 
INFO [08-15|16:46:38.951] Enabling metrics collection
INFO [08-15|16:46:38.951] Enabling stand-alone metrics HTTP endpoint address=0.0.0.0:6060
INFO [08-15|16:46:38.951] Starting metrics server                  addr=http://0.0.0.0:6060/debug/metrics
INFO [08-15|16:46:38.951] Maximum peer count                       ETH=30 total=30
INFO [08-15|16:46:38.953] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [08-15|16:46:38.955] Enabling recording of key preimages since archive mode is used
WARN [08-15|16:46:38.955] Disabled transaction unindexing for archive node
INFO [08-15|16:46:38.955] Set global gas cap                       cap=50,000,000
INFO [08-15|16:46:38.955] Initializing the KZG library             backend=gokzg
INFO [08-15|16:46:38.983] Allocated trie memory caches             clean=307.00MiB dirty=0.00B
INFO [08-15|16:46:38.983] Using pebble as the backing database
INFO [08-15|16:46:38.983] Allocated cache and file handles         database=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/nodes_t4/node1/geth/chaindata cache=512.00MiB handles=524,288
INFO [08-15|16:46:39.051] Opened ancient database                  database=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/nodes_t4/node1/geth/chaindata/ancient/chain readonly=false
INFO [08-15|16:46:39.052] State scheme set to already existing     scheme=hash
INFO [08-15|16:46:39.055] Initialising Ethereum protocol           network=12,227,332 dbversion=<nil>
INFO [08-15|16:46:39.058] 
INFO [08-15|16:46:39.058] ---------------------------------------------------------------------------------------------------------------------------------------------------------
INFO [08-15|16:46:39.059] Chain ID:  12227332 (unknown)
INFO [08-15|16:46:39.059] Consensus: dBFT (proof-of-authority)
INFO [08-15|16:46:39.059] 
INFO [08-15|16:46:39.059] Pre-Merge hard forks (block based):
INFO [08-15|16:46:39.059]  - Homestead:                   #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/homestead.md)
INFO [08-15|16:46:39.059]  - Tangerine Whistle (EIP 150): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/tangerine-whistle.md)
INFO [08-15|16:46:39.059]  - Spurious Dragon/1 (EIP 155): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md)
INFO [08-15|16:46:39.059]  - Spurious Dragon/2 (EIP 158): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md)
INFO [08-15|16:46:39.059]  - Byzantium:                   #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/byzantium.md)
INFO [08-15|16:46:39.059]  - Constantinople:              #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/constantinople.md)
INFO [08-15|16:46:39.059]  - Petersburg:                  #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/petersburg.md)
INFO [08-15|16:46:39.059]  - Istanbul:                    #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/istanbul.md)
INFO [08-15|16:46:39.059]  - Muir Glacier:                #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/muir-glacier.md)
INFO [08-15|16:46:39.059]  - Berlin:                      #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/berlin.md)
INFO [08-15|16:46:39.059]  - London:                      #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/london.md)
INFO [08-15|16:46:39.059]  - Arrow Glacier:               #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/arrow-glacier.md)
INFO [08-15|16:46:39.059]  - Gray Glacier:                #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/gray-glacier.md)
INFO [08-15|16:46:39.059] 
INFO [08-15|16:46:39.059] The Merge is not yet available for this network!
INFO [08-15|16:46:39.059]  - Hard-fork specification: https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/paris.md
INFO [08-15|16:46:39.059] 
INFO [08-15|16:46:39.059] Post-Merge hard forks (timestamp based):
INFO [08-15|16:46:39.059]  - Shanghai:                    @0          (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md)
INFO [08-15|16:46:39.059]  - NeoXBurn:                      @0         
INFO [08-15|16:46:39.059] 
INFO [08-15|16:46:39.059] ---------------------------------------------------------------------------------------------------------------------------------------------------------
INFO [08-15|16:46:39.059] 
INFO [08-15|16:46:39.060] Loaded most recent local block           number=0 hash=221f7d..9beb71 td=1 age=55y5mo13h
WARN [08-15|16:46:39.061] Failed to load snapshot                  err="missing or corrupted snapshot"
INFO [08-15|16:46:39.065] Rebuilding state snapshot
INFO [08-15|16:46:39.066] Initialized transaction indexer          range="entire chain"
INFO [08-15|16:46:39.067] Resuming state snapshot generation       root=db2f7e..24e8e9 accounts=0 slots=0 storage=0.00B dangling=0 elapsed=1.857ms
INFO [08-15|16:46:39.073] Generated state snapshot                 accounts=26 slots=70 storage=7.82KiB dangling=0 elapsed=8.845ms
INFO [08-15|16:46:39.134] Gasprice oracle is ignoring threshold set threshold=2
WARN [08-15|16:46:39.135] Engine API enabled                       protocol=eth
WARN [08-15|16:46:39.135] Engine API started but chain not configured for merge yet
INFO [08-15|16:46:39.135] Starting peer-to-peer node               instance=Geth/NSPCC/v0.2.2-unstable-5019c602-20240815/linux-amd64/go1.22.0
INFO [08-15|16:46:39.143] New local node record                    seq=1,723,729,599,142 id=855451a06f2eca14 ip=127.0.0.1 udp=30401 tcp=30401
INFO [08-15|16:46:39.144] Started P2P networking                   self=enode://e31bf03139ca2358cac1e86a731e2f66cd1a4fc16bdeb92fdb49bf40f0777ff7582fc3034a413a37b9a22dd4132f5cb9c5d12bc067d5391dd325f8f8747598f3@127.0.0.1:30401
INFO [08-15|16:46:39.146] IPC endpoint opened                      url=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/nodes_t4/node1/geth.ipc
INFO [08-15|16:46:39.147] Generated JWT secret                     path=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/nodes_t4/node1/geth/jwtsecret
INFO [08-15|16:46:39.148] HTTP server started                      endpoint=127.0.0.1:8646 auth=false prefix= cors= vhosts=localhost
INFO [08-15|16:46:39.148] WebSocket enabled                        url=ws://127.0.0.1:8762
INFO [08-15|16:46:39.149] HTTP server started                      endpoint=127.0.0.1:8762 auth=true  prefix= cors=localhost vhosts=localhost
INFO [08-15|16:46:39.812] Unlocked account                         address=0x1f719A429B431b9645083F15C3f0d2149fa4A29a
INFO [08-15|16:46:41.417] New local node record                    seq=1,723,729,599,143 id=855451a06f2eca14 ip=172.30.218.222 udp=30401 tcp=30401
INFO [08-15|16:46:41.790] NAT mapped port                          proto=TCP extport=30401 intport=30401 interface="UPNP IGDv1-IP1"
INFO [08-15|16:46:42.407] NAT mapped alternative port              proto=UDP extport=57432 intport=30401 interface="UPNP IGDv1-IP1"
INFO [08-15|16:46:42.417] New local node record                    seq=1,723,729,599,144 id=855451a06f2eca14 ip=172.30.218.222 udp=57432 tcp=30401
INFO [08-15|16:46:49.284] Looking for peers                        peercount=0 tried=112 static=0
INFO [08-15|16:46:59.351] Looking for peers                        peercount=0 tried=141 static=0
INFO [08-15|16:47:09.437] Looking for peers                        peercount=0 tried=96  static=0
INFO [08-15|16:47:19.528] Looking for peers                        peercount=1 tried=120 static=0
INFO [08-15|16:47:19.787] Block synchronisation started
INFO [08-15|16:47:26.950] Imported new chain segment               number=192 hash=bc602d..d7576a blocks=192 txs=0 mgas=0.000 elapsed=492.705ms mgasps=0.000 age=1mo5d2h   triedirty=0.00B
INFO [08-15|16:47:26.955] Indexed transactions                     blocks=193 txs=0 tail=0 elapsed=4.351ms
INFO [08-15|16:47:27.327] Imported new chain segment               number=384 hash=1e4539..113514 blocks=192 txs=0 mgas=0.000 elapsed=370.786ms mgasps=0.000 age=1mo5d1h   triedirty=0.00B
INFO [08-15|16:47:28.181] Imported new chain segment               number=768 hash=3799fd..bc5e6a blocks=384 txs=0 mgas=0.000 elapsed=849.140ms mgasps=0.000 age=1mo4d23h  triedirty=0.00B
INFO [08-15|16:47:29.353] Imported new chain segment               number=1344 hash=61fc77..03c945 blocks=576 txs=0 mgas=0.000 elapsed=1.156s    mgasps=0.000 age=1mo4d22h  triedirty=0.00B
INFO [08-15|16:47:29.660] Looking for peers                        peercount=1 tried=102 static=0
INFO [08-15|16:47:30.996] Imported new chain segment               number=2112 hash=686b3c..dfd426 blocks=768 txs=0 mgas=0.000 elapsed=1.637s    mgasps=0.000 age=1mo4d19h  triedirty=0.00B
INFO [08-15|16:47:33.511] Imported new chain segment               number=3264 hash=5903d8..c0edd0 blocks=1152 txs=0 mgas=0.000 elapsed=2.506s    mgasps=0.000 age=1mo4d16h  triedirty=0.00B
INFO [08-15|16:47:37.344] Imported new chain segment               number=4992 hash=66d7f6..14d37e blocks=1728 txs=0 mgas=0.000 elapsed=3.816s    mgasps=0.000 age=1mo4d10h  triedirty=0.00B
INFO [08-15|16:47:39.707] Looking for peers                        peercount=2 tried=134 static=0
INFO [08-15|16:47:42.113] Imported new chain segment               number=7040 hash=929c28..3f5fba blocks=2048 txs=0 mgas=0.000 elapsed=4.751s    mgasps=0.000 age=1mo4d4h   triedirty=0.00B
INFO [08-15|16:47:46.354] Imported new chain segment               number=9088 hash=ebc24a..740f44 blocks=2048 txs=0 mgas=0.000 elapsed=4.224s    mgasps=0.000 age=1mo3d22h  triedirty=0.00B
INFO [08-15|16:47:49.785] Looking for peers                        peercount=2 tried=99  static=0
INFO [08-15|16:47:50.984] Imported new chain segment               number=11136 hash=4bf32d..627090 blocks=2048 txs=0 mgas=0.000 elapsed=4.612s    mgasps=0.000 age=1mo3d16h  triedirty=0.00B
INFO [08-15|16:47:55.537] Imported new chain segment               number=13184 hash=08f982..9a71db blocks=2048 txs=0 mgas=0.000 elapsed=4.530s    mgasps=0.000 age=1mo3d9h   triedirty=0.00B

...

=0.00B
INFO [08-15|16:58:45.367] Imported new chain segment               number=269,644 hash=8d8b73..aa6526 blocks=460  txs=1    mgas=0.052   elapsed=561.262ms mgasps=0.093  snapdiffs=312.56KiB triedirty=0.00B
INFO [08-15|16:58:47.565] Imported new chain segment               number=269,646 hash=d67913..aa348a blocks=2    txs=0    mgas=0.000   elapsed=31.600ms  mgasps=0.000  snapdiffs=312.56KiB triedirty=0.00B
INFO [08-15|16:59:05.126] Chain reorg detected                     number=269,645 hash=6e4e70..69029d drop=1 dropfrom=d67913..aa348a add=2 addfrom=0d6b45..fabb50
INFO [08-15|16:59:05.129] Imported new chain segment               number=269,648 hash=15728b..9da533 blocks=3    txs=0    mgas=0.000   elapsed=11.668ms  mgasps=0.000  snapdiffs=312.56KiB triedirty=0.00B ignored=1
INFO [08-15|16:59:15.082] Imported new chain segment               number=269,649 hash=72720e..7e81da blocks=1    txs=1    mgas=0.052   elapsed=16.127ms  mgasps=3.248  snapdiffs=312.96KiB triedirty=0.00B
INFO [08-15|16:59:24.317] Imported new chain segment               number=269,650 hash=7fc7dc..aa14e9 blocks=1    txs=0    mgas=0.000   elapsed=22.588ms  mgasps=0.000  snapdiffs=313.78KiB triedirty=0.00B
INFO [08-15|16:59:24.480] Imported new chain segment               number=269,650 hash=9a72cc..a7f6e1 blocks=1    txs=0    mgas=0.000   elapsed=17.024ms  mgasps=0.000  snapdiffs=313.78KiB triedirty=0.00B
INFO [08-15|16:59:34.890] Imported new chain segment               number=269,651 hash=224471..22474d blocks=1    txs=0    mgas=0.000   elapsed=12.997ms  mgasps=0.000  snapdiffs=313.78KiB triedirty=0.00B
INFO [08-15|16:59:46.455] Imported new chain segment               number=269,652 hash=566b83..8a4d9e blocks=1    txs=1    mgas=0.062   elapsed=17.716ms  mgasps=3.517  snapdiffs=314.27KiB triedirty=0.00B
INFO [08-15|16:59:46.647] Imported new chain segment               number=269,652 hash=854526..b1c58b blocks=1    txs=1    mgas=0.062   elapsed=18.393ms  mgasps=3.387  snapdiffs=314.27KiB triedirty=0.00B
INFO [08-15|16:59:47.551] Imported new chain segment               number=269,652 hash=32e607..9b2ea5 blocks=1    txs=1    mgas=0.062   elapsed=13.687ms  mgasps=4.552  snapdiffs=314.27KiB triedirty=0.00B
INFO [08-15|16:59:56.805] Imported new chain segment               number=269,653 hash=87ed1e..9049dc blocks=1    txs=1    mgas=0.055   elapsed=21.648ms  mgasps=2.548  snapdiffs=315.37KiB triedirty=0.00B
INFO [08-15|16:59:56.871] Imported new chain segment               number=269,653 hash=7bb27f..157216 blocks=1    txs=1    mgas=0.055   elapsed=10.052ms  mgasps=5.486  snapdiffs=315.37KiB triedirty=0.00B
INFO [08-15|17:00:08.160] Imported new chain segment               number=269,654 hash=697996..14337d blocks=1    txs=0    mgas=0.000   elapsed=15.806ms  mgasps=0.000  snapdiffs=316.19KiB triedirty=0.00B
INFO [08-15|17:00:19.640] Imported new chain segment               number=269,655 hash=56a047..dde44c blocks=1    txs=0    mgas=0.000   elapsed=13.412ms  mgasps=0.000  snapdiffs=316.19KiB triedirty=0.00B
```  

</details>

Mainnet sync is also OK, but mainnet nodes don't have this problem because mainnet is still driven by StandBy validators.

<details>
  <summary>Mainnet CN sync log</summary>
  
```
anna@kiwi:~/Documents/GitProjects/bane-labs/go-ethereum$ cat ./nodes_mainnet/node1/node.log 
INFO [08-15|17:22:48.454] Enabling metrics collection
INFO [08-15|17:22:48.454] Enabling stand-alone metrics HTTP endpoint address=0.0.0.0:6060
INFO [08-15|17:22:48.454] Starting metrics server                  addr=http://0.0.0.0:6060/debug/metrics
INFO [08-15|17:22:49.026] Maximum peer count                       ETH=30 total=30
INFO [08-15|17:22:49.033] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [08-15|17:22:49.043] Enabling recording of key preimages since archive mode is used
WARN [08-15|17:22:49.044] Disabled transaction unindexing for archive node
INFO [08-15|17:22:49.045] Set global gas cap                       cap=50,000,000
INFO [08-15|17:22:49.046] Initializing the KZG library             backend=gokzg
INFO [08-15|17:22:49.086] Allocated trie memory caches             clean=307.00MiB dirty=0.00B
INFO [08-15|17:22:49.086] Using pebble as the backing database
INFO [08-15|17:22:49.086] Allocated cache and file handles         database=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/nodes_mainnet/node1/geth/chaindata cache=512.00MiB handles=524,288
INFO [08-15|17:22:49.111] Opened ancient database                  database=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/nodes_mainnet/node1/geth/chaindata/ancient/chain readonly=false
INFO [08-15|17:22:49.111] State scheme set to already existing     scheme=hash
INFO [08-15|17:22:49.114] Initialising Ethereum protocol           network=47763 dbversion=<nil>
INFO [08-15|17:22:49.116] 
INFO [08-15|17:22:49.116] ---------------------------------------------------------------------------------------------------------------------------------------------------------
INFO [08-15|17:22:49.116] Chain ID:  47763 (unknown)
INFO [08-15|17:22:49.116] Consensus: dBFT (proof-of-authority)
INFO [08-15|17:22:49.116] 
INFO [08-15|17:22:49.117] Pre-Merge hard forks (block based):
INFO [08-15|17:22:49.117]  - Homestead:                   #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/homestead.md)
INFO [08-15|17:22:49.117]  - Tangerine Whistle (EIP 150): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/tangerine-whistle.md)
INFO [08-15|17:22:49.117]  - Spurious Dragon/1 (EIP 155): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md)
INFO [08-15|17:22:49.117]  - Spurious Dragon/2 (EIP 158): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md)
INFO [08-15|17:22:49.117]  - Byzantium:                   #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/byzantium.md)
INFO [08-15|17:22:49.117]  - Constantinople:              #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/constantinople.md)
INFO [08-15|17:22:49.117]  - Petersburg:                  #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/petersburg.md)
INFO [08-15|17:22:49.117]  - Istanbul:                    #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/istanbul.md)
INFO [08-15|17:22:49.117]  - Muir Glacier:                #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/muir-glacier.md)
INFO [08-15|17:22:49.117]  - Berlin:                      #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/berlin.md)
INFO [08-15|17:22:49.117]  - London:                      #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/london.md)
INFO [08-15|17:22:49.117]  - Arrow Glacier:               #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/arrow-glacier.md)
INFO [08-15|17:22:49.117]  - Gray Glacier:                #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/gray-glacier.md)
INFO [08-15|17:22:49.117] 
INFO [08-15|17:22:49.117] The Merge is not yet available for this network!
INFO [08-15|17:22:49.117]  - Hard-fork specification: https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/paris.md
INFO [08-15|17:22:49.117] 
INFO [08-15|17:22:49.117] Post-Merge hard forks (timestamp based):
INFO [08-15|17:22:49.117]  - Shanghai:                    @0          (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md)
INFO [08-15|17:22:49.117]  - NeoXBurn:                      @0         
INFO [08-15|17:22:49.117] 
INFO [08-15|17:22:49.117] ---------------------------------------------------------------------------------------------------------------------------------------------------------
INFO [08-15|17:22:49.117] 
INFO [08-15|17:22:49.118] Loaded most recent local block           number=0 hash=2ee574..d8dbd7 td=1 age=55y5mo14h
WARN [08-15|17:22:49.118] Failed to load snapshot                  err="missing or corrupted snapshot"
INFO [08-15|17:22:49.123] Rebuilding state snapshot
INFO [08-15|17:22:49.124] Initialized transaction indexer          range="entire chain"
INFO [08-15|17:22:49.124] Resuming state snapshot generation       root=92a17d..2ccd9c accounts=0 slots=0 storage=0.00B dangling=0 elapsed=1.701ms
INFO [08-15|17:22:49.132] Generated state snapshot                 accounts=26 slots=75 storage=8.34KiB dangling=0 elapsed=8.942ms
INFO [08-15|17:22:49.199] Gasprice oracle is ignoring threshold set threshold=2
WARN [08-15|17:22:49.204] Engine API enabled                       protocol=eth
WARN [08-15|17:22:49.204] Engine API started but chain not configured for merge yet
INFO [08-15|17:22:49.204] Starting peer-to-peer node               instance=Geth/NSPCC/v0.2.2-unstable-5019c602-20240815/linux-amd64/go1.22.0
INFO [08-15|17:22:49.214] New local node record                    seq=1,723,731,769,211 id=74c73b57ea97d341 ip=127.0.0.1 udp=30301 tcp=30301
INFO [08-15|17:22:49.214] Started P2P networking                   self=enode://f040a2990c720f705103eef5a6b2ab8462d720b7e3f651851ae01f65558067ade718ebc729a30f99cb548da017d609aa7aa9531f86c46e241cc211a08aef2c9b@127.0.0.1:30301
INFO [08-15|17:22:49.217] IPC endpoint opened                      url=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/nodes_mainnet/node1/geth.ipc
INFO [08-15|17:22:49.218] Generated JWT secret                     path=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/nodes_mainnet/node1/geth/jwtsecret
INFO [08-15|17:22:49.218] HTTP server started                      endpoint=127.0.0.1:8546 auth=false prefix= cors= vhosts=localhost
INFO [08-15|17:22:49.218] WebSocket enabled                        url=ws://127.0.0.1:8562
INFO [08-15|17:22:49.219] HTTP server started                      endpoint=127.0.0.1:8562 auth=true  prefix= cors=localhost vhosts=localhost
INFO [08-15|17:22:49.894] Unlocked account                         address=0x1f719A429B431b9645083F15C3f0d2149fa4A29a
INFO [08-15|17:22:49.894] Legacy pool tip threshold updated        tip=0
INFO [08-15|17:22:49.894] Legacy pool tip threshold updated        tip=1,000,000,000
INFO [08-15|17:22:49.894] Initializing BFT consensus               account=0x1f719A429B431b9645083F15C3f0d2149fa4A29a
INFO [08-15|17:22:49.894] Fetching latest sealing proposal         "desired number"=1
INFO [08-15|17:22:49.894] Commit new sealing work                  number=1 sealhash=dd7cab..7e4f34 "parent hash"=2ee574..d8dbd7 etherbase=0x1212000000000000000000000000000000000003 txs=0 gas=0 fees=0 elapsed="208.685µs"
INFO [08-15|17:22:50.496] New local node record                    seq=1,723,731,769,212 id=74c73b57ea97d341 ip=91.204.150.32 udp=30301 tcp=30301
INFO [08-15|17:22:50.895] Sealing proposal updated                 number=1 sealhash=dd7cab..7e4f34 "parent hash"=2ee574..d8dbd7 txs=0
INFO [08-15|17:22:50.895] Starting dBFT engine                     "last height"=0 "last timestamp"=0
2024-08-15T17:22:50.896+0300	INFO	dbft@v0.2.0/dbft.go:107	initializing dbft	{"height": 1, "view": 0, "index": -1, "role": "WatchOnly"}
INFO [08-15|17:22:50.896] dBFT event loop started
INFO [08-15|17:22:51.652] NAT mapped port                          proto=TCP extport=30301 intport=30301 interface="UPNP IGDv1-IP1"
INFO [08-15|17:22:52.190] New local node record                    seq=1,723,731,769,213 id=74c73b57ea97d341 ip=172.30.218.222 udp=30301 tcp=30301
INFO [08-15|17:22:52.267] NAT mapped port                          proto=TCP extport=30301 intport=30301 interface="UPNP IGDv1-IP1"
INFO [08-15|17:22:52.881] NAT mapped alternative port              proto=UDP extport=37895 intport=30301 interface="UPNP IGDv1-IP1"
INFO [08-15|17:22:53.249] New local node record                    seq=1,723,731,769,214 id=74c73b57ea97d341 ip=172.30.218.222 udp=37895 tcp=30301
2024-08-15T17:22:56.110+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "PrepareRequest", "from": 1, "height": 151908, "view": 0, "my_height": 1, "my_view": 0}
2024-08-15T17:22:56.110+0300	DEBUG	dbft@v0.2.0/dbft.go:229	caching message from future	{"height": 151908, "view": 0, "cache": null}
2024-08-15T17:22:56.140+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "PrepareResponse", "from": 3, "height": 151908, "view": 0, "my_height": 1, "my_view": 0}
2024-08-15T17:22:56.140+0300	DEBUG	dbft@v0.2.0/dbft.go:229	caching message from future	{"height": 151908, "view": 0, "cache": {}}
2024-08-15T17:22:56.504+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "PrepareResponse", "from": 4, "height": 151908, "view": 0, "my_height": 1, "my_view": 0}
2024-08-15T17:22:56.504+0300	DEBUG	dbft@v0.2.0/dbft.go:229	caching message from future	{"height": 151908, "view": 0, "cache": {}}
2024-08-15T17:22:56.659+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "PrepareResponse", "from": 5, "height": 151908, "view": 0, "my_height": 1, "my_view": 0}
2024-08-15T17:22:56.659+0300	DEBUG	dbft@v0.2.0/dbft.go:229	caching message from future	{"height": 151908, "view": 0, "cache": {}}
2024-08-15T17:22:56.667+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "PrepareResponse", "from": 2, "height": 151908, "view": 0, "my_height": 1, "my_view": 0}
2024-08-15T17:22:56.668+0300	DEBUG	dbft@v0.2.0/dbft.go:229	caching message from future	{"height": 151908, "view": 0, "cache": {}}
2024-08-15T17:22:56.668+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "PrepareResponse", "from": 6, "height": 151908, "view": 0, "my_height": 1, "my_view": 0}
2024-08-15T17:22:56.668+0300	DEBUG	dbft@v0.2.0/dbft.go:229	caching message from future	{"height": 151908, "view": 0, "cache": {}}
2024-08-15T17:22:56.669+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "Commit", "from": 1, "height": 151908, "view": 0, "my_height": 1, "my_view": 0}
2024-08-15T17:22:56.669+0300	DEBUG	dbft@v0.2.0/dbft.go:229	caching message from future	{"height": 151908, "view": 0, "cache": {}}
2024-08-15T17:22:56.686+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "Commit", "from": 5, "height": 151908, "view": 0, "my_height": 1, "my_view": 0}
2024-08-15T17:22:56.686+0300	DEBUG	dbft@v0.2.0/dbft.go:229	caching message from future	{"height": 151908, "view": 0, "cache": {}}
2024-08-15T17:22:56.694+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "Commit", "from": 2, "height": 151908, "view": 0, "my_height": 1, "my_view": 0}
2024-08-15T17:22:56.694+0300	DEBUG	dbft@v0.2.0/dbft.go:229	caching message from future	{"height": 151908, "view": 0, "cache": {}}
2024-08-15T17:22:56.694+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "Commit", "from": 6, "height": 151908, "view": 0, "my_height": 1, "my_view": 0}
2024-08-15T17:22:56.694+0300	DEBUG	dbft@v0.2.0/dbft.go:229	caching message from future	{"height": 151908, "view": 0, "cache": {}}
2024-08-15T17:22:56.697+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "Commit", "from": 3, "height": 151908, "view": 0, "my_height": 1, "my_view": 0}
2024-08-15T17:22:56.697+0300	DEBUG	dbft@v0.2.0/dbft.go:229	caching message from future	{"height": 151908, "view": 0, "cache": {}}
2024-08-15T17:22:56.896+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "Commit", "from": 4, "height": 151908, "view": 0, "my_height": 1, "my_view": 0}
2024-08-15T17:22:56.896+0300	DEBUG	dbft@v0.2.0/dbft.go:229	caching message from future	{"height": 151908, "view": 0, "cache": {}}
2024-08-15T17:22:56.933+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "PrepareResponse", "from": 0, "height": 151908, "view": 0, "my_height": 1, "my_view": 0}
2024-08-15T17:22:56.934+0300	DEBUG	dbft@v0.2.0/dbft.go:229	caching message from future	{"height": 151908, "view": 0, "cache": {}}
2024-08-15T17:22:56.935+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "Commit", "from": 0, "height": 151908, "view": 0, "my_height": 1, "my_view": 0}
2024-08-15T17:22:56.935+0300	DEBUG	dbft@v0.2.0/dbft.go:229	caching message from future	{"height": 151908, "view": 0, "cache": {}}
2024-08-15T17:22:57.049+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "PrepareResponse", "from": 0, "height": 151908, "view": 0, "my_height": 1, "my_view": 0}
2024-08-15T17:22:57.049+0300	DEBUG	dbft@v0.2.0/dbft.go:229	caching message from future	{"height": 151908, "view": 0, "cache": {}}
2024-08-15T17:22:57.049+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "Commit", "from": 0, "height": 151908, "view": 0, "my_height": 1, "my_view": 0}
2024-08-15T17:22:57.049+0300	DEBUG	dbft@v0.2.0/dbft.go:229	caching message from future	{"height": 151908, "view": 0, "cache": {}}
INFO [08-15|17:22:59.220] Block synchronisation started
INFO [08-15|17:22:59.220] Mining aborted due to sync
INFO [08-15|17:22:59.872] Imported new chain segment               number=192 hash=e4ea81..27a671 blocks=192 txs=0 mgas=0.000 elapsed=382.149ms   mgasps=0.000 age=3w1d5m    triedirty=0.00B
INFO [08-15|17:22:59.872] Skipping dBFT block callback due to sync "block index"=192 "dbft index"=1
INFO [08-15|17:22:59.875] Indexed transactions                     blocks=193 txs=0 tail=0 elapsed=2.445ms
INFO [08-15|17:23:00.449] Looking for peers                        peercount=2 tried=51 static=0
INFO [08-15|17:23:04.861] Imported new chain segment               number=2240 hash=067423..32c6f0 blocks=2048 txs=0 mgas=0.000 elapsed=4.470s      mgasps=0.000 age=3w14h39m  triedirty=0.00B
INFO [08-15|17:23:04.862] Skipping dBFT block callback due to sync "block index"=2240 "dbft index"=1
INFO [08-15|17:23:09.545] Imported new chain segment               number=4288 hash=dedad9..9d3ad4 blocks=2048 txs=11 mgas=0.684 elapsed=4.659s      mgasps=0.147 age=3w8h13m   snapdiffs=8.46KiB triedirty=0.00B
INFO [08-15|17:23:09.545] Skipping dBFT block callback due to sync "block index"=4288 "dbft index"=1
INFO [08-15|17:23:10.465] Looking for peers                        peercount=2 tried=155 static=0
INFO [08-15|17:23:14.176] Imported new chain segment               number=6336 hash=8af70a..36a6a4 blocks=2048 txs=14 mgas=1.925 elapsed=4.591s      mgasps=0.419 age=3w1h48m   snapdiffs=21.73KiB triedirty=0.00B
INFO [08-15|17:23:14.176] Skipping dBFT block callback due to sync "block index"=6336 "dbft index"=1
INFO [08-15|17:23:18.929] Imported new chain segment               number=8384 hash=3baa77..b4ae56 blocks=2048 txs=81 mgas=49.748 elapsed=4.733s      mgasps=10.511 age=2w6d19h   snapdiffs=104.79KiB triedirty=0.00B

...

INFO [08-15|17:29:29.341] Skipping dBFT block callback due to sync "block index"=147,648 "dbft index"=1
INFO [08-15|17:29:34.748] Imported new chain segment               number=149,696 hash=6ffb1b..79729e blocks=2048 txs=23  mgas=1.181  elapsed=5.396s      mgasps=0.219  age=6h57m49s  snapdiffs=1.57MiB    triedirty=0.00B
INFO [08-15|17:29:34.748] Skipping dBFT block callback due to sync "block index"=149,696 "dbft index"=1
INFO [08-15|17:29:38.897] Looking for peers                        peercount=2 tried=59  static=0
INFO [08-15|17:29:39.635] Imported new chain segment               number=151,744 hash=8f6b90..eeba84 blocks=2048 txs=59  mgas=14.107 elapsed=4.851s      mgasps=2.908  age=37m25s    snapdiffs=1.61MiB    triedirty=0.00B
INFO [08-15|17:29:39.636] Skipping dBFT block callback due to sync "block index"=151,744 "dbft index"=1
INFO [08-15|17:29:40.179] Imported new chain segment               number=151,942 hash=b215fa..d82a60 blocks=198  txs=17  mgas=1.198  elapsed=540.122ms   mgasps=2.217  snapdiffs=1.63MiB    triedirty=0.00B
INFO [08-15|17:29:40.179] Skipping dBFT block callback due to sync "block index"=151,942 "dbft index"=1
INFO [08-15|17:29:41.942] Imported new chain segment               number=151,944 hash=734d9b..f4e19f blocks=2    txs=0   mgas=0.000  elapsed=40.738ms    mgasps=0.000  snapdiffs=1.63MiB    triedirty=0.00B
INFO [08-15|17:29:41.943] New block in the chain                   "dbft index"=1 "chain index"=151,944 hash=0x734d9b086f6f3ed7c9d3e9df1311e4905afbf351c754785743ab9ae6c0f4e19f "parent hash"=0x3e2b7a52ecae80901ffb0afccafd8e42eca133420fd17b95f79102cb4d6dfe2f primary=2 coinbase=0x1212000000000000000000000000000000000003 "mix digest"=0xeb59c093e3a02bfa4e0d4677d4769022cd9399bbc8b93ad1e892acd6a08aa533
INFO [08-15|17:29:41.943] Fetching latest sealing proposal         "desired number"=151,945
INFO [08-15|17:29:41.944] Commit new sealing work                  number=151,945 sealhash=bc2cf3..860ccb "parent hash"=734d9b..f4e19f etherbase=0x1212000000000000000000000000000000000003 txs=0   gas=0 fees=0 elapsed=1.160ms
INFO [08-15|17:29:41.945] Commit new sealing work                  number=151,945 sealhash=bc2cf3..860ccb "parent hash"=734d9b..f4e19f etherbase=0x1212000000000000000000000000000000000003 txs=0   gas=0 fees=0 elapsed="818.71µs"
INFO [08-15|17:29:42.944] Sealing proposal updated                 number=151,945 sealhash=bc2cf3..860ccb "parent hash"=734d9b..f4e19f txs=0
2024-08-15T17:29:42.945+0300	INFO	dbft@v0.2.0/dbft.go:107	initializing dbft	{"height": 151945, "view": 0, "index": -1, "role": "WatchOnly"}
2024-08-15T17:29:48.527+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "PrepareRequest", "from": 3, "height": 151945, "view": 0, "my_height": 151945, "my_view": 0}
2024-08-15T17:29:48.527+0300	DEBUG	dbft@v0.2.0/dbft.go:322	received empty PrepareRequest
2024-08-15T17:29:48.527+0300	INFO	dbft@v0.2.0/dbft.go:329	received PrepareRequest	{"validator": 3, "tx": 0}
2024-08-15T17:29:48.528+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "PrepareResponse", "from": 1, "height": 151945, "view": 0, "my_height": 151945, "my_view": 0}
2024-08-15T17:29:48.528+0300	INFO	dbft@v0.2.0/dbft.go:424	received PrepareResponse	{"validator": 1}
2024-08-15T17:29:48.913+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "PrepareResponse", "from": 4, "height": 151945, "view": 0, "my_height": 151945, "my_view": 0}
2024-08-15T17:29:48.913+0300	INFO	dbft@v0.2.0/dbft.go:424	received PrepareResponse	{"validator": 4}
2024-08-15T17:29:49.069+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "PrepareResponse", "from": 5, "height": 151945, "view": 0, "my_height": 151945, "my_view": 0}
2024-08-15T17:29:49.069+0300	INFO	dbft@v0.2.0/dbft.go:424	received PrepareResponse	{"validator": 5}
2024-08-15T17:29:49.079+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "PrepareResponse", "from": 6, "height": 151945, "view": 0, "my_height": 151945, "my_view": 0}
2024-08-15T17:29:49.079+0300	INFO	dbft@v0.2.0/dbft.go:424	received PrepareResponse	{"validator": 6}
2024-08-15T17:29:49.080+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "PrepareResponse", "from": 2, "height": 151945, "view": 0, "my_height": 151945, "my_view": 0}
2024-08-15T17:29:49.080+0300	INFO	dbft@v0.2.0/dbft.go:424	received PrepareResponse	{"validator": 2}
2024-08-15T17:29:49.080+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "Commit", "from": 5, "height": 151945, "view": 0, "my_height": 151945, "my_view": 0}
2024-08-15T17:29:49.080+0300	INFO	dbft@v0.2.0/dbft.go:498	received Commit	{"validator": 5}
2024-08-15T17:29:49.081+0300	DEBUG	dbft@v0.2.0/check.go:56	not enough to commit	{"count": 1}
2024-08-15T17:29:49.081+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "Commit", "from": 2, "height": 151945, "view": 0, "my_height": 151945, "my_view": 0}
2024-08-15T17:29:49.081+0300	INFO	dbft@v0.2.0/dbft.go:498	received Commit	{"validator": 2}
2024-08-15T17:29:49.081+0300	DEBUG	dbft@v0.2.0/check.go:56	not enough to commit	{"count": 2}
2024-08-15T17:29:49.081+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "Commit", "from": 6, "height": 151945, "view": 0, "my_height": 151945, "my_view": 0}
2024-08-15T17:29:49.082+0300	INFO	dbft@v0.2.0/dbft.go:498	received Commit	{"validator": 6}
2024-08-15T17:29:49.082+0300	DEBUG	dbft@v0.2.0/check.go:56	not enough to commit	{"count": 3}
2024-08-15T17:29:49.083+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "Commit", "from": 1, "height": 151945, "view": 0, "my_height": 151945, "my_view": 0}
2024-08-15T17:29:49.083+0300	INFO	dbft@v0.2.0/dbft.go:498	received Commit	{"validator": 1}
2024-08-15T17:29:49.084+0300	DEBUG	dbft@v0.2.0/check.go:56	not enough to commit	{"count": 4}
2024-08-15T17:29:49.111+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "Commit", "from": 3, "height": 151945, "view": 0, "my_height": 151945, "my_view": 0}
2024-08-15T17:29:49.111+0300	INFO	dbft@v0.2.0/dbft.go:498	received Commit	{"validator": 3}
2024-08-15T17:29:49.111+0300	INFO	dbft@v0.2.0/check.go:65	approving block	{"height": 151945, "hash": "0x0b5879700c014155181e31c88de941015deb68a746743d4d890305642d849ccd", "tx_count": 0, "merkle": "0x75517337dd136721c2106fe1c18ad9dd127d2689880a2ab15e0b8b351426dbc9", "prev": "0x734d9b086f6f3ed7c9d3e9df1311e4905afbf351c754785743ab9ae6c0f4e19f"}
INFO [08-15|17:29:49.533] Looking for peers                        peercount=2 tried=32  static=0
INFO [08-15|17:29:49.670] Successfully wrote new block with state  number=151,945 hash=251e6d..acd0ba
INFO [08-15|17:29:49.670] New block in the chain                   "dbft index"=151,945 "chain index"=151,945 hash=0x251e6d0694f109dba88be507fa15b4199504f7cd7b35cf9b2f8fcda574acd0ba "parent hash"=0x734d9b086f6f3ed7c9d3e9df1311e4905afbf351c754785743ab9ae6c0f4e19f primary=3 coinbase=0x1212000000000000000000000000000000000003 "mix digest"=0xeb59c093e3a02bfa4e0d4677d4769022cd9399bbc8b93ad1e892acd6a08aa533
INFO [08-15|17:29:49.670] Fetching latest sealing proposal         "desired number"=151,946
INFO [08-15|17:29:49.671] Commit new sealing work                  number=151,946 sealhash=d13382..6bacf6 "parent hash"=251e6d..acd0ba etherbase=0x1212000000000000000000000000000000000003 txs=0   gas=0 fees=0 elapsed="634.373µs"
INFO [08-15|17:29:50.031] Imported new chain segment               number=151,945 hash=d9fe78..b9dc8c blocks=1    txs=0   mgas=0.000  elapsed=4.856ms     mgasps=0.000  snapdiffs=1.63MiB    triedirty=0.00B
INFO [08-15|17:29:50.671] Sealing proposal updated                 number=151,946 sealhash=d13382..6bacf6 "parent hash"=251e6d..acd0ba txs=0
2024-08-15T17:29:50.673+0300	INFO	dbft@v0.2.0/dbft.go:107	initializing dbft	{"height": 151946, "view": 0, "index": -1, "role": "WatchOnly"}
2024-08-15T17:29:50.673+0300	DEBUG	dbft@v0.2.0/dbft.go:214	received message	{"type": "PrepareResponse", "from": 0, "height": 151945, "view": 0, "my_height": 151946, "my_view": 0}
2024-08-15T17:29:50.673+0300	DEBUG	dbft@v0.2.0/dbft.go:223	ignoring old height	{"height": 151945}
```
  
</details>

<details>
  <summary>Mainnet seed sync logs</summary>

```
anna@kiwi:~/Documents/GitProjects/bane-labs/go-ethereum$ cat ./nodes_mainnet/node1/node.log 
INFO [08-15|18:05:17.729] Enabling metrics collection
INFO [08-15|18:05:17.729] Enabling stand-alone metrics HTTP endpoint address=0.0.0.0:6060
INFO [08-15|18:05:17.729] Starting metrics server                  addr=http://0.0.0.0:6060/debug/metrics
INFO [08-15|18:05:18.351] Maximum peer count                       ETH=30 total=30
INFO [08-15|18:05:18.358] Smartcard socket not found, disabling    err="stat /run/pcscd/pcscd.comm: no such file or directory"
INFO [08-15|18:05:18.367] Enabling recording of key preimages since archive mode is used
WARN [08-15|18:05:18.368] Disabled transaction unindexing for archive node
INFO [08-15|18:05:18.370] Set global gas cap                       cap=50,000,000
INFO [08-15|18:05:18.371] Initializing the KZG library             backend=gokzg
INFO [08-15|18:05:18.413] Allocated trie memory caches             clean=307.00MiB dirty=0.00B
INFO [08-15|18:05:18.413] Using pebble as the backing database
INFO [08-15|18:05:18.413] Allocated cache and file handles         database=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/nodes_mainnet/node1/geth/chaindata cache=512.00MiB handles=524,288
INFO [08-15|18:05:18.432] Opened ancient database                  database=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/nodes_mainnet/node1/geth/chaindata/ancient/chain readonly=false
INFO [08-15|18:05:18.432] State scheme set to already existing     scheme=hash
INFO [08-15|18:05:18.433] Initialising Ethereum protocol           network=47763 dbversion=<nil>
INFO [08-15|18:05:18.434] 
INFO [08-15|18:05:18.434] ---------------------------------------------------------------------------------------------------------------------------------------------------------
INFO [08-15|18:05:18.434] Chain ID:  47763 (unknown)
INFO [08-15|18:05:18.434] Consensus: dBFT (proof-of-authority)
INFO [08-15|18:05:18.434] 
INFO [08-15|18:05:18.434] Pre-Merge hard forks (block based):
INFO [08-15|18:05:18.434]  - Homestead:                   #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/homestead.md)
INFO [08-15|18:05:18.434]  - Tangerine Whistle (EIP 150): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/tangerine-whistle.md)
INFO [08-15|18:05:18.434]  - Spurious Dragon/1 (EIP 155): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md)
INFO [08-15|18:05:18.434]  - Spurious Dragon/2 (EIP 158): #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/spurious-dragon.md)
INFO [08-15|18:05:18.434]  - Byzantium:                   #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/byzantium.md)
INFO [08-15|18:05:18.434]  - Constantinople:              #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/constantinople.md)
INFO [08-15|18:05:18.434]  - Petersburg:                  #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/petersburg.md)
INFO [08-15|18:05:18.434]  - Istanbul:                    #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/istanbul.md)
INFO [08-15|18:05:18.434]  - Muir Glacier:                #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/muir-glacier.md)
INFO [08-15|18:05:18.434]  - Berlin:                      #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/berlin.md)
INFO [08-15|18:05:18.434]  - London:                      #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/london.md)
INFO [08-15|18:05:18.434]  - Arrow Glacier:               #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/arrow-glacier.md)
INFO [08-15|18:05:18.434]  - Gray Glacier:                #0        (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/gray-glacier.md)
INFO [08-15|18:05:18.434] 
INFO [08-15|18:05:18.434] The Merge is not yet available for this network!
INFO [08-15|18:05:18.434]  - Hard-fork specification: https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/paris.md
INFO [08-15|18:05:18.434] 
INFO [08-15|18:05:18.434] Post-Merge hard forks (timestamp based):
INFO [08-15|18:05:18.434]  - Shanghai:                    @0          (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md)
INFO [08-15|18:05:18.434]  - NeoXBurn:                      @0         
INFO [08-15|18:05:18.434] 
INFO [08-15|18:05:18.434] ---------------------------------------------------------------------------------------------------------------------------------------------------------
INFO [08-15|18:05:18.434] 
INFO [08-15|18:05:18.434] Loaded most recent local block           number=0 hash=2ee574..d8dbd7 td=1 age=55y5mo15h
WARN [08-15|18:05:18.434] Failed to load snapshot                  err="missing or corrupted snapshot"
INFO [08-15|18:05:18.437] Rebuilding state snapshot
INFO [08-15|18:05:18.438] Initialized transaction indexer          range="entire chain"
INFO [08-15|18:05:18.438] Resuming state snapshot generation       root=92a17d..2ccd9c accounts=0 slots=0 storage=0.00B dangling=0 elapsed=1.145ms
INFO [08-15|18:05:18.441] Generated state snapshot                 accounts=26 slots=75 storage=8.34KiB dangling=0 elapsed=3.844ms
INFO [08-15|18:05:18.468] Gasprice oracle is ignoring threshold set threshold=2
WARN [08-15|18:05:18.469] Engine API enabled                       protocol=eth
WARN [08-15|18:05:18.469] Engine API started but chain not configured for merge yet
INFO [08-15|18:05:18.469] Starting peer-to-peer node               instance=Geth/NSPCC/v0.2.2-unstable-5019c602-20240815/linux-amd64/go1.22.0
INFO [08-15|18:05:18.476] New local node record                    seq=1,723,734,318,475 id=b06059331a697bf8 ip=127.0.0.1 udp=30301 tcp=30301
INFO [08-15|18:05:18.477] Started P2P networking                   self=enode://bb534da2a4c9b25adea88f9be0f353e3b80d3dbf85ceb40a77f836411f2ce0684075624ba4f22ade80364f8f672bce2cc855a39ecde5bd701d08f9ced008f920@127.0.0.1:30301
INFO [08-15|18:05:18.481] IPC endpoint opened                      url=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/nodes_mainnet/node1/geth.ipc
INFO [08-15|18:05:18.481] Generated JWT secret                     path=/home/anna/Documents/GitProjects/bane-labs/go-ethereum/nodes_mainnet/node1/geth/jwtsecret
INFO [08-15|18:05:18.483] HTTP server started                      endpoint=127.0.0.1:8546 auth=false prefix= cors= vhosts=localhost
INFO [08-15|18:05:18.483] WebSocket enabled                        url=ws://127.0.0.1:8562
INFO [08-15|18:05:18.483] HTTP server started                      endpoint=127.0.0.1:8562 auth=true  prefix= cors=localhost vhosts=localhost
INFO [08-15|18:05:19.161] Unlocked account                         address=0x1f719A429B431b9645083F15C3f0d2149fa4A29a
INFO [08-15|18:05:20.132] New local node record                    seq=1,723,734,318,476 id=b06059331a697bf8 ip=91.204.150.32 udp=30301 tcp=30301
INFO [08-15|18:05:20.716] New local node record                    seq=1,723,734,318,477 id=b06059331a697bf8 ip=172.30.218.222 udp=30301 tcp=30301
INFO [08-15|18:05:21.328] NAT mapped alternative port              proto=UDP extport=62757 intport=30301 interface="UPNP IGDv1-IP1"
INFO [08-15|18:05:21.498] New local node record                    seq=1,723,734,318,478 id=b06059331a697bf8 ip=172.30.218.222 udp=62757 tcp=30301
INFO [08-15|18:05:21.738] NAT mapped port                          proto=TCP extport=30301 intport=30301 interface="UPNP IGDv1-IP1"
INFO [08-15|18:05:28.484] Block synchronisation started
INFO [08-15|18:05:28.553] Looking for peers                        peercount=2 tried=121 static=0
INFO [08-15|18:05:29.185] Imported new chain segment               number=192 hash=e4ea81..27a671 blocks=192 txs=0 mgas=0.000 elapsed=448.662ms mgasps=0.000 age=3w1d48m   triedirty=0.00B
INFO [08-15|18:05:29.187] Indexed transactions                     blocks=193 txs=0 tail=0 elapsed=2.205ms
INFO [08-15|18:05:33.828] Imported new chain segment               number=2240 hash=067423..32c6f0 blocks=2048 txs=0 mgas=0.000 elapsed=4.455s    mgasps=0.000 age=3w15h22m  triedirty=0.00B
INFO [08-15|18:05:38.453] Imported new chain segment               number=4288 hash=dedad9..9d3ad4 blocks=2048 txs=11 mgas=0.684 elapsed=4.613s    mgasps=0.148 age=3w8h56m   snapdiffs=8.46KiB triedirty=0.00B
INFO [08-15|18:05:42.133] Looking for peers                        peercount=2 tried=16  static=0
INFO [08-15|18:05:42.912] Imported new chain segment               number=6336 hash=8af70a..36a6a4 blocks=2048 txs=14 mgas=1.925 elapsed=4.443s    mgasps=0.433 age=3w2h31m   snapdiffs=21.73KiB triedirty=0.00B
INFO [08-15|18:05:47.655] Imported new chain segment               number=8384 hash=3baa77..b4ae56 blocks=2048 txs=81 mgas=49.748 elapsed=4.728s    mgasps=10.522 age=2w6d20h   snapdiffs=104.79KiB triedirty=0.00B
INFO [08-15|18:05:52.160] Looking for peers                        peercount=2 tried=76  static=0
INFO [08-15|18:05:52.681] Imported new chain segment               number=10432 hash=7d7ead..8119c9 blocks=2048 txs=8  mgas=7.194  elapsed=5.001s    mgasps=1.438  age=2w6d13h   snapdiffs=118.17KiB triedirty=0.00B
INFO [08-15|18:05:57.704] Imported new chain segment               number=12480 hash=25c340..3bd205 blocks=2048 txs=32 mgas=19.565 elapsed=4.993s    mgasps=3.918  age=2w6d7h    snapdiffs=147.13KiB triedirty=0.00B
INFO [08-15|18:06:02.211] Imported new chain segment               number=14528 hash=3b0447..dbea9d blocks=2048 txs=36 mgas=16.374 elapsed=4.492s    mgasps=3.645  age=2w6d52m   snapdiffs=178.15KiB triedirty=0.00B
INFO [08-15|18:06:06.855] Imported new chain segment               number=16576 hash=d10d4c..f7c6a3 blocks=2048 txs=23 mgas=10.596 elapsed=4.626s    mgasps=2.290  age=2w5d18h   snapdiffs=203.04KiB triedirty=0.00B
INFO [08-15|18:06:11.483] Imported new chain segment               number=18624 hash=38da2b..47e1ed blocks=2048 txs=0  mgas=0.000  elapsed=4.601s    mgasps=0.000  age=2w5d12h   snapdiffs=203.04KiB triedirty=0.00B
INFO [08-15|18:06:12.474] Looking for peers                        peercount=2 tried=179 static=0
INFO [08-15|18:06:16.038] Imported new chain segment               number=20672 hash=60b70b..a837fc blocks=2048 txs=2  mgas=0.305  elapsed=4.526s    mgasps=0.067  age=2w5d5h    snapdiffs=205.11KiB triedirty=0.00B
INFO [08-15|18:06:20.566] Imported new chain segment               number=22720 hash=391517..58924a blocks=2048 txs=0  mgas=0.000  elapsed=4.510s    mgasps=0.000  age=2w4d23h   snapdiffs=205.11KiB triedirty=0.00B

...

INFO [08-15|18:28:15.766] Looking for peers                        peercount=2 tried=72  static=0
INFO [08-15|18:28:26.093] Looking for peers                        peercount=2 tried=67  static=0
INFO [08-15|18:28:33.591] Chain reorg detected                     number=152,255 hash=374633..b7b812 drop=1 dropfrom=f6e7c5..3d13f0 add=2 addfrom=f049a8..caea61
INFO [08-15|18:28:33.603] Imported new chain segment               number=152,260 hash=c53a01..765713 blocks=5    txs=0   mgas=0.000  elapsed=23.297ms  mgasps=0.000  snapdiffs=1.63MiB    triedirty=0.00B
INFO [08-15|18:28:36.123] Looking for peers                        peercount=2 tried=13  static=0
INFO [08-15|18:28:39.993] Imported new chain segment               number=152,260 hash=a416c9..c21111 blocks=1    txs=0   mgas=0.000  elapsed=13.065ms  mgasps=0.000  snapdiffs=1.63MiB    triedirty=0.00B
INFO [08-15|18:28:39.997] Imported new chain segment               number=152,258 hash=6c2a6b..63bc0d blocks=1    txs=0   mgas=0.000  elapsed=4.020ms   mgasps=0.000  snapdiffs=1.63MiB    triedirty=0.00B
INFO [08-15|18:28:40.253] Chain reorg detected                     number=152,259 hash=beab48..752d62 drop=1 dropfrom=c53a01..765713 add=2 addfrom=09bd48..8f52b8
INFO [08-15|18:28:40.256] Imported new chain segment               number=152,261 hash=09bd48..8f52b8 blocks=1    txs=0   mgas=0.000  elapsed=15.772ms  mgasps=0.000  snapdiffs=1.63MiB    triedirty=0.00B
INFO [08-15|18:28:40.289] Imported new chain segment               number=152,261 hash=8821e7..e71971 blocks=1    txs=0   mgas=0.000  elapsed=4.106ms   mgasps=0.000  snapdiffs=1.63MiB    triedirty=0.00B
INFO [08-15|18:28:46.129] Looking for peers                        peercount=2 tried=36  static=0
INFO [08-15|18:28:51.794] Imported new chain segment               number=152,262 hash=14a6b4..14e180 blocks=1    txs=0   mgas=0.000  elapsed=15.483ms  mgasps=0.000  snapdiffs=1.63MiB    triedirty=0.00B
INFO [08-15|18:28:56.210] Looking for peers                        peercount=2 tried=24  static=0
INFO [08-15|18:29:02.637] Imported new chain segment               number=152,263 hash=c684f6..a96613 blocks=1    txs=0   mgas=0.000  elapsed=6.392ms   mgasps=0.000  snapdiffs=1.63MiB    triedirty=0.00B
INFO [08-15|18:29:03.019] Imported new chain segment               number=152,263 hash=89ffa6..2dc571 blocks=1    txs=0   mgas=0.000  elapsed=13.184ms  mgasps=0.000  snapdiffs=1.63MiB    triedirty=0.00B
INFO [08-15|18:29:07.002] Looking for peers                        peercount=2 tried=48  static=0
INFO [08-15|18:29:13.771] Imported new chain segment               number=152,264 hash=79780b..cda19f blocks=1    txs=0   mgas=0.000  elapsed=15.200ms  mgasps=0.000  snapdiffs=1.63MiB    triedirty=0.00B
INFO [08-15|18:29:17.051] Looking for peers                        peercount=2 tried=124 static=0
```  

</details>

@txhsl, @chenquanyu, @songb2 welcome to review and test.