### PR TITLE
core: add antimev related crypto and keystore

### DIFF
--- a/core/antimev/keygroup.go
+++ b/core/antimev/keygroup.go
@@ -1,0 +1,314 @@
+package antimev
+
+import (
+	"errors"
+	"math/big"
+	"math/rand"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto/ecies"
+	"github.com/ethereum/go-ethereum/crypto/tpke"
+)
+
+var (
+	ErrMessageEncryption    = errors.New("message encryption failed")
+	ErrDKGPVSS              = errors.New("invalid dkg pvss")
+	ErrDKGSecret            = errors.New("invalid dkg secret")
+	ErrNoSecretToReshare    = errors.New("no secret to reshare")
+	ErrInvalidReshare       = errors.New("invalid reshare")
+	ErrInvalidRecover       = errors.New("invalid recover")
+	ErrSecretShareNotEnough = errors.New("secret share not enough")
+)
+
+// thresholdKeyGroup records the process and result of a round of dkg.
+type thresholdKeyGroup struct {
+	holders []*thresholdKeyHolder // Members of this dkg group
+	pvsses  []*tpke.PVSS          // Public verifiable sharing commitments
+
+	selfAddr        common.Address // Self address
+	localSecret     *tpke.Secret   // The local random secret
+	receivedSecrets []*big.Int     // Received secret sharings
+
+	globalPubKey *tpke.PublicKey  // The aggregated global public key
+	localPrvKey  *tpke.PrivateKey // The aggregated local secret key
+}
+
+// thresholdKeyHolder is a message receiver in dkg.
+type thresholdKeyHolder struct {
+	address   common.Address   // The account address
+	ethPubKey *ecies.PublicKey // The account public key
+}
+
+// newThresholdKeyGroup returns a new key group with the input address list.
+func newThresholdKeyGroup(selfAddr common.Address, validators []common.Address, pubkeys []*ecies.PublicKey) *thresholdKeyGroup {
+	size := len(validators)
+	holders := make([]*thresholdKeyHolder, size)
+	for i, validator := range validators {
+		holders[i] = &thresholdKeyHolder{
+			address:   validator,
+			ethPubKey: pubkeys[i],
+		}
+	}
+	return &thresholdKeyGroup{
+		holders:         holders,
+		selfAddr:        selfAddr,
+		pvsses:          make([]*tpke.PVSS, size),
+		receivedSecrets: make([]*big.Int, size),
+	}
+}
+
+// newTemplateForRecover copies and returns a shared key group for recovering.
+func (tkg *thresholdKeyGroup) newTemplateForRecover(indexes []int, validators []common.Address, pubkeys []*ecies.PublicKey) *thresholdKeyGroup {
+	size := len(tkg.holders)
+	holders := make([]*thresholdKeyHolder, size)
+	for i, index := range indexes {
+		holders[index-1] = &thresholdKeyHolder{
+			address:   validators[i],
+			ethPubKey: pubkeys[i],
+		}
+	}
+	// Refer pvss and global key for verification
+	return &thresholdKeyGroup{
+		holders:         holders,
+		selfAddr:        tkg.selfAddr,
+		pvsses:          tkg.pvsses,
+		receivedSecrets: make([]*big.Int, size),
+		globalPubKey:    tkg.globalPubKey,
+	}
+}
+
+// newTemplateForReshare copies and returns a shared key group for resharing.
+func (tkg *thresholdKeyGroup) newTemplateForReshare(validators []common.Address, pubkeys []*ecies.PublicKey) *thresholdKeyGroup {
+	size := len(validators)
+	holders := make([]*thresholdKeyHolder, size)
+	// Use the new holder list
+	for i, validator := range validators {
+		holders[i] = &thresholdKeyHolder{
+			address:   validator,
+			ethPubKey: pubkeys[i],
+		}
+	}
+	// Copy pvss and refer global key for verification
+	pvsses := make([]*tpke.PVSS, size)
+	copy(pvsses, tkg.pvsses)
+	return &thresholdKeyGroup{
+		holders:         holders,
+		selfAddr:        tkg.selfAddr,
+		pvsses:          pvsses,
+		receivedSecrets: make([]*big.Int, size),
+		globalPubKey:    tkg.globalPubKey,
+	}
+}
+
+// dkgPrepare generates local secrets and returns sharing messages.
+// selfIndex is the dkg member index which starts from 1.
+// ethPrvKey is the sender's eth secret key for signing.
+func (tkg *thresholdKeyGroup) dkgPrepare(threshold int) ([][]byte, *tpke.PVSS, error) {
+	// Generate nothing if not a member
+	selfIndex := tkg.holderIndex(tkg.selfAddr)
+	if selfIndex < 1 {
+		return nil, nil, nil
+	}
+	// Generate local secret
+	tkg.localSecret = tpke.RandomSecret(threshold)
+	// Generate and encrypt messages to share the secret
+	return generateShareMessages(tkg.localSecret, selfIndex, tkg.holders)
+}
+
+// dkgAggregate aggregates received secrets and pvss to get global public key and
+// a local piece of secret key for message decryption and signing.
+func (tkg *thresholdKeyGroup) dkgAggregate(scaler int) error {
+	// Compute public key S=sum(A0)
+	scs := make([]*tpke.Commitment, len(tkg.holders))
+	for i, pvss := range tkg.pvsses {
+		if pvss == nil {
+			return ErrSecretShareNotEnough
+		}
+		scs[i] = pvss.GetCommitment()
+	}
+	globalPubKey := tpke.NewGlobalPublicKey(scs, scaler)
+	// Verify the key if this is resharing
+	if tkg.globalPubKey == nil {
+		tkg.globalPubKey = globalPubKey
+	} else {
+		if !tkg.globalPubKey.Equal(globalPubKey) {
+			return ErrInvalidReshare
+		}
+	}
+	// Compute local secret key
+	if tkg.holderIndex(tkg.selfAddr) > 0 {
+		tkg.localPrvKey = tpke.NewPrivateKey(tkg.receivedSecrets)
+	}
+	return nil
+}
+
+// dkgRecover returns received shared secrets with different message encryption.
+func (tkg *thresholdKeyGroup) dkgRecover(secretIndexs []int, receiverEthPubKeys []*ecies.PublicKey) ([][]byte, error) {
+	// Share nothing if not a member
+	selfIndex := tkg.holderIndex(tkg.selfAddr)
+	if selfIndex < 1 {
+		return nil, nil
+	}
+	// Random source for message encryption
+	source := rand.NewSource(time.Now().UnixNano())
+	random := rand.New(source)
+	// Generate message
+	srms := make([][]byte, len(secretIndexs))
+	for i, index := range secretIndexs {
+		arrIndex := index - 1
+		ess, err := ecies.Encrypt(random, receiverEthPubKeys[i], tkg.receivedSecrets[arrIndex].Bytes(), nil, nil)
+		if err != nil {
+			return nil, ErrMessageEncryption
+		}
+		srms[i] = ess
+	}
+
+	return srms, nil
+}
+
+// dkgReshare does almost the same as dkgPrepare, but local secret is reused to
+// produce the same global public key.
+func (tkg *thresholdKeyGroup) dkgReshare(target *thresholdKeyGroup) ([][]byte, *tpke.PVSS, error) {
+	// Share nothing if not a member
+	selfIndex := tkg.holderIndex(tkg.selfAddr)
+	if selfIndex < 1 {
+		return nil, nil, nil
+	}
+	// Check if has a local secret
+	if tkg.localSecret == nil {
+		return nil, nil, ErrNoSecretToReshare
+	}
+	// Generate and encrypt messages to share the secret
+	return generateShareMessages(tkg.localSecret.Renovate(), selfIndex, target.holders)
+}
+
+func (tkg *thresholdKeyGroup) dkgReshareRecovered(threshold int, target *thresholdKeyGroup) ([][]byte, *tpke.PVSS, error) {
+	// Do nothing if not a receiver
+	if tkg.holderIndex(tkg.selfAddr) < 1 {
+		return nil, nil, nil
+	}
+	// Collect all shares
+	is := make([]int, 0)
+	fis := make([]*big.Int, 0)
+	for i, ss := range tkg.receivedSecrets {
+		if ss != nil {
+			is = append(is, i+1)
+			fis = append(fis, ss)
+		}
+	}
+	if len(tkg.receivedSecrets) < threshold {
+		return nil, nil, ErrInvalidRecover
+	}
+	// Recover the secret
+	tkg.localSecret = tpke.RecoverSecret(is[:threshold], fis[:threshold])
+	return tkg.dkgReshare(target)
+}
+
+// generateShareMessages generates secret sharing messages.
+// Secret shares can be decrypted by specific receivers, but pvss is public.
+func generateShareMessages(secret *tpke.Secret, selfIndexIndex int, receivers []*thresholdKeyHolder) ([][]byte, *tpke.PVSS, error) {
+	// Random source for message encryption
+	source := rand.NewSource(time.Now().UnixNano())
+	random := rand.New(source)
+	// Random value for pvss generation
+	randR := randScalar()
+	size := len(receivers)
+	pvss, ss := tpke.GenerateSecretShares(randR, size, secret)
+	// Generate message
+	messages := make([][]byte, size)
+	for i, receiver := range receivers {
+		ess, err := ecies.Encrypt(random, receiver.ethPubKey, ss[i].Bytes(), nil, nil)
+		if err != nil {
+			return nil, nil, ErrMessageEncryption
+		}
+		messages[i] = ess
+	}
+
+	return messages, pvss, nil
+}
+
+// receiveShareMessage verifies received sharing messages. It verifies shared
+// secret if is a member, otherwise only the pvss. Received data will be stored
+// in thresholdKeyGroup for further aggregation.
+func (tkg *thresholdKeyGroup) receiveShareMessage(fromIndex int, ss *big.Int, pvss *tpke.PVSS) error {
+	// Transform dkg index to array index
+	arrIndex := fromIndex - 1
+	// Verify the commitment
+	if !pvss.VerifyCommitment() {
+		return ErrDKGPVSS
+	}
+	// If is a member of receiver
+	if ss != nil {
+		// Verify with pvss
+		if !pvss.VerifySecret(tkg.holderIndex(tkg.selfAddr)-1, ss) {
+			return ErrDKGSecret
+		}
+		// Store ss for local secret key generation
+		tkg.receivedSecrets[arrIndex] = ss
+	}
+	// Store pvss for global public key generation
+	tkg.pvsses[arrIndex] = pvss
+	return nil
+}
+
+// receiveReshareMessage verifies received resharing messages. It verifies shared
+// secret if is a member, otherwise only the pvss. Received data will be stored
+// in thresholdKeyGroup for further aggregation.
+func (tkg *thresholdKeyGroup) receiveReshareMessage(fromIndex int, rs *big.Int, pvss *tpke.PVSS) error {
+	// Transform dkg index to array index
+	arrIndex := fromIndex - 1
+	// Verify the commitment
+	if !pvss.VerifyCommitment() {
+		return ErrDKGPVSS
+	}
+	// Check delta if resharing
+	if tkg.pvsses[arrIndex] != nil && !pvss.VerifyRenovate(tkg.pvsses[arrIndex]) {
+		return ErrDKGPVSS
+	}
+	// If is a member of receiver
+	if rs != nil {
+		// Verify with pvss
+		if !pvss.VerifySecret(tkg.holderIndex(tkg.selfAddr)-1, rs) {
+			return ErrDKGSecret
+		}
+		// Store ss for local secret key generation
+		tkg.receivedSecrets[arrIndex] = rs
+	}
+	// Store pvss for global public key generation
+	tkg.pvsses[arrIndex] = pvss
+	return nil
+}
+
+// receiveRecoverMessage verifies received recovering messages. It verifies shared
+// secret if is a member, with the existing pvss. Received data will be stored
+// in thresholdKeyGroup for further aggregation.
+func (tkg *thresholdKeyGroup) receiveRecoverMessage(fromIndex int, rs *big.Int) error {
+	// Do nothing if not a member
+	selfIndex := tkg.holderIndex(tkg.selfAddr)
+	if selfIndex < 1 {
+		return nil
+	}
+	// Transform dkg index to array index
+	arrIndex := fromIndex - 1
+	// Verify with pvss
+	if !tkg.pvsses[selfIndex-1].VerifySecret(arrIndex, rs) {
+		return ErrDKGSecret
+	}
+	tkg.receivedSecrets[arrIndex] = rs
+
+	return nil
+}
+
+// holderIndex is the dkg member index start from 1, 0 means not a member.
+func (tkg *thresholdKeyGroup) holderIndex(addr common.Address) int {
+	for i, holder := range tkg.holders {
+		if holder == nil {
+			continue
+		}
+		if holder.address.Cmp(addr) == 0 {
+			return i + 1
+		}
+	}
+	return 0
+}

--- a/core/antimev/keystore.go
+++ b/core/antimev/keystore.go
@@ -1,0 +1,233 @@
+package antimev
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto/ecies"
+	"github.com/ethereum/go-ethereum/crypto/tpke"
+)
+
+var (
+	ErrInvalidLength     = errors.New("invalid array length")
+	ErrInvalidThreshold  = errors.New("invalid threshold")
+	ErrNotParticipant    = errors.New("not dkg participant")
+	ErrUnrecoverable     = errors.New("unrecoverable sharing")
+	ErrMessageDecryption = errors.New("message decryption failed")
+)
+
+// AMEVKeyStore is the container of all useful dkg information.
+type AMEVKeyStore struct {
+	size      int // The size of each key group
+	threshold int // The threshold of each key group
+	scaler    int // The scaler to speed up computation, refer to crypto/tpke
+
+	address   common.Address    // Self account address
+	ethPrvKey *ecies.PrivateKey // Self account secret key
+
+	recovering *thresholdKeyGroup // The recovering key group
+	resharing  *thresholdKeyGroup // The resharing key group
+	reshared   *thresholdKeyGroup // The group can decrypt old messages
+	shared     *thresholdKeyGroup // The sharing key group
+	sharing    *thresholdKeyGroup // The group can encrypt and decrypt new messages
+}
+
+// NewKeyStore returns a new instance of antimev key store.
+func NewKeyStore(addr common.Address, prvkey *ecies.PrivateKey, groupSize int, threshold int) (*AMEVKeyStore, error) {
+	// TODO: Recover keystore from persistence
+	if groupSize < threshold {
+		return nil, ErrInvalidThreshold
+	}
+	return &AMEVKeyStore{
+		size:      groupSize,
+		threshold: threshold,
+		scaler:    getScaler(groupSize, threshold),
+		address:   addr,
+		ethPrvKey: prvkey,
+	}, nil
+}
+
+// OnValidatorList initializes sharing and resharing, should be called
+// when the key group members are determined. It returns resharing
+// messages immediately.
+func (ks *AMEVKeyStore) OnValidatorList(validators []common.Address, pubkeys []*ecies.PublicKey) ([][]byte, []byte, error) {
+	if len(validators) != ks.size || len(pubkeys) != ks.size {
+		return nil, nil, ErrInvalidLength
+	}
+	// Set up groups for dkg sharing and resharing
+	if ks.shared != nil {
+		ks.resharing = ks.shared.newTemplateForReshare(validators, pubkeys)
+	}
+	ks.sharing = newThresholdKeyGroup(ks.address, validators, pubkeys)
+	// Generate secret resharing messages and pvss
+	if ks.resharing != nil {
+		rMsgs, pvss, err := ks.shared.dkgReshare(ks.resharing)
+		if err != nil || pvss == nil {
+			return nil, nil, err
+		}
+		return rMsgs, pvss.ToBytes(), nil
+	}
+	// Nothing to reshare
+	return nil, nil, nil
+}
+
+func (ks *AMEVKeyStore) OnRecoverStart(indexes []int, validators []common.Address, pubkeys []*ecies.PublicKey) ([][]byte, error) {
+	if ks.shared == nil {
+		return nil, nil
+	}
+	if len(validators) != len(indexes) || len(pubkeys) != len(indexes) {
+		return nil, ErrInvalidLength
+	}
+	// Return error if amount is more than recoverable
+	if len(indexes) > ks.size-ks.threshold {
+		return nil, ErrUnrecoverable
+	}
+	// Do nothing if no need to recover
+	if len(indexes) < 1 {
+		return nil, nil
+	}
+	// Only place new ones in recovering group
+	ks.recovering = ks.shared.newTemplateForRecover(indexes, validators, pubkeys)
+	// Generate secret recovering messages
+	return ks.shared.dkgRecover(indexes, pubkeys)
+}
+
+// OnRecoverFinish tries to finish ongoing recovering, should be called when
+// resharing fails. It returns resharing messages immediately if recoverd.
+func (ks *AMEVKeyStore) OnRecoverFinish() ([][]byte, []byte, error) {
+	msgs, pvss, err := ks.recovering.dkgReshareRecovered(ks.threshold, ks.resharing)
+	if err != nil || pvss == nil {
+		return nil, nil, err
+	}
+	return msgs, pvss.ToBytes(), nil
+}
+
+// OnReshareFinish tries to finish ongoing resharing, should be called before
+// the new round sharing. It returns sharing messages immediately.
+func (ks *AMEVKeyStore) OnReshareFinish() ([][]byte, []byte, error) {
+	// Check if resharing are finished and aggregate keys
+	if ks.resharing != nil {
+		err := ks.resharing.dkgAggregate(ks.scaler)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	// Generate secret sharing messages and pvss
+	sMsgs, pvss, err := ks.sharing.dkgPrepare(ks.threshold)
+	if err != nil || pvss == nil {
+		return nil, nil, err
+	}
+	return sMsgs, pvss.ToBytes(), nil
+}
+
+// OnEpochChange tries to finish ongoing sharing, should be called before
+// the key group is needed for encryption and signing.
+func (ks *AMEVKeyStore) OnEpochChange() error {
+	// Check if sharing are finished and aggregate keys
+	if ks.sharing != nil {
+		err := ks.sharing.dkgAggregate(ks.scaler)
+		if err != nil {
+			return err
+		}
+	}
+	// Set finished dkg as current using
+	ks.reshared = ks.resharing
+	ks.resharing = nil
+	ks.shared = ks.sharing
+	ks.sharing = nil
+
+	return nil
+}
+
+// ReceiveSecretShare tries to verify a sharing message array and store their data.
+func (ks *AMEVKeyStore) ReceiveSecretShare(from common.Address, ess [][]byte, pvss []byte) error {
+	fromIndex := ks.sharing.holderIndex(from)
+	if fromIndex > ks.size || fromIndex < 1 {
+		return ErrNotParticipant
+	}
+	p, err := new(tpke.PVSS).FromBytes(pvss, ks.size, ks.threshold)
+	if err != nil {
+		return ErrDKGPVSS
+	}
+	// If is a member of receiver
+	selfIndex := ks.sharing.holderIndex(ks.address)
+	if selfIndex > 0 {
+		ss, err := ks.decryptSecretShare(ess[selfIndex-1])
+		if err != nil {
+			return ErrDecryptionFailed
+		}
+		return ks.sharing.receiveShareMessage(fromIndex, ss, p)
+	}
+	return ks.sharing.receiveShareMessage(fromIndex, nil, p)
+}
+
+// ReceiveSecretReshare tries to verify a resharing message array and store their data.
+func (ks *AMEVKeyStore) ReceiveSecretReshare(from common.Address, ers [][]byte, pvss []byte) error {
+	fromIndex := ks.shared.holderIndex(from)
+	if fromIndex > ks.size || fromIndex < 1 {
+		return ErrNotParticipant
+	}
+	p, err := new(tpke.PVSS).FromBytes(pvss, ks.size, ks.threshold)
+	if err != nil {
+		return ErrDKGPVSS
+	}
+	// If is a member of receiver
+	selfIndex := ks.resharing.holderIndex(ks.address)
+	if selfIndex > 0 {
+		ss, err := ks.decryptSecretShare(ers[selfIndex-1])
+		if err != nil {
+			return ErrDecryptionFailed
+		}
+		return ks.resharing.receiveReshareMessage(fromIndex, ss, p)
+	}
+	return ks.resharing.receiveReshareMessage(fromIndex, nil, p)
+}
+
+// ReceiveRecoveredReshare tries to verify a resharing message array and store their data.
+func (ks *AMEVKeyStore) ReceiveRecoveredReshare(from common.Address, ers [][]byte, pvss []byte) error {
+	fromIndex := ks.recovering.holderIndex(from)
+	if fromIndex > ks.size || fromIndex < 1 {
+		return ErrNotParticipant
+	}
+	p, err := new(tpke.PVSS).FromBytes(pvss, ks.size, ks.threshold)
+	if err != nil {
+		return ErrDKGPVSS
+	}
+	// If is a member of receiver
+	selfIndex := ks.resharing.holderIndex(ks.address)
+	if selfIndex > 0 {
+		ss, err := ks.decryptSecretShare(ers[selfIndex-1])
+		if err != nil {
+			return ErrDecryptionFailed
+		}
+		return ks.resharing.receiveReshareMessage(fromIndex, ss, p)
+	}
+	return ks.resharing.receiveReshareMessage(fromIndex, nil, p)
+}
+
+// ReceiveRecoverShare tries to verify a recovering message array and store their data.
+func (ks *AMEVKeyStore) ReceiveRecoverShare(from common.Address, ers []byte) error {
+	fromIndex := ks.shared.holderIndex(from)
+	if fromIndex > ks.size || fromIndex < 1 {
+		return ErrNotParticipant
+	}
+	// If is a member of receiver
+	selfIndex := ks.recovering.holderIndex(ks.address)
+	if selfIndex > 0 {
+		ss, err := ks.decryptSecretShare(ers)
+		if err != nil {
+			return ErrDecryptionFailed
+		}
+		return ks.recovering.receiveRecoverMessage(fromIndex, ss)
+	}
+	return nil
+}
+
+func (ks *AMEVKeyStore) decryptSecretShare(ess []byte) (*big.Int, error) {
+	ss, err := ks.ethPrvKey.Decrypt(ess, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return new(big.Int).SetBytes(ss), nil
+}

--- a/core/antimev/keystore_test.go
+++ b/core/antimev/keystore_test.go
@@ -1,0 +1,395 @@
+package antimev
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/ecies"
+)
+
+var size = 7
+var threshold = 5
+
+var addrs = []common.Address{
+	common.HexToAddress("0xcbbeca26e89011e32ba25610520b20741b809007"),
+	common.HexToAddress("0x4ea2a4697d40247c8be1f2b9ffa03a0e92dcbacc"),
+	common.HexToAddress("0xd10f47396dc6c76ad53546158751582d3e2683ef"),
+	common.HexToAddress("0xa51fe05b0183d01607bf48c1718d1168a1c11171"),
+	common.HexToAddress("0x01b517b301bb143476da35bb4a1399500d925514"),
+	common.HexToAddress("0x7976ad987d572377d39fb4bab86c80e08b6f8327"),
+	common.HexToAddress("0xd711da2d8c71a801fc351163337656f1321343a0"),
+}
+
+type MockContractStorage struct {
+	reshareMsgs   [][][]byte
+	resharePVSSes [][]byte
+	shareMsgs     [][][]byte
+	sharePVSSes   [][]byte
+	recoverMsgs   [][][]byte
+}
+
+func TestDKG(t *testing.T) {
+	source := rand.NewSource(time.Now().UnixNano())
+	random := rand.New(source)
+	// Init keystores
+	pubs := make([]*ecies.PublicKey, size)
+	kss := make([]*AMEVKeyStore, size)
+	for i := 0; i < size; i++ {
+		key, _ := ecies.GenerateKey(random, crypto.S256(), nil)
+		pubs[i] = &key.PublicKey
+		ks, err := NewKeyStore(addrs[i], key, size, threshold)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		kss[i] = ks
+	}
+	// Ignore resharing and execute sharing
+	contract := &MockContractStorage{
+		shareMsgs:   make([][][]byte, size),
+		sharePVSSes: make([][]byte, size),
+	}
+	for i := 0; i < size; i++ {
+		_, _, err := kss[i].OnValidatorList(addrs, pubs)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		// No reshare to handle
+		msgs, pvss, err := kss[i].OnReshareFinish()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		contract.shareMsgs[i] = msgs
+		contract.sharePVSSes[i] = pvss
+	}
+	// Send secret sharing messages
+	for i := 0; i < size; i++ {
+		for j := 0; j < size; j++ {
+			err := kss[i].ReceiveSecretShare(kss[j].address, contract.shareMsgs[j], contract.sharePVSSes[j])
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+		}
+	}
+	// Only check sharing
+	for i := 0; i < size; i++ {
+		err := kss[i].OnEpochChange()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+	}
+}
+
+func TestReshare(t *testing.T) {
+	source := rand.NewSource(time.Now().UnixNano())
+	random := rand.New(source)
+	// Init keystores
+	pubs := make([]*ecies.PublicKey, size)
+	kss := make([]*AMEVKeyStore, size)
+	for i := 0; i < size; i++ {
+		key, _ := ecies.GenerateKey(random, crypto.S256(), nil)
+		pubs[i] = &key.PublicKey
+		ks, err := NewKeyStore(addrs[i], key, size, threshold)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		kss[i] = ks
+	}
+	// Ignore resharing and execute sharing
+	contract := &MockContractStorage{
+		reshareMsgs:   make([][][]byte, size),
+		resharePVSSes: make([][]byte, size),
+		shareMsgs:     make([][][]byte, size),
+		sharePVSSes:   make([][]byte, size),
+	}
+	for i := 0; i < size; i++ {
+		_, _, err := kss[i].OnValidatorList(addrs, pubs)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		// No reshare to handle
+		msgs, pvss, err := kss[i].OnReshareFinish()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		contract.shareMsgs[i] = msgs
+		contract.sharePVSSes[i] = pvss
+	}
+	// Send secret sharing messages
+	for i := 0; i < size; i++ {
+		for j := 0; j < size; j++ {
+			err := kss[i].ReceiveSecretShare(kss[j].address, contract.shareMsgs[j], contract.sharePVSSes[j])
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+		}
+	}
+	// Finalize dkg
+	for i := 0; i < size; i++ {
+		err := kss[i].OnEpochChange()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+	}
+	// Execute resharing this time
+	for i := 0; i < size; i++ {
+		msgs, pvss, err := kss[i].OnValidatorList(addrs, pubs)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		contract.reshareMsgs[i] = msgs
+		contract.resharePVSSes[i] = pvss
+	}
+	// Send resharing messages
+	for i := 0; i < size; i++ {
+		for j := 0; j < size; j++ {
+			err := kss[i].ReceiveSecretReshare(kss[j].address, contract.reshareMsgs[j], contract.resharePVSSes[j])
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+		}
+	}
+	// Only check resharing
+	for i := 0; i < size; i++ {
+		_, _, err := kss[i].OnReshareFinish()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+	}
+}
+
+func TestGroupChange(t *testing.T) {
+	// Add another address for group change
+	addrs := []common.Address{
+		common.HexToAddress("0xcbbeca26e89011e32ba25610520b20741b809007"),
+		common.HexToAddress("0x4ea2a4697d40247c8be1f2b9ffa03a0e92dcbacc"),
+		common.HexToAddress("0xd10f47396dc6c76ad53546158751582d3e2683ef"),
+		common.HexToAddress("0xa51fe05b0183d01607bf48c1718d1168a1c11171"),
+		common.HexToAddress("0x01b517b301bb143476da35bb4a1399500d925514"),
+		common.HexToAddress("0x7976ad987d572377d39fb4bab86c80e08b6f8327"),
+		common.HexToAddress("0xd711da2d8c71a801fc351163337656f1321343a0"),
+		common.HexToAddress("0xd94b88c9d92845256019ee3bd9b07a57ca067970"),
+	}
+	source := rand.NewSource(time.Now().UnixNano())
+	random := rand.New(source)
+	// Init keystores
+	pubs := make([]*ecies.PublicKey, len(addrs))
+	kss := make([]*AMEVKeyStore, len(addrs))
+	for i := 0; i < len(addrs); i++ {
+		key, _ := ecies.GenerateKey(random, crypto.S256(), nil)
+		pubs[i] = &key.PublicKey
+		ks, err := NewKeyStore(addrs[i], key, size, threshold)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		kss[i] = ks
+	}
+	// Ignore resharing and execute sharing
+	contract := &MockContractStorage{
+		reshareMsgs:   make([][][]byte, 0),
+		resharePVSSes: make([][]byte, 0),
+		shareMsgs:     make([][][]byte, 0),
+		sharePVSSes:   make([][]byte, 0),
+	}
+	for i := 0; i < len(addrs); i++ {
+		_, _, err := kss[i].OnValidatorList(addrs[:size], pubs[:size])
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		// No reshare to handle
+		msgs, pvss, err := kss[i].OnReshareFinish()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		if len(msgs) > 0 {
+			contract.sharePVSSes = append(contract.sharePVSSes, pvss)
+			contract.shareMsgs = append(contract.shareMsgs, msgs)
+		}
+	}
+	if len(contract.sharePVSSes) != size || len(contract.shareMsgs) != size {
+		t.Fatalf("invalid message amount")
+	}
+	// Send secret sharing messages, broadcast to all nodes
+	for i := 0; i < len(addrs); i++ {
+		for j := 0; j < size; j++ {
+			err := kss[i].ReceiveSecretShare(kss[j].address, contract.shareMsgs[j], contract.sharePVSSes[j])
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+		}
+	}
+	// Finalize dkg
+	for i := 0; i < len(addrs); i++ {
+		err := kss[i].OnEpochChange()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+	}
+	// Execute resharing this time
+	for i := 0; i < len(addrs); i++ {
+		msgs, pvss, err := kss[i].OnValidatorList(addrs[1:], pubs[1:])
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		if len(msgs) > 0 {
+			contract.resharePVSSes = append(contract.resharePVSSes, pvss)
+			contract.reshareMsgs = append(contract.reshareMsgs, msgs)
+		}
+	}
+	if len(contract.reshareMsgs) != size {
+		t.Fatalf("invalid message amount")
+	}
+	// Send resharing messages, broadcast to all nodes
+	for i := 0; i < len(addrs); i++ {
+		for j := 0; j < size; j++ {
+			err := kss[i].ReceiveSecretReshare(kss[j].address, contract.reshareMsgs[j], contract.resharePVSSes[j])
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+		}
+	}
+	// Only check resharing
+	for i := 0; i < len(addrs); i++ {
+		_, _, err := kss[i].OnReshareFinish()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+	}
+}
+
+func TestRecover(t *testing.T) {
+	// Add another address for group change
+	addrs := []common.Address{
+		common.HexToAddress("0xcbbeca26e89011e32ba25610520b20741b809007"),
+		common.HexToAddress("0x4ea2a4697d40247c8be1f2b9ffa03a0e92dcbacc"),
+		common.HexToAddress("0xd10f47396dc6c76ad53546158751582d3e2683ef"),
+		common.HexToAddress("0xa51fe05b0183d01607bf48c1718d1168a1c11171"),
+		common.HexToAddress("0x01b517b301bb143476da35bb4a1399500d925514"),
+		common.HexToAddress("0x7976ad987d572377d39fb4bab86c80e08b6f8327"),
+		common.HexToAddress("0xd711da2d8c71a801fc351163337656f1321343a0"),
+		common.HexToAddress("0xd94b88c9d92845256019ee3bd9b07a57ca067970"),
+	}
+	source := rand.NewSource(time.Now().UnixNano())
+	random := rand.New(source)
+	// Init keystores
+	pubs := make([]*ecies.PublicKey, len(addrs))
+	kss := make([]*AMEVKeyStore, len(addrs))
+	for i := 0; i < len(addrs); i++ {
+		key, _ := ecies.GenerateKey(random, crypto.S256(), nil)
+		pubs[i] = &key.PublicKey
+		ks, err := NewKeyStore(addrs[i], key, size, threshold)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		kss[i] = ks
+	}
+	// Ignore resharing and execute sharing
+	contract := &MockContractStorage{
+		reshareMsgs:   make([][][]byte, 0),
+		resharePVSSes: make([][]byte, 0),
+		shareMsgs:     make([][][]byte, 0),
+		sharePVSSes:   make([][]byte, 0),
+		recoverMsgs:   make([][][]byte, 0),
+	}
+	for i := 0; i < len(addrs); i++ {
+		_, _, err := kss[i].OnValidatorList(addrs[:size], pubs[:size])
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		// No reshare to handle
+		msgs, pvss, err := kss[i].OnReshareFinish()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		if len(msgs) > 0 {
+			contract.sharePVSSes = append(contract.sharePVSSes, pvss)
+			contract.shareMsgs = append(contract.shareMsgs, msgs)
+		}
+	}
+	if len(contract.shareMsgs) != size {
+		t.Fatalf("invalid message amount")
+	}
+	// Send secret sharing messages, broadcast to all nodes
+	for i := 0; i < len(addrs); i++ {
+		for j := 0; j < size; j++ {
+			err := kss[i].ReceiveSecretShare(kss[j].address, contract.shareMsgs[j], contract.sharePVSSes[j])
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+		}
+	}
+	// Finalize dkg
+	for i := 0; i < len(addrs); i++ {
+		err := kss[i].OnEpochChange()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+	}
+	// Execute resharing this time
+	for i := 0; i < len(addrs); i++ {
+		msgs, pvss, err := kss[i].OnValidatorList(addrs[1:], pubs[1:])
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		if len(msgs) > 0 {
+			contract.reshareMsgs = append(contract.reshareMsgs, msgs)
+			contract.resharePVSSes = append(contract.resharePVSSes, pvss)
+		}
+	}
+	if len(contract.reshareMsgs) != size {
+		t.Fatalf("invalid message amount")
+	}
+	// Send resharing messages, expect validator 7
+	for i := 0; i < len(addrs); i++ {
+		for j := 0; j < size-1; j++ {
+			err := kss[i].ReceiveSecretReshare(kss[j].address, contract.reshareMsgs[j], contract.resharePVSSes[j])
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+		}
+	}
+	// Execute recovering this time, dead index 7, recover to validator 8
+	rIdxs := []int{7}
+	rAddrs := []common.Address{addrs[7]}
+	rPubs := []*ecies.PublicKey{pubs[7]}
+	for i := 0; i < len(addrs); i++ {
+		msgs, err := kss[i].OnRecoverStart(rIdxs, rAddrs, rPubs)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		// Length of msgs is 1
+		if msgs != nil {
+			contract.recoverMsgs = append(contract.recoverMsgs, msgs)
+		}
+	}
+	if len(contract.recoverMsgs) != size {
+		t.Fatalf("invalid message amount")
+	}
+	// Send recover messages, broadcast to all nodes
+	for i := 0; i < size-1; i++ {
+		err := kss[7].ReceiveRecoverShare(kss[i].address, contract.recoverMsgs[i][0])
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+	}
+	// Recover the lost resharing messages
+	msgs, pvss, err := kss[7].OnRecoverFinish()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	for i := 0; i < size; i++ {
+		err := kss[i].ReceiveRecoveredReshare(kss[7].address, msgs, pvss)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+	}
+	// Only check resharing
+	for i := 0; i < size; i++ {
+		_, _, err := kss[i].OnReshareFinish()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+	}
+}

--- a/core/antimev/signature.go
+++ b/core/antimev/signature.go
@@ -1,0 +1,76 @@
+package antimev
+
+import (
+	"errors"
+	"math"
+
+	"github.com/ethereum/go-ethereum/crypto/tpke"
+)
+
+var (
+	ErrSigShareNotEnough = errors.New("crypto/tpke: sig share not enough")
+	ErrSigAggregation    = errors.New("crypto/tpke: sig aggregation failed")
+)
+
+// SignShare tries to sign a message with local private key.
+func (ks *AMEVKeyStore) SignShare(msg []byte) (*tpke.SignatureShare, error) {
+	if ks.shared == nil || ks.shared.localPrvKey == nil {
+		return nil, ErrNoPrvKey
+	}
+	return ks.shared.localPrvKey.SignShare(msg), nil
+}
+
+// AggregateAndVerifySig tries to aggregate signature shares and returns
+// the final signature if the verification passes. The key of inputs is
+// dkg index which starts from 1, when the array index of a member in the
+// key group starts from 0.
+func (ks *AMEVKeyStore) AggregateAndVerifySig(msg []byte, inputs map[int]*tpke.SignatureShare) (*tpke.Signature, error) {
+	if ks.shared == nil {
+		return nil, ErrNoPubKey
+	}
+	return ks.shared.aggregateAndVerifySig(msg, inputs, ks.threshold, ks.scaler)
+}
+
+// aggregateAndVerifySig tries to aggregate signature shares and returns
+// the final signature if the verification passes.
+func (tkg *thresholdKeyGroup) aggregateAndVerifySig(msg []byte, inputs map[int]*tpke.SignatureShare, threshold int, scaler int) (*tpke.Signature, error) {
+	if len(inputs) < threshold {
+		return nil, ErrSigShareNotEnough
+	}
+	if tkg.globalPubKey == nil {
+		return nil, ErrNoPubKey
+	}
+
+	matrix := make([][]int, len(inputs))                // size=len(inputs)*threshold, including all rows
+	shares := make([]*tpke.SignatureShare, len(inputs)) // size=len(inputs), including all shares
+
+	// Be aware of a random order of sig shares
+	i := 0
+	for index, v := range inputs {
+		row := make([]int, threshold)
+		for j := 0; j < threshold; j++ {
+			row[j] = int(math.Pow(float64(index), float64(j)))
+		}
+		matrix[i] = row
+		shares[i] = v
+		i++
+	}
+
+	// Use different combinations to verify
+	combs := getCombs(len(inputs), threshold)
+	for _, v := range combs {
+		m := make([][]int, threshold)                // size=threshold*threshold, only seleted rows
+		s := make([]*tpke.SignatureShare, threshold) // size=threshold, only seleted shares
+		for i := 0; i < len(v); i++ {
+			m[i] = matrix[v[i]]
+			s[i] = shares[v[i]]
+		}
+		sig, err := tpke.AggregateSigShares(m, s, scaler)
+		// Verify if the aggregation is valid
+		if err == nil && tkg.globalPubKey.VerifySig(msg, sig) {
+			return sig, nil
+		}
+	}
+	// Return error since this share mapping is not able to recover the signature
+	return nil, ErrSigAggregation
+}

--- a/core/antimev/signature_test.go
+++ b/core/antimev/signature_test.go
@@ -1,0 +1,91 @@
+package antimev
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/ecies"
+	"github.com/ethereum/go-ethereum/crypto/tpke"
+)
+
+func TestSingleSignature(t *testing.T) {
+	sk := tpke.RandomPrivateKey()
+	pk := sk.GetPublicKey()
+
+	msg := []byte("pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza")
+	share := sk.SignShare(msg)
+	if !pk.VerifySigShare(msg, share) {
+		t.Fatalf("invalid signature")
+	}
+}
+
+func TestThresholdSignature(t *testing.T) {
+	source := rand.NewSource(time.Now().UnixNano())
+	random := rand.New(source)
+
+	pubs := make([]*ecies.PublicKey, size)
+	kss := make([]*AMEVKeyStore, size)
+	for i := 0; i < size; i++ {
+		key, _ := ecies.GenerateKey(random, crypto.S256(), nil)
+		pubs[i] = &key.PublicKey
+		ks, err := NewKeyStore(addrs[i], key, size, threshold)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		kss[i] = ks
+	}
+
+	msgbox := make([][][]byte, size)
+	pvssbox := make([][]byte, size)
+	for i := 0; i < size; i++ {
+		// No reshare to handle
+		_, _, err := kss[i].OnValidatorList(addrs, pubs)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		// Handle share
+		msgs, pvss, err := kss[i].OnReshareFinish()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		msgbox[i] = msgs
+		pvssbox[i] = pvss
+	}
+
+	for i := 0; i < size; i++ {
+		for j := 0; j < size; j++ {
+			err := kss[i].ReceiveSecretShare(kss[j].address, msgbox[j], pvssbox[j])
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+		}
+	}
+
+	for i := 0; i < size; i++ {
+		err := kss[i].OnEpochChange()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+	}
+
+	// Test functionality
+	msg := []byte("pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza")
+	shares := make(map[int]*tpke.SignatureShare)
+	for i := 0; i < size; i++ {
+		share, err := kss[i].SignShare(msg)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		shares[i+1] = share
+	}
+
+	sig, err := kss[0].AggregateAndVerifySig(msg, shares)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if sig == nil {
+		t.Fatalf("invalid signature")
+	}
+}

--- a/core/antimev/tpke.go
+++ b/core/antimev/tpke.go
@@ -1,0 +1,188 @@
+package antimev
+
+import (
+	"errors"
+	"math"
+
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+	"github.com/ethereum/go-ethereum/crypto/tpke"
+)
+
+var (
+	ErrDecryptionShareNotEnough = errors.New("decryption share not enough")
+	ErrDecryptionFailed         = errors.New("decryption failed")
+	ErrNoPrvKey                 = errors.New("no local private key")
+	ErrNoPubKey                 = errors.New("no global public key")
+	ErrLengthMismatch           = errors.New("input length mismatch")
+)
+
+// Encrypt uses the current finished sharing to encrypt the input byte array.
+// It returns an encrypted aes key and an encrypted byte array.
+func (ks *AMEVKeyStore) Encrypt(msg []byte) (*tpke.CipherText, []byte, error) {
+	if ks.shared == nil {
+		return nil, nil, ErrNoPubKey
+	}
+	// Random AES key
+	aesKey := randPG1()
+	// Encrypt the key
+	encryptedKey, err := ks.shared.encrypt(aesKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	// Encrypt the message
+	encryptedMsg, err := tpke.AESEncrypt(aesKey, msg)
+	if err != nil {
+		return nil, nil, err
+	}
+	return encryptedKey, encryptedMsg, nil
+}
+
+// DecryptWithShare generates decryption shares for decrypting an array of
+// aes keys. The returned array is ordered the same as inputs.
+func (ks *AMEVKeyStore) DecryptWithShare(cts []*tpke.CipherText) ([]*tpke.DecryptionShare, error) {
+	if ks.shared == nil {
+		return nil, ErrNoPrvKey
+	}
+	return ks.shared.decryptShare(cts)
+}
+
+// DecryptWithShare generates decryption shares for decrypting an array of
+// aes keys, which is encrypted by old global public key. The returned
+// array is ordered the same as inputs.
+func (ks *AMEVKeyStore) DecryptWithReshare(cts []*tpke.CipherText) ([]*tpke.DecryptionShare, error) {
+	if ks.reshared == nil {
+		return nil, ErrNoPrvKey
+	}
+	return ks.reshared.decryptShare(cts)
+}
+
+// AggregateAndDecryptWithShare tries to aggregate decryption shares and finally
+// decrypt the aes keys and the raw messages. The encrypted keys, encrypted
+// messages and decryption shares should have the same input order. The key of
+// inputs is dkg index which starts from 1, when the array index of a member in
+// the key group starts from 0.
+func (ks *AMEVKeyStore) AggregateAndDecryptWithShare(cts []*tpke.CipherText, msg [][]byte, inputs map[int]([]*tpke.DecryptionShare)) ([][]byte, error) {
+	if ks.shared == nil {
+		return nil, ErrNoPubKey
+	}
+	if len(cts) != len(msg) {
+		return nil, ErrLengthMismatch
+	}
+	for _, v := range inputs {
+		if len(v) != len(cts) {
+			return nil, ErrLengthMismatch
+		}
+	}
+	// Try decrypt the aes keys, err will be nil if the provided shares are valid,
+	// but it doesn't promise the following aes decryption will succeed
+	aesKeys, err := ks.shared.aggregateAndDecrypt(cts, inputs, ks.threshold, ks.scaler)
+	if err != nil {
+		return nil, err
+	}
+	// Decrypt the messages, err will be nil if the user encryption is valid
+	decryptedMsgs := make([][]byte, len(msg))
+	for i := 0; i < len(decryptedMsgs); i++ {
+		// Set nil if the aes fails
+		m, _ := tpke.AESDecrypt(aesKeys[i], msg[i])
+		decryptedMsgs[i] = m
+	}
+	return decryptedMsgs, nil
+}
+
+// AggregateAndDecryptWithShare tries to aggregate decryption shares and finally
+// decrypt the aes keys and the raw messages, but the reshared key group is used.
+func (ks *AMEVKeyStore) AggregateAndDecryptWithReshare(cts []*tpke.CipherText, msg [][]byte, inputs map[int]([]*tpke.DecryptionShare)) ([][]byte, error) {
+	if ks.reshared == nil {
+		return nil, ErrNoPubKey
+	}
+	if len(cts) != len(msg) {
+		return nil, ErrLengthMismatch
+	}
+	for _, v := range inputs {
+		if len(v) != len(cts) {
+			return nil, ErrLengthMismatch
+		}
+	}
+	// Try decrypt the aes keys, err will be nil if the provided shares are valid,
+	// but it doesn't promise the following aes decryption will succeed
+	aesKeys, err := ks.reshared.aggregateAndDecrypt(cts, inputs, ks.threshold, ks.scaler)
+	if err != nil {
+		return nil, err
+	}
+	// Decrypt the messages, err will be nil if the user encryption is valid
+	decryptedMsgs := make([][]byte, len(msg))
+	for i := 0; i < len(decryptedMsgs); i++ {
+		// Set nil if the aes fails
+		raw, _ := tpke.AESDecrypt(aesKeys[i], msg[i])
+		decryptedMsgs[i] = raw
+	}
+	return decryptedMsgs, nil
+}
+
+// encrypt encrypts the input bls12381 g1 point which is also an aes key.
+func (tkg *thresholdKeyGroup) encrypt(msg *bls12381.G1Affine) (*tpke.CipherText, error) {
+	if tkg.globalPubKey == nil {
+		return nil, ErrNoPubKey
+	}
+	return tkg.globalPubKey.Encrypt(msg), nil
+}
+
+// decryptShare generates decryption shares for an array of encrypted aes keys.
+func (tkg *thresholdKeyGroup) decryptShare(cts []*tpke.CipherText) ([]*tpke.DecryptionShare, error) {
+	if tkg.localPrvKey == nil {
+		return nil, ErrNoPrvKey
+	}
+	share := make([]*tpke.DecryptionShare, len(cts))
+	for j := 0; j < len(cts); j++ {
+		share[j] = tkg.localPrvKey.DecryptShare(cts[j])
+	}
+
+	return share, nil
+}
+
+// aggregateAndDecrypt tries to aggregate decryption shares and recover an array of
+// encrypted aes keys. It returns error if the decryption share input is not able to
+// recover the correct data as they are committed. The key of inputs is dkg index
+// which starts from 1, when the array index of a member in the key group starts from 0.
+func (tkg *thresholdKeyGroup) aggregateAndDecrypt(cts []*tpke.CipherText, inputs map[int]([]*tpke.DecryptionShare), threshold int, scaler int) ([]*bls12381.G1Affine, error) {
+	if len(inputs) < threshold {
+		return nil, ErrDecryptionShareNotEnough
+	}
+	if tkg.globalPubKey == nil {
+		return nil, ErrNoPubKey
+	}
+
+	matrix := make([][]int, len(inputs))                   // size=len(inputs)*threshold, including all rows
+	shares := make([][]*tpke.DecryptionShare, len(inputs)) // size=len(inputs)*len(cts), including all shares
+
+	// Be aware of a random order of decryption shares
+	i := 0
+	for index, v := range inputs {
+		row := make([]int, threshold)
+		for j := 0; j < threshold; j++ {
+			row[j] = int(math.Pow(float64(index), float64(j)))
+		}
+		matrix[i] = row
+		shares[i] = v
+		i++
+	}
+
+	// Use different combinations to decrypt
+	combs := getCombs(len(inputs), threshold)
+	for _, v := range combs {
+		m := make([][]int, threshold)                   // size=threshold*threshold, only seleted rows
+		s := make([][]*tpke.DecryptionShare, threshold) // size=threshold*len(cts), only seleted shares
+		for i := 0; i < len(v); i++ {
+			m[i] = matrix[v[i]]
+			s[i] = shares[v[i]]
+		}
+		// The parallel verification of decryption is contained, refer to crypto/tpke
+		// Any failure here means an invalid decryption combination, should continue
+		results, err := tpke.AggregateAndDecrypt(cts, m, s, tkg.globalPubKey, scaler)
+		if err == nil {
+			return results, nil
+		}
+	}
+	// Return error since this share mapping is not able to recover the message
+	return nil, ErrDecryptionFailed
+}

--- a/core/antimev/tpke_test.go
+++ b/core/antimev/tpke_test.go
@@ -1,0 +1,233 @@
+package antimev
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/crypto/ecies"
+	"github.com/ethereum/go-ethereum/crypto/tpke"
+)
+
+func TestTPKE(t *testing.T) {
+	source := rand.NewSource(time.Now().UnixNano())
+	random := rand.New(source)
+
+	pubs := make([]*ecies.PublicKey, size)
+	kss := make([]*AMEVKeyStore, size)
+	for i := 0; i < size; i++ {
+		key, _ := ecies.GenerateKey(random, crypto.S256(), nil)
+		pubs[i] = &key.PublicKey
+		ks, err := NewKeyStore(addrs[i], key, size, threshold)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		kss[i] = ks
+	}
+
+	msgbox := make([][][]byte, size)
+	pvssbox := make([][]byte, size)
+	for i := 0; i < size; i++ {
+		// No reshare to handle
+		_, _, err := kss[i].OnValidatorList(addrs, pubs)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		// Handle share
+		msgs, pvss, err := kss[i].OnReshareFinish()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		msgbox[i] = msgs
+		pvssbox[i] = pvss
+	}
+
+	for i := 0; i < size; i++ {
+		for j := 0; j < size; j++ {
+			err := kss[i].ReceiveSecretShare(kss[j].address, msgbox[j], pvssbox[j])
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+		}
+	}
+
+	for i := 0; i < size; i++ {
+		err := kss[i].OnEpochChange()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+	}
+
+	// Encrypt
+	msg := []byte("pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza")
+	encryptedKey, encryptedMsg, err := kss[0].Encrypt(msg)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// Verify ciphertext
+	if err := encryptedKey.Verify(); err != nil {
+		t.Fatalf("invalid ciphertext.")
+	}
+
+	// Generate shares
+	shares := make(map[int][]*tpke.DecryptionShare)
+	for i := 0; i < size; i++ {
+		share, err := kss[i].DecryptWithShare([]*tpke.CipherText{encryptedKey})
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		shares[i+1] = share
+	}
+
+	// Decrypt
+	results, err := kss[0].AggregateAndDecryptWithShare([]*tpke.CipherText{encryptedKey}, [][]byte{encryptedMsg}, shares)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	for i := 0; i < len(msg); i++ {
+		if msg[i] != results[0][i] {
+			t.Fatalf("decryption failed.")
+		}
+	}
+}
+
+func TestBenchmark(t *testing.T) {
+	sampleAmount := 1500
+	size := 7
+	threshold := 5
+
+	// DKG
+	source := rand.NewSource(time.Now().UnixNano())
+	random := rand.New(source)
+
+	pubs := make([]*ecies.PublicKey, size)
+	kss := make([]*AMEVKeyStore, size)
+	for i := 0; i < size; i++ {
+		key, _ := ecies.GenerateKey(random, crypto.S256(), nil)
+		pubs[i] = &key.PublicKey
+		ks, err := NewKeyStore(addrs[i], key, size, threshold)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		kss[i] = ks
+	}
+
+	msgbox := make([][][]byte, size)
+	pvssbox := make([][]byte, size)
+	for i := 0; i < size; i++ {
+		// No reshare to handle
+		_, _, err := kss[i].OnValidatorList(addrs, pubs)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		// Handle share
+		msgs, pvss, err := kss[i].OnReshareFinish()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		msgbox[i] = msgs
+		pvssbox[i] = pvss
+	}
+
+	for i := 0; i < size; i++ {
+		for j := 0; j < size; j++ {
+			err := kss[i].ReceiveSecretShare(kss[j].address, msgbox[j], pvssbox[j])
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+		}
+	}
+
+	for i := 0; i < size; i++ {
+		err := kss[i].OnEpochChange()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+	}
+
+	// Build a 1MB script
+	script := make([]byte, 131072)
+	rand.Read(script)
+	ch := make(chan message, sampleAmount)
+
+	// Encrypt script
+	for i := 0; i < sampleAmount; i++ {
+		go parallelEncrypt(i, kss[0], script, ch)
+	}
+	encryptedSeeds, encryptedMsgs, _ := messageHandler(ch, sampleAmount)
+
+	// Verify encrypted seeds
+	for i := 0; i < sampleAmount; i++ {
+		go parallelCTVerify(encryptedSeeds[i], ch)
+	}
+	_, _, err := messageHandler(ch, sampleAmount)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// Generate shares
+	shares := make(map[int][]*tpke.DecryptionShare)
+	for i := 0; i < size; i++ {
+		share, err := kss[i].DecryptWithShare(encryptedSeeds)
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		shares[i+1] = share
+	}
+
+	// Decrypt
+	t1 := time.Now()
+	results, err := kss[0].AggregateAndDecryptWithShare(encryptedSeeds, encryptedMsgs, shares)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	t.Logf("threshold decryption time: %v", time.Since(t1))
+	for i := 0; i < sampleAmount; i++ {
+		if !bytes.Equal(results[i], script) {
+			t.Fatalf("decryption failed.")
+		}
+	}
+}
+
+type message struct {
+	index int
+	ck    *tpke.CipherText
+	cmsg  []byte
+	err   error
+}
+
+func parallelCTVerify(ct *tpke.CipherText, ch chan<- message) {
+	ch <- message{
+		index: 0,
+		err:   ct.Verify(),
+		ck:    nil,
+		cmsg:  nil,
+	}
+}
+
+func parallelEncrypt(index int, ks *AMEVKeyStore, input []byte, ch chan<- message) {
+	ck, cmsg, err := ks.Encrypt(input)
+	ch <- message{
+		index: index,
+		ck:    ck,
+		cmsg:  cmsg,
+		err:   err,
+	}
+}
+
+func messageHandler(ch <-chan message, amount int) ([]*tpke.CipherText, [][]byte, error) {
+	cks := make([]*tpke.CipherText, amount)
+	cmsgs := make([][]byte, amount)
+	for i := 0; i < amount; i++ {
+		msg := <-ch
+		if msg.err != nil {
+			return nil, nil, msg.err
+		}
+		cks[msg.index] = msg.ck
+		cmsgs[msg.index] = msg.cmsg
+	}
+	return cks, cmsgs, nil
+}

--- a/core/antimev/util.go
+++ b/core/antimev/util.go
@@ -1,0 +1,97 @@
+package antimev
+
+import (
+	"crypto/rand"
+	"math"
+	"math/big"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+	"github.com/ethereum/go-ethereum/crypto/tpke"
+)
+
+// randPG1 returns a random bls12381 g1 point
+func randPG1() *bls12381.G1Affine {
+	r := randScalar()
+	return new(bls12381.G1Affine).ScalarMultiplicationBase(r)
+}
+
+// randScalar returns a random big int
+func randScalar() *big.Int {
+	a, _ := rand.Int(rand.Reader, ecc.BLS12_381.ScalarField())
+	return a
+}
+
+// getScaler returns a scaler factor for public key, works under size 7,
+// but need to be carefully verified in a larger size.
+func getScaler(size int, threshold int) int {
+	matrix := make([][]int, threshold) // size=threshold*threshold
+	return searchDLCM(matrix, 1, 0, 0, size, threshold)
+}
+
+// searchDLCM tries to find a minimum value of scaler for the given matrix.
+func searchDLCM(matrix [][]int, l, pos, offset, size, threshold int) int {
+	if pos == threshold {
+		d, coeff := tpke.Feldman(matrix)
+		g := d
+		for i := 0; i < len(coeff); i++ {
+			g = gcd(g, coeff[i])
+		}
+		d = d / g
+		return abs(d)
+	}
+	for i := pos + offset; i < size-threshold+pos+1; i++ {
+		row := make([]int, threshold)
+		for j := 0; j < threshold; j++ {
+			row[j] = int(math.Pow(float64(i+1), float64(j)))
+		}
+		matrix[pos] = row
+		l = lcm(l, searchDLCM(matrix, l, pos+1, i-pos, size, threshold))
+	}
+	return l
+}
+
+// getCombs returns all possible combinations to take n of m.
+func getCombs(m int, n int) [][]int {
+	return searchCombs(make([]int, n), 0, 0, m, n)
+}
+
+// searchDLCM tries to find possible combinations to take n of m.
+func searchCombs(arr []int, pos, offset, m, n int) [][]int {
+	results := make([][]int, 0)
+	if pos == n {
+		comb := make([]int, n)
+		copy(comb, arr)
+		results = append(results, comb)
+		return results
+	}
+	for i := pos + offset; i < m; i++ {
+		arr[pos] = i
+		results = append(results, searchCombs(arr, pos+1, i-pos, m, n)...)
+	}
+	return results
+}
+
+// gcd returns the greatest common divisor of a and b.
+func gcd(a, b int) int {
+	if b == 0 {
+		return a
+	}
+	if b < 0 {
+		b = -b
+	}
+	return gcd(b, a%b)
+}
+
+// lcm returns the least common multiple of a and b.
+func lcm(a, b int) int {
+	return a * b / gcd(a, b)
+}
+
+// abs returns the absolute value of a.
+func abs(a int) int {
+	if a < 0 {
+		return -a
+	}
+	return a
+}

--- a/crypto/tpke/aes.go
+++ b/crypto/tpke/aes.go
@@ -1,0 +1,64 @@
+package tpke
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha256"
+	"errors"
+
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+)
+
+var (
+	ErrAESMessage    = errors.New("crypto/tpke: empty aes message")
+	ErrAESCiphertext = errors.New("crypto/tpke: empty aes ciphertext")
+	ErrAESEncryption = errors.New("crypto/tpke: aes encryption faild")
+	ErrAESDecryption = errors.New("crypto/tpke: aes decryption faild")
+)
+
+// AESEncrypt uses a bls g1 point as a key to encrypt the input message
+func AESEncrypt(pg1 *bls12381.G1Affine, msg []byte) ([]byte, error) {
+	if len(msg) < 1 {
+		return nil, ErrAESMessage
+	}
+	// Take pg1 as the input of sha256 to generate an aes key
+	seed := pg1.RawBytes()
+	hash := sha256.Sum256(seed[0:96])
+	block, err := aes.NewCipher(hash[0:32])
+	if err != nil {
+		return nil, ErrAESEncryption
+	}
+	blockSize := block.BlockSize()
+
+	data := pkcs7Padding(msg, blockSize)
+	blockMode := cipher.NewCBCEncrypter(block, hash[:blockSize])
+	encrypted := make([]byte, len(data))
+	blockMode.CryptBlocks(encrypted, data)
+
+	return encrypted, nil
+}
+
+// AESDecrypt uses a bls g1 point as a key to decrypt the input ciphertext
+func AESDecrypt(pg1 *bls12381.G1Affine, cipherText []byte) ([]byte, error) {
+	if len(cipherText) < 1 {
+		return nil, ErrAESCiphertext
+	}
+	// Take pg1 as the input of sha256 to generate an aes key
+	seed := pg1.RawBytes()
+	hash := sha256.Sum256(seed[0:96])
+	block, err := aes.NewCipher(hash[0:32])
+	if err != nil {
+		return nil, ErrAESDecryption
+	}
+	blockSize := block.BlockSize()
+
+	blockMode := cipher.NewCBCDecrypter(block, hash[:blockSize])
+	decrypted := make([]byte, len(cipherText))
+	blockMode.CryptBlocks(decrypted, cipherText)
+	result, err := pkcs7UnPadding(decrypted)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}

--- a/crypto/tpke/aes_test.go
+++ b/crypto/tpke/aes_test.go
@@ -1,0 +1,25 @@
+package tpke
+
+import (
+	"testing"
+)
+
+func TestAES(t *testing.T) {
+	msg := []byte("pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza")
+	g1 := randPG1()
+	t.Logf("origin msg : %v", string(msg))
+
+	// Encrypt
+	encrypted, err := AESEncrypt(g1, msg)
+	if err != nil {
+		t.Fatalf("encryption failed.")
+	}
+	t.Logf("encrypted msg : %v", encrypted)
+
+	// Decrypt
+	decrypted, err := AESDecrypt(g1, encrypted)
+	if err != nil {
+		t.Fatalf("decryption failed.")
+	}
+	t.Logf("decrypted msg : %v", string(decrypted))
+}

--- a/crypto/tpke/encryption.go
+++ b/crypto/tpke/encryption.go
@@ -1,0 +1,198 @@
+package tpke
+
+import (
+	"errors"
+	"math/big"
+
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+)
+
+var (
+	fpByteSize            = 48
+	workerCount           = 24
+	ErrTPKECiphertext     = errors.New("crypto/tpke: invalid tpke ciphertext")
+	ErrTPKEDecryption     = errors.New("crypto/tpke: tpke decryption failed")
+	ErrTPKEDecoding       = errors.New("crypto/tpke: invalid decode length")
+	ErrTPKELengthMismatch = errors.New("crypto/tpke: input length mismatch")
+)
+
+// The encrypted message carrier in TPKE
+type CipherText struct {
+	cMsg       *bls12381.G1Affine // Encrypted message
+	bigR       *bls12381.G1Affine // Verifiable commitment of encryption commitment
+	commitment *bls12381.G2Affine // Encryption commitment
+}
+
+// ToBytes encodes a CipherText into a byte array whose length is 192
+func (ct *CipherText) ToBytes() []byte {
+	out := make([]byte, 4*fpByteSize)
+	bmsg := ct.cMsg.Bytes()
+	br := ct.bigR.Bytes()
+	bc := ct.commitment.Bytes()
+	copy(out[:fpByteSize], bmsg[:])
+	copy(out[fpByteSize:2*fpByteSize], br[:])
+	copy(out[2*fpByteSize:4*fpByteSize], bc[:])
+	return out
+}
+
+// FromBytes reads the first 192 bytes of input array and decodes as CipherText
+func (ct *CipherText) FromBytes(b []byte) (*CipherText, error) {
+	if len(b) != 4*fpByteSize {
+		return nil, ErrTPKEDecoding
+	}
+	cMsg := new(bls12381.G1Affine)
+	bigR := new(bls12381.G1Affine)
+	commitment := new(bls12381.G2Affine)
+	_, err := cMsg.SetBytes(b[:fpByteSize])
+	if err != nil {
+		return nil, err
+	}
+	_, err = bigR.SetBytes(b[fpByteSize : 2*fpByteSize])
+	if err != nil {
+		return nil, err
+	}
+	_, err = commitment.SetBytes(b[2*fpByteSize : 4*fpByteSize])
+	if err != nil {
+		return nil, err
+	}
+	ct.cMsg = cMsg
+	ct.bigR = bigR
+	ct.commitment = commitment
+	return ct, nil
+}
+
+// Verify checks if the CipherText has a valid commitment for random encryption
+// If this returns no error, then the random r is confirmed without knowledge
+func (ct *CipherText) Verify() error {
+	// User sends an invalid commitment for his random r
+	_, _, g1, g2 := bls12381.Generators()
+	r, err := bls12381.PairingCheck([]bls12381.G1Affine{*ct.bigR, g1}, []bls12381.G2Affine{g2, *ct.commitment})
+	if err != nil || !r {
+		return ErrTPKECiphertext
+	}
+	return nil
+}
+
+// The decryption message for further aggregation
+type DecryptionShare struct {
+	pg1 *bls12381.G1Affine
+}
+
+// ToBytes encodes a DecryptionShare into a byte array whose length is 48
+func (s *DecryptionShare) ToBytes() []byte {
+	b := s.pg1.Bytes()
+	return b[:]
+}
+
+// FromBytes decodes a 48-byte array as a DecryptionShare
+func (s *DecryptionShare) FromBytes(b []byte) (*DecryptionShare, error) {
+	pg1 := new(bls12381.G1Affine)
+	_, err := pg1.SetBytes(b)
+	if err != nil {
+		return nil, err
+	}
+	s.pg1 = pg1
+	return s, nil
+}
+
+// The task message for local decryption and verification
+type workerTask struct {
+	i     int
+	ct    *CipherText
+	pk    *PublicKey
+	ss    []*DecryptionShare
+	coeff []int
+	d     *big.Int
+}
+
+// The task result about local decryption and verification
+type workerResult struct {
+	i   int
+	msg *bls12381.G1Affine
+	err error
+}
+
+// AggregateAndDecrypt tries to aggregate DecryptionShares and decrypts CipherTexts with verification
+// This method takes a batch of ordered CipherTexts, DecryptionShares and a matrix for Feldman
+// The size of DecryptionShare array should be len(message)*len(ciphertext)
+// Each row of the input matrix should be [1, i, i^2, ..., i^(threshold-1)], i is the dkg key index
+// The message amount should be larger than threshold, otherwise the result will be wrong
+func AggregateAndDecrypt(cts []*CipherText, matrix [][]int, shares [][]*DecryptionShare, pub *PublicKey, scaler int) ([]*bls12381.G1Affine, error) {
+	for i := 0; i < len(shares); i++ {
+		if len(cts) != len(shares[i]) {
+			return nil, ErrTPKELengthMismatch
+		}
+	}
+	if len(matrix) != len(shares) {
+		return nil, ErrTPKELengthMismatch
+	}
+
+	// Be aware of the integer overflow when the size and threshold of tpke grow big
+	d, coeff := Feldman(matrix)
+	d = scaler / d
+	results := make([]*bls12381.G1Affine, len(cts))
+	// Compute M=C-d1/d
+	denominator := big.NewInt(int64(abs(d)))
+	if d < 0 {
+		denominator.Neg(denominator)
+	}
+	in := make(chan workerTask, len(cts))
+	out := make(chan workerResult, len(cts))
+	for i := 0; i < workerCount; i++ {
+		go startWorker(in, out)
+	}
+	for i := 0; i < len(cts); i++ {
+		ss := make([]*DecryptionShare, len(shares))
+		for j := 0; j < len(shares); j++ {
+			ss[j] = shares[j][i]
+		}
+		// Parallel tasks
+		in <- workerTask{i, cts[i], pub, ss, coeff, denominator}
+	}
+	close(in)
+	// Verification passes if the decrypted rpk contains the same r as the ciphertext declares
+	// If a user (the encryptor) use a different r to generate cMsg, no error will be detected
+	// here, but the following aes decryption will fail
+	for i := 0; i < len(cts); i++ {
+		r := <-out
+		if r.err != nil {
+			return nil, r.err
+		}
+		results[r.i] = r.msg
+	}
+
+	return results, nil
+}
+
+// startVerifier verifies if the decrypted rpk is the same as the message declares
+func startWorker(in <-chan workerTask, out chan<- workerResult) {
+	for {
+		t, ok := <-in
+		if !ok {
+			return
+		}
+		// Try Decrypt
+		rpk := new(bls12381.G1Affine).ScalarMultiplicationBase(big.NewInt(0))
+		// Add up shares with some factors as d1, and plus -1
+		for i := 0; i < len(t.ss); i++ {
+			minor := new(bls12381.G1Affine).ScalarMultiplication(t.ss[i].pg1, big.NewInt(int64(abs(t.coeff[i]))))
+			if t.coeff[i] < 0 {
+				minor.Neg(minor)
+			}
+			rpk.Add(rpk, minor)
+		}
+		// Divide -d1 by d
+		rpk.ScalarMultiplication(rpk, t.d)
+		msg := new(bls12381.G1Affine).Sub(t.ct.cMsg, rpk)
+
+		// Verify
+		_, _, _, g2 := bls12381.Generators()
+		// Decrypted rpk is not correct, e(pk,rG2)!=e(rpk,G2), decryption fails
+		r, err := bls12381.PairingCheck([]bls12381.G1Affine{*t.pk.pg1, *rpk}, []bls12381.G2Affine{*t.ct.commitment, g2})
+		if err != nil || !r {
+			out <- workerResult{t.i, nil, ErrTPKEDecryption}
+		} else {
+			out <- workerResult{t.i, msg, nil}
+		}
+	}
+}

--- a/crypto/tpke/encryption_test.go
+++ b/crypto/tpke/encryption_test.go
@@ -1,0 +1,31 @@
+package tpke
+
+import (
+	"math/big"
+	"testing"
+
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+)
+
+func TestCipherTextEncoding(t *testing.T) {
+	_, _, _, g2 := bls12381.Generators()
+	ct := &CipherText{
+		cMsg:       new(bls12381.G1Affine).ScalarMultiplicationBase(big.NewInt(1)),
+		bigR:       new(bls12381.G1Affine).ScalarMultiplicationBase(big.NewInt(1)),
+		commitment: new(bls12381.G2Affine).ScalarMultiplication(&g2, big.NewInt(1)),
+	}
+	b := ct.ToBytes()
+	result, err := new(CipherText).FromBytes(b)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if !ct.cMsg.Equal(result.cMsg) {
+		t.Fatalf("cMsg mismatch.")
+	}
+	if !ct.bigR.Equal(result.bigR) {
+		t.Fatalf("bigR mismatch.")
+	}
+	if !ct.commitment.Equal(result.commitment) {
+		t.Fatalf("commitment mismatch.")
+	}
+}

--- a/crypto/tpke/poly.go
+++ b/crypto/tpke/poly.go
@@ -1,0 +1,144 @@
+package tpke
+
+import (
+	"math/big"
+
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+)
+
+type Poly struct {
+	coeff []*big.Int
+}
+
+func randomPoly(degree int) *Poly {
+	coeff := make([]*big.Int, degree)
+
+	for i := range coeff {
+		fr := randScalar()
+		coeff[i] = fr
+	}
+	return &Poly{
+		coeff: coeff,
+	}
+}
+
+func (p *Poly) evaluate(x *big.Int) *big.Int {
+	i := len(p.coeff) - 1
+	result := new(big.Int).Set(p.coeff[i])
+	for i >= 0 {
+		if i != len(p.coeff)-1 {
+			result.Mul(result, x)
+			result.Add(result, p.coeff[i])
+		}
+		i--
+	}
+	return result
+}
+
+func (p *Poly) AddAssign(op *Poly) {
+	pLen := len(p.coeff)
+	opLen := len(op.coeff)
+	for pLen < opLen {
+		p.coeff = append(p.coeff, big.NewInt(0))
+		pLen++
+	}
+	for i := range p.coeff {
+		p.coeff[i].Add(p.coeff[i], op.coeff[i])
+	}
+}
+
+func (p *Poly) MulAssign(x *big.Int) {
+	// TODO : check if op is zero
+	for _, c := range p.coeff {
+		c.Mul(c, x)
+	}
+}
+
+func (p *Poly) commitment() *Commitment {
+	coeff := make([]*bls12381.G1Affine, len(p.coeff))
+	for i := range coeff {
+		coeff[i] = new(bls12381.G1Affine).ScalarMultiplicationBase(p.coeff[i])
+	}
+	return &Commitment{
+		coeff: coeff,
+	}
+}
+
+type Commitment struct {
+	coeff []*bls12381.G1Affine
+}
+
+func (c *Commitment) Clone() *Commitment {
+	coeff := make([]*bls12381.G1Affine, len(c.coeff))
+	for i := range coeff {
+		coeff[i] = new(bls12381.G1Affine).Set(c.coeff[i])
+	}
+	return &Commitment{
+		coeff: coeff,
+	}
+}
+
+func (c *Commitment) ToBytes() []byte {
+	arr := make([]byte, 0)
+	for i := range c.coeff {
+		b := encodePointG1(c.coeff[i])
+		arr = append(arr, b[:]...)
+	}
+	return arr
+}
+
+func (c *Commitment) FromBytes(b []byte, t int) (*Commitment, error) {
+	if len(b) != t*128 {
+		return nil, ErrTPKEDecoding
+	}
+	arr := make([]*bls12381.G1Affine, t)
+	for i := 0; i < t; i++ {
+		pg1, err := decodePointG1(b[i*128 : (i+1)*128])
+		if err != nil {
+			return nil, err
+		}
+		arr[i] = pg1
+	}
+	c.coeff = arr
+	return c, nil
+}
+
+func (c *Commitment) evaluate(x *big.Int) *bls12381.G1Affine {
+	if len(c.coeff) == 0 {
+		return new(bls12381.G1Affine).ScalarMultiplicationBase(big.NewInt(0))
+	}
+	i := len(c.coeff) - 1
+	result := new(bls12381.G1Affine).Set(c.coeff[i])
+	for i >= 0 {
+		if i != len(c.coeff)-1 {
+			result.ScalarMultiplication(result, x)
+			result.Add(result, c.coeff[i])
+		}
+		i--
+	}
+	return result
+}
+
+func (c *Commitment) AddAssign(op *Commitment) {
+	pLen := len(c.coeff)
+	opLen := len(op.coeff)
+	for pLen < opLen {
+		c.coeff = append(c.coeff, new(bls12381.G1Affine).ScalarMultiplicationBase(big.NewInt(0)))
+		pLen++
+	}
+	for i := range c.coeff {
+		c.coeff[i].Add(c.coeff[i], op.coeff[i])
+	}
+}
+
+func (c *Commitment) Equals(oc *Commitment) bool {
+	if len(c.coeff) != len(oc.coeff) {
+		return false
+	}
+	for i := range c.coeff {
+		if !c.coeff[i].Equal(oc.coeff[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/crypto/tpke/poly_test.go
+++ b/crypto/tpke/poly_test.go
@@ -1,0 +1,68 @@
+package tpke
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestPoly_AddAssign(t *testing.T) {
+	fr1 := big.NewInt(1)
+	poly := &Poly{
+		coeff: []*big.Int{
+			fr1,
+			fr1,
+			fr1,
+		},
+	}
+	poly2 := &Poly{
+		coeff: []*big.Int{
+			fr1,
+			fr1,
+			fr1,
+			fr1,
+			fr1,
+		},
+	}
+	t.Logf("%v", poly.coeff)
+	poly.AddAssign(poly2)
+	t.Logf("%v", poly.coeff)
+}
+
+func TestPoly_evaluate(t *testing.T) {
+	expectedFr := big.NewInt(47)
+	fr1 := big.NewInt(2)
+	fr2 := big.NewInt(3)
+	fr3 := big.NewInt(4)
+	poly := &Poly{
+		[]*big.Int{
+			fr1,
+			fr2,
+			fr3,
+		},
+	}
+
+	result := poly.evaluate(big.NewInt(3))
+	if result.Cmp(expectedFr) != 0 {
+		t.Errorf("results are not equal.")
+	}
+	// PASS
+}
+
+func TestPoly_commitment(t *testing.T) {
+	fr1 := big.NewInt(2)
+	fr2 := big.NewInt(3)
+	fr3 := big.NewInt(4)
+
+	poly := &Poly{
+		coeff: []*big.Int{
+			fr1,
+			fr2,
+			fr3,
+		},
+	}
+
+	com := poly.commitment()
+	result := com.evaluate(big.NewInt(3))
+	t.Logf("%v", com)
+	t.Logf("%v", result)
+}

--- a/crypto/tpke/private_key.go
+++ b/crypto/tpke/private_key.go
@@ -1,0 +1,56 @@
+package tpke
+
+import (
+	"math/big"
+
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+)
+
+type PrivateKey struct {
+	fr *big.Int // A secret number aggregated from DKG sharing
+}
+
+func RandomPrivateKey() *PrivateKey {
+	fr := randScalar()
+	return &PrivateKey{
+		fr: fr,
+	}
+}
+
+// NewPrivateKey returns a tpke private key for threshold decryption
+func NewPrivateKey(secretShares []*big.Int) *PrivateKey {
+	fr := new(big.Int).Set(secretShares[0])
+	// Add up fi
+	for i := 1; i < len(secretShares); i++ {
+		fr.Add(fr, secretShares[i])
+	}
+	return &PrivateKey{
+		fr: fr,
+	}
+}
+
+// GetPublicKey returns a tpke public key for threshold signature
+func (sk *PrivateKey) GetPublicKey() *PublicKey {
+	return &PublicKey{
+		pg1: new(bls12381.G1Affine).ScalarMultiplicationBase(sk.fr),
+	}
+}
+
+// DecryptShare returns a decryption share for input ciphertext
+func (sk *PrivateKey) DecryptShare(ct *CipherText) *DecryptionShare {
+	// S=R1*sk
+	return &DecryptionShare{
+		pg1: new(bls12381.G1Affine).ScalarMultiplication(ct.bigR, sk.fr),
+	}
+}
+
+// SignShare returns a signature share for input message
+func (sk *PrivateKey) SignShare(msg []byte) *SignatureShare {
+	// S=H(msg)*sk
+	g2Hash, _ := bls12381.HashToG2(msg, Domain)
+	sig := new(bls12381.G2Affine).ScalarMultiplication(&g2Hash, sk.fr)
+	sig.Neg(sig)
+	return &SignatureShare{
+		pg2: sig,
+	}
+}

--- a/crypto/tpke/public_key.go
+++ b/crypto/tpke/public_key.go
@@ -1,0 +1,68 @@
+package tpke
+
+import (
+	"math/big"
+
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+)
+
+type PublicKey struct {
+	pg1 *bls12381.G1Affine // A public value for tpke encryption
+}
+
+// NewGlobalPublicKey aggregates and returns a PublicKey
+func NewGlobalPublicKey(cs []*Commitment, scaler int) *PublicKey {
+	pg1 := new(bls12381.G1Affine).Set(cs[0].coeff[0])
+	// Add up A0
+	for i := 1; i < len(cs); i++ {
+		pg1.Add(pg1, cs[i].coeff[0])
+	}
+	pg1.ScalarMultiplication(pg1, big.NewInt(int64(scaler)))
+	return &PublicKey{
+		pg1: pg1,
+	}
+}
+
+// Equal compares if two public keys are the same
+func (pk *PublicKey) Equal(opk *PublicKey) bool {
+	return pk.pg1.Equal(opk.pg1)
+}
+
+// Encrypt returns an encrypted point with encryption commitment
+func (pk *PublicKey) Encrypt(msg *bls12381.G1Affine) *CipherText {
+	r := randScalar()
+
+	// C=M+rpk, R1=rG1, R2=-rG2
+	_, _, _, g2 := bls12381.Generators()
+	bigR1 := new(bls12381.G1Affine).ScalarMultiplicationBase(r)
+	bigR2 := new(bls12381.G2Affine).ScalarMultiplication(&g2, r)
+	bigR2.Neg(bigR2)
+
+	rpk := new(bls12381.G1Affine).ScalarMultiplication(pk.pg1, r)
+	cMsg := new(bls12381.G1Affine).Add(msg, rpk)
+
+	return &CipherText{
+		cMsg:       cMsg,
+		bigR:       bigR1,
+		commitment: bigR2,
+	}
+}
+
+// VerifySigShare verifies a signature in form of a single signature
+func (pk *PublicKey) VerifySigShare(msg []byte, sig *SignatureShare) bool {
+	return pk.VerifySig(msg, (*Signature)(sig))
+}
+
+// VerifySig verifies a signature with corresponding message
+func (pk *PublicKey) VerifySig(msg []byte, sig *Signature) bool {
+	_, _, g1, _ := bls12381.Generators()
+	g2Hash, _ := bls12381.HashToG2(msg, Domain)
+
+	// e(pk,g2Hash)=e(g1,-sig)
+	r, err := bls12381.PairingCheck([]bls12381.G1Affine{*pk.pg1, g1}, []bls12381.G2Affine{g2Hash, *sig.pg2})
+	if err != nil || !r {
+		return false
+	} else {
+		return true
+	}
+}

--- a/crypto/tpke/pvss.go
+++ b/crypto/tpke/pvss.go
@@ -1,0 +1,122 @@
+package tpke
+
+import (
+	"math/big"
+
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+)
+
+type PVSS struct {
+	commitment *Commitment          // The commitment of local secret polynomial
+	r1         *bls12381.G1Affine   // The commitment of of random r
+	r2         *bls12381.G2Affine   // The verifiable commitment of of r1
+	bigf       []*bls12381.G1Affine // The commitment of secret sharing
+}
+
+// GenerateSecretShares takes a random r to generate PVSS
+func GenerateSecretShares(r *big.Int, size int, secret *Secret) (*PVSS, []*big.Int) {
+	_, _, _, g2 := bls12381.Generators()
+	r1 := new(bls12381.G1Affine).ScalarMultiplicationBase(r)
+	r2 := new(bls12381.G2Affine).ScalarMultiplication(&g2, r)
+	r2.Neg(r2)
+	f := make([]*big.Int, size)
+	bigf := make([]*bls12381.G1Affine, size)
+	for i := 0; i < size; i++ {
+		// Start from 1
+		fr := big.NewInt(int64(i + 1))
+		// Compute secret share f(i)
+		f[i] = secret.poly.evaluate(fr)
+		// Compute public share F(i)=f(i)*G1
+		bigf[i] = secret.poly.commitment().evaluate(fr)
+	}
+	return &PVSS{
+		commitment: secret.Commitment(),
+		r1:         r1,
+		r2:         r2,
+		bigf:       bigf,
+	}, f
+}
+
+func (pvss *PVSS) GetCommitment() *Commitment { return pvss.commitment }
+
+func (pvss *PVSS) ToBytes() []byte {
+	arr := make([]byte, 0)
+	arr = append(arr, pvss.commitment.ToBytes()...)
+	arr = append(arr, encodePointG1(pvss.r1)...)
+	arr = append(arr, encodePointG2(pvss.r2)...)
+	for i := 0; i < len(pvss.bigf); i++ {
+		arr = append(arr, encodePointG1(pvss.bigf[i])...)
+	}
+	return arr
+}
+
+func (pvss *PVSS) FromBytes(b []byte, n int, t int) (*PVSS, error) {
+	if len(b) != (t+n+1)*128+256 {
+		return nil, ErrTPKEDecoding
+	}
+	comm, err := new(Commitment).FromBytes(b[:t*128], t)
+	if err != nil {
+		return nil, err
+	}
+	r1, err := decodePointG1(b[t*128 : (t+1)*128])
+	if err != nil {
+		return nil, err
+	}
+	r2, err := decodePointG2(b[(t+1)*128 : (t+1)*128+256])
+	if err != nil {
+		return nil, err
+	}
+	bigf := make([]*bls12381.G1Affine, n)
+	for i := 0; i < n; i++ {
+		pg1, err := decodePointG1(b[(t+1)*128+256+i*128 : (t+1)*128+256+(i+1)*128])
+		if err != nil {
+			return nil, err
+		}
+		bigf[i] = pg1
+	}
+	pvss.commitment = comm
+	pvss.r1 = r1
+	pvss.r2 = r2
+	pvss.bigf = bigf
+	return pvss, nil
+}
+
+// VerifyCommitment verifies a PVSS based on its commitment
+func (pvss *PVSS) VerifyCommitment() bool {
+	_, _, g1, g2 := bls12381.Generators()
+	// Verify e(R1,G2)==e(G1,-R2)
+	r, err := bls12381.PairingCheck([]bls12381.G1Affine{*pvss.r1, g1}, []bls12381.G2Affine{g2, *pvss.r2})
+	if err != nil || !r {
+		return false
+	}
+	for i := 0; i < len(pvss.bigf); i++ {
+		fr := big.NewInt(int64(i + 1))
+		// Verify F(i)==sum(A_{t-1}*i^(t-1))
+		if !pvss.bigf[i].Equal(pvss.commitment.evaluate(fr)) {
+			return false
+		}
+
+	}
+	return true
+}
+
+// VerifySecret verifies a PVSS based on shared secret
+func (pvss *PVSS) VerifySecret(index int, fi *big.Int) bool {
+	_, _, _, g2 := bls12381.Generators()
+	// e(r1*fi,g2)=e(bigfi,-r2)
+	r, err := bls12381.PairingCheck([]bls12381.G1Affine{*new(bls12381.G1Affine).ScalarMultiplication(pvss.r1, fi), *pvss.bigf[index]}, []bls12381.G2Affine{g2, *pvss.r2})
+	if err != nil || !r {
+		return false
+	} else {
+		return true
+	}
+}
+
+// VerifyRenovate verifies if a PVSS renovate correctly for resharing
+func (pvss *PVSS) VerifyRenovate(op *PVSS) bool {
+	// Verify the new pvss bigf has the same A0
+	if len(pvss.commitment.coeff) != len(op.commitment.coeff) {
+		return false
+	}
+	return pvss.commitment.coeff[0].Equal(op.commitment.coeff[0])
+}

--- a/crypto/tpke/pvss_test.go
+++ b/crypto/tpke/pvss_test.go
@@ -1,0 +1,45 @@
+package tpke
+
+import (
+	"math/big"
+	"testing"
+
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+)
+
+func TestPVSSEncoding(t *testing.T) {
+	_, _, g1, g2 := bls12381.Generators()
+	poly := randomPoly(2)
+	comm := poly.commitment()
+	bigf := make([]*bls12381.G1Affine, 3)
+	bigf[0] = comm.evaluate(big.NewInt(1))
+	bigf[1] = comm.evaluate(big.NewInt(2))
+	bigf[2] = comm.evaluate(big.NewInt(3))
+	pvss := &PVSS{
+		commitment: poly.commitment(),
+		r1:         &g1,
+		r2:         &g2,
+		bigf:       bigf,
+	}
+	b := pvss.ToBytes()
+	result, err := new(PVSS).FromBytes(b, 3, 2)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	for i, pg1 := range pvss.commitment.coeff {
+		if !pg1.Equal(result.commitment.coeff[i]) {
+			t.Fatalf("commitment mismatch.")
+		}
+	}
+	if !pvss.r1.Equal(result.r1) {
+		t.Fatalf("r1 mismatch.")
+	}
+	if !pvss.r2.Equal(result.r2) {
+		t.Fatalf("r2 mismatch.")
+	}
+	for i, pg1 := range pvss.bigf {
+		if !pg1.Equal(result.bigf[i]) {
+			t.Fatalf("bigf mismatch.")
+		}
+	}
+}

--- a/crypto/tpke/secrect.go
+++ b/crypto/tpke/secrect.go
@@ -1,0 +1,56 @@
+package tpke
+
+import (
+	"math/big"
+)
+
+type Secret struct {
+	poly *Poly // a local secret polynomial for secret sharing
+}
+
+// RandomSecret returns a random polynomial with zero δ
+func RandomSecret(threshold int) *Secret {
+	return &Secret{
+		poly: randomPoly(threshold),
+	}
+}
+
+// RecoverSecret tries to recover a polynomial with (x,fx) array
+func RecoverSecret(is []int, fis []*big.Int) *Secret {
+	return &Secret{
+		poly: &Poly{
+			coeff: polyRecover(is, fis),
+		},
+	}
+}
+
+// Renovate returns a new secret random a1..an-1 expect a0
+func (s *Secret) Renovate() *Secret {
+	poly := randomPoly(len(s.poly.coeff))
+	poly.coeff[0].Set(s.poly.coeff[0])
+	return &Secret{
+		poly: poly,
+	}
+}
+
+func (s *Secret) Commitment() *Commitment {
+	return s.poly.commitment()
+}
+
+func (s *Secret) Evaluate(x *big.Int) *big.Int {
+	return s.poly.evaluate(x)
+}
+
+func (s *Secret) Equals(other *Secret) bool {
+	if len(s.poly.coeff) != len(other.poly.coeff) {
+		return false
+	}
+
+	for i := range s.poly.coeff {
+		if s.poly.coeff[i].Cmp(other.poly.coeff[i]) != 0 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/crypto/tpke/signature.go
+++ b/crypto/tpke/signature.go
@@ -1,0 +1,94 @@
+package tpke
+
+import (
+	"math/big"
+
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+)
+
+var Domain = []byte("BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_")
+
+type Signature struct {
+	pg2 *bls12381.G2Affine
+}
+
+func NewSignature(pg2 *bls12381.G2Affine) *Signature {
+	return &Signature{
+		pg2: pg2,
+	}
+}
+
+func (s *Signature) Equals(sig *Signature) bool {
+	return s.pg2.Equal(sig.pg2)
+}
+
+// ToBytes encodes a Signature into a byte array whose length is 96
+func (s *Signature) ToBytes() []byte {
+	b := s.pg2.Bytes()
+	return b[:]
+}
+
+// FromBytes decodes a 96-byte array as a Signature
+func (s *Signature) FromBytes(b []byte) (*Signature, error) {
+	if len(b) != 96 {
+		return nil, ErrTPKEDecoding
+	}
+	pg2 := new(bls12381.G2Affine)
+	_, err := pg2.SetBytes(b)
+	if err != nil {
+		return nil, err
+	}
+	s.pg2 = pg2
+	return s, nil
+}
+
+// SignatureShare is the same as Signature, but used for BLS aggregation
+type SignatureShare struct {
+	pg2 *bls12381.G2Affine
+}
+
+// ToBytes encodes a SignatureShare into a byte array whose length is 96
+func (s *SignatureShare) ToBytes() []byte {
+	b := s.pg2.Bytes()
+	return b[:]
+}
+
+// FromBytes decodes a 96-byte array as a SignatureShare
+func (s *SignatureShare) FromBytes(b []byte) (*SignatureShare, error) {
+	pg2 := new(bls12381.G2Affine)
+	_, err := pg2.SetBytes(b)
+	if err != nil {
+		return nil, err
+	}
+	s.pg2 = pg2
+	return s, nil
+}
+
+// AggregateSigShares tries to aggregate SignatureShare to a BLS signature
+// This method takes a batch of SignatureShares and a matrix for Feldman
+// The size of SignatureShare array should be len(message)
+// Each row of the input matrix should be [1, i, i^2, ..., i^(threshold-1)], i is the dkg key index
+// The message amount should be larger than threshold, otherwise the result will be wrong
+func AggregateSigShares(matrix [][]int, shares []*SignatureShare, scaler int) (*Signature, error) {
+	if len(matrix) != len(shares) {
+		return nil, ErrTPKELengthMismatch
+	}
+	// Be aware of the integer overflow when the size and threshold grow big
+	d, coeff := Feldman(matrix)
+	d = scaler / d
+	// Compute d1
+	denominator := big.NewInt(int64(abs(d)))
+	pg2 := new(bls12381.G2Affine)
+	// Add up shares with some factors as d1
+	for i := 0; i < len(shares); i++ {
+		minor := new(bls12381.G2Affine).ScalarMultiplication(shares[i].pg2, big.NewInt(int64(abs(coeff[i]))))
+		if coeff[i] < 0 {
+			minor.Neg(minor)
+		}
+		pg2.Add(pg2, minor)
+	}
+	// Divide d1 by d
+	pg2.ScalarMultiplication(pg2, denominator)
+	// Verify
+	return NewSignature(pg2), nil
+}

--- a/crypto/tpke/util.go
+++ b/crypto/tpke/util.go
@@ -1,0 +1,312 @@
+package tpke
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"math/big"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+	"github.com/consensys/gnark-crypto/ecc/bls12-381/fp"
+)
+
+var (
+	ErrTPKEG1Decoding           = errors.New("crypto/tpke: invalid g1 decoding")
+	ErrTPKEG2Decoding           = errors.New("crypto/tpke: invalid g2 decoding")
+	ErrTPKEFieldElementDecoding = errors.New("crypto/tpke: invalid fe decoding")
+)
+
+func randScalar() *big.Int {
+	a, _ := rand.Int(rand.Reader, ecc.BLS12_381.ScalarField())
+	return a
+}
+
+func randPG1() *bls12381.G1Affine {
+	r := randScalar()
+	return new(bls12381.G1Affine).ScalarMultiplicationBase(r)
+}
+
+func decodePointG1(in []byte) (*bls12381.G1Affine, error) {
+	if len(in) != 128 {
+		return nil, ErrTPKEG1Decoding
+	}
+	// decode x
+	x, err := decodeBLS12381FieldElement(in[:64])
+	if err != nil {
+		return nil, err
+	}
+	// decode y
+	y, err := decodeBLS12381FieldElement(in[64:])
+	if err != nil {
+		return nil, err
+	}
+	elem := bls12381.G1Affine{X: x, Y: y}
+	if !elem.IsOnCurve() {
+		return nil, ErrTPKEG1Decoding
+	}
+
+	return &elem, nil
+}
+
+// decodePointG2 given encoded (x, y) coordinates in 256 bytes returns a valid G2 Point.
+func decodePointG2(in []byte) (*bls12381.G2Affine, error) {
+	if len(in) != 256 {
+		return nil, ErrTPKEG2Decoding
+	}
+	x0, err := decodeBLS12381FieldElement(in[:64])
+	if err != nil {
+		return nil, err
+	}
+	x1, err := decodeBLS12381FieldElement(in[64:128])
+	if err != nil {
+		return nil, err
+	}
+	y0, err := decodeBLS12381FieldElement(in[128:192])
+	if err != nil {
+		return nil, err
+	}
+	y1, err := decodeBLS12381FieldElement(in[192:])
+	if err != nil {
+		return nil, err
+	}
+
+	p := bls12381.G2Affine{X: bls12381.E2{A0: x0, A1: x1}, Y: bls12381.E2{A0: y0, A1: y1}}
+	if !p.IsOnCurve() {
+		return nil, ErrTPKEG2Decoding
+	}
+	return &p, err
+}
+
+// decodeBLS12381FieldElement decodes BLS12-381 elliptic curve field element.
+// Removes top 16 bytes of 64 byte input.
+func decodeBLS12381FieldElement(in []byte) (fp.Element, error) {
+	if len(in) != 64 {
+		return fp.Element{}, ErrTPKEFieldElementDecoding
+	}
+	// check top bytes
+	for i := 0; i < 16; i++ {
+		if in[i] != byte(0x00) {
+			return fp.Element{}, ErrTPKEFieldElementDecoding
+		}
+	}
+	var res [48]byte
+	copy(res[:], in[16:])
+
+	return fp.BigEndian.Element(&res)
+}
+
+// encodePointG1 encodes a point into 128 bytes.
+func encodePointG1(p *bls12381.G1Affine) []byte {
+	out := make([]byte, 128)
+	fp.BigEndian.PutElement((*[fp.Bytes]byte)(out[16:]), p.X)
+	fp.BigEndian.PutElement((*[fp.Bytes]byte)(out[64+16:]), p.Y)
+	return out
+}
+
+// encodePointG2 encodes a point into 256 bytes.
+func encodePointG2(p *bls12381.G2Affine) []byte {
+	out := make([]byte, 256)
+	// encode x
+	fp.BigEndian.PutElement((*[fp.Bytes]byte)(out[16:16+48]), p.X.A0)
+	fp.BigEndian.PutElement((*[fp.Bytes]byte)(out[80:80+48]), p.X.A1)
+	// encode y
+	fp.BigEndian.PutElement((*[fp.Bytes]byte)(out[144:144+48]), p.Y.A0)
+	fp.BigEndian.PutElement((*[fp.Bytes]byte)(out[208:208+48]), p.Y.A1)
+	return out
+}
+
+func polyRecover(xs []int, ys []*big.Int) []*big.Int {
+	if len(xs) != len(ys) {
+		panic("array length mismatch")
+	}
+	// Compute lagrange
+	length := len(ys)
+	ns := make([][]int, length)
+	ds := make([]int, length)
+	for i := 0; i < length; i++ {
+		ns[i], ds[i] = lagrange(xs, i)
+	}
+	bigR := 1
+	for i := 0; i < length; i++ {
+		bigR *= ds[i]
+	}
+	for i := 0; i < length; i++ {
+		div := bigR / ds[i]
+		for j := 0; j < len(ns[i]); j++ {
+			ns[i][j] *= div
+		}
+		ds[i] = bigR
+	}
+
+	// Recover polynomial
+	t := make([]*big.Int, 0)
+	for i := 0; i < length; i++ {
+		poly := make([]*big.Int, len(ns[i]))
+		for j := 0; j < len(ns[i]); j++ {
+			poly[j] = new(big.Int).Mul(big.NewInt(int64(ns[i][j])), ys[i])
+		}
+		t = polyAdd(t, poly)
+	}
+	for i := 0; i < len(t); i++ {
+		t[i] = new(big.Int).Div(t[i], big.NewInt(int64(bigR)))
+	}
+	return t
+}
+
+func lagrange(xs []int, n int) ([]int, int) {
+	numerator := []int{1}
+	for i := 0; i < len(xs); i++ {
+		if n == i {
+			continue
+		}
+		numerator = polyMul(numerator, []int{-xs[i], 1})
+	}
+	denominator := 1
+	for i := 0; i < len(xs); i++ {
+		if n == i {
+			continue
+		}
+		denominator *= xs[n] - xs[i]
+	}
+	return numerator, denominator
+}
+
+// (a0+a1x+a2x^2)*(b0+b1x+b2x^2)
+func polyMul(p1 []int, p2 []int) []int {
+	r := make([]int, len(p1)+len(p2)-1)
+	for i := 0; i < len(p1); i++ {
+		for j := 0; j < len(p2); j++ {
+			r[i+j] += p1[i] * p2[j]
+		}
+	}
+	return r
+}
+
+// (a0+a1x+a2x^2)+(b0+b1x+b2x^2)
+func polyAdd(p1 []*big.Int, p2 []*big.Int) []*big.Int {
+	if len(p1) > len(p2) {
+		r := make([]*big.Int, len(p1))
+		for i := 0; i < len(p2); i++ {
+			r[i] = new(big.Int).Add(p1[i], p2[i])
+		}
+		for i := len(p2); i < len(p1); i++ {
+			r[i] = new(big.Int).Set(p1[i])
+		}
+		return r
+	} else {
+		r := make([]*big.Int, len(p2))
+		for i := 0; i < len(p1); i++ {
+			r[i] = new(big.Int).Add(p1[i], p2[i])
+		}
+		for i := len(p1); i < len(p2); i++ {
+			r[i] = new(big.Int).Set(p2[i])
+		}
+		return r
+	}
+}
+
+func Feldman(matrix [][]int) (int, []int) {
+	// Compute D, D1
+	d, coeff := determinant(matrix, len(matrix))
+	g := d
+	for i := 0; i < len(coeff); i++ {
+		g = gcd(g, coeff[i])
+	}
+	d = d / g
+	for i := 0; i < len(coeff); i++ {
+		coeff[i] = coeff[i] / g
+	}
+	if d < 0 {
+		d = -d
+		for i := 0; i < len(coeff); i++ {
+			coeff[i] = -coeff[i]
+		}
+	}
+	return d, coeff
+}
+
+func determinant(matrix [][]int, order int) (int, []int) {
+	value := 0
+	coeff := make([]int, order)
+	sign := 1
+	if order == 1 {
+		value = matrix[0][0]
+		coeff[0] = 1
+	} else {
+		for i := 0; i < order; i++ {
+			cofactor := laplace(matrix, i, 0, order)
+			value += sign * matrix[i][0] * cofactor
+			coeff[i] = sign * cofactor
+			sign *= -1
+		}
+	}
+	return value, coeff
+}
+
+func laplace(matrix [][]int, r int, c int, order int) int {
+	result := 0
+	cofactor := make([][]int, order)
+	for i := 0; i < order; i++ {
+		cofactor[i] = make([]int, order)
+	}
+	for i := 0; i < order; i++ {
+		for j := 0; j < order; j++ {
+			tmpi := i
+			tmpj := j
+			if i != r && j != c {
+				if i > r {
+					i--
+				}
+				if j > c {
+					j--
+				}
+				cofactor[i][j] = matrix[tmpi][tmpj]
+				i = tmpi
+				j = tmpj
+			}
+		}
+	}
+	if order >= 2 {
+		result, _ = determinant(cofactor, order-1)
+	}
+	return result
+}
+
+func pkcs7Padding(data []byte, blockSize int) []byte {
+	padding := blockSize - len(data)%blockSize
+	if padding == 0 {
+		padding = blockSize
+	}
+	padText := bytes.Repeat([]byte{byte(padding)}, padding)
+	return append(data, padText...)
+}
+
+func pkcs7UnPadding(data []byte) ([]byte, error) {
+	length := len(data)
+	if length == 0 {
+		return nil, errors.New("empty array")
+	}
+	unPadding := int(data[length-1])
+	if length-unPadding < 0 {
+		return nil, errors.New("unpadding failed")
+	}
+	return data[:(length - unPadding)], nil
+}
+
+func gcd(a, b int) int {
+	if b == 0 {
+		return a
+	}
+	if b < 0 {
+		b = -b
+	}
+	return gcd(b, a%b)
+}
+
+func abs(a int) int {
+	if a < 0 {
+		return -a
+	}
+	return a
+}

--- a/crypto/tpke/util_test.go
+++ b/crypto/tpke/util_test.go
@@ -1,0 +1,55 @@
+package tpke
+
+import (
+	"math/big"
+	"testing"
+)
+
+func TestRecover(t *testing.T) {
+	s := randomPoly(5)
+	p := polyRecover([]int{1, 2, 3, 4, 5}, []*big.Int{s.evaluate(big.NewInt(1)), s.evaluate(big.NewInt(2)), s.evaluate(big.NewInt(3)), s.evaluate(big.NewInt(4)), s.evaluate(big.NewInt(5))})
+	if p[0].Cmp(s.coeff[0]) != 0 || p[1].Cmp(s.coeff[1]) != 0 || p[2].Cmp(s.coeff[2]) != 0 || p[3].Cmp(s.coeff[3]) != 0 || p[4].Cmp(s.coeff[4]) != 0 {
+		t.Fatalf("recover failed.")
+	}
+}
+
+func TestDeterminant(t *testing.T) {
+	matrix := [][]int{{7, 8, 9, 4, 3}, {4, 9, 7, 0, 0}, {3, 6, 1, 0, 0}, {0, 5, 6, 0, 0}, {0, 6, 8, 0, 0}}
+	result, _ := determinant(matrix, len(matrix))
+	if result != 0 {
+		t.Fatalf("test failed. %v", result)
+	}
+	matrix = [][]int{{6, 5, 4, 3, 2}, {4, 9, 7, 0, 0}, {3, 6, 1, 0, 0}, {0, 5, 6, 0, 0}, {0, 6, 8, 0, 0}}
+	result, _ = determinant(matrix, len(matrix))
+	if result != 0 {
+		t.Fatalf("test failed. %v", result)
+	}
+	matrix = [][]int{{6, 5, 4, 3, 2}, {7, 8, 9, 4, 3}, {3, 6, 1, 0, 0}, {0, 5, 6, 0, 0}, {0, 6, 8, 0, 0}}
+	result, _ = determinant(matrix, len(matrix))
+	if result != 12 {
+		t.Fatalf("test failed. %v", result)
+	}
+	matrix = [][]int{{6, 5, 4, 3, 2}, {7, 8, 9, 4, 3}, {4, 9, 7, 0, 0}, {0, 5, 6, 0, 0}, {0, 6, 8, 0, 0}}
+	result, _ = determinant(matrix, len(matrix))
+	if result != 16 {
+		t.Fatalf("test failed. %v", result)
+	}
+	matrix = [][]int{{6, 5, 4, 3, 2}, {7, 8, 9, 4, 3}, {4, 9, 7, 0, 0}, {3, 6, 1, 0, 0}, {0, 6, 8, 0, 0}}
+	result, _ = determinant(matrix, len(matrix))
+	if result != 78 {
+		t.Fatalf("test failed. %v", result)
+	}
+	matrix = [][]int{{6, 5, 4, 3, 2}, {7, 8, 9, 4, 3}, {4, 9, 7, 0, 0}, {3, 6, 1, 0, 0}, {0, 5, 6, 0, 0}}
+	result, _ = determinant(matrix, len(matrix))
+	if result != 67 {
+		t.Fatalf("test failed. %v", result)
+	}
+	matrix = [][]int{{7, 6, 5, 4, 3, 2}, {9, 7, 8, 9, 4, 3}, {7, 4, 9, 7, 0, 0}, {5, 3, 6, 1, 0, 0}, {0, 0, 5, 6, 0, 0}, {0, 0, 6, 8, 0, 0}}
+	result, coeff := determinant(matrix, len(matrix))
+	if result != 4 {
+		t.Fatalf("test failed. %v", result)
+	}
+	if coeff[0]*7+coeff[1]*9+coeff[2]*7+coeff[3]*5+coeff[4]*0+coeff[5]*0 != result {
+		t.Fatalf("test failed.")
+	}
+}


### PR DESCRIPTION
Close #300.

Some implemented codes from branch [antimev-crypto-bls12381](https://github.com/bane-labs/go-ethereum/tree/antimev-crypto-bls12381), without contract and zero knowledge, not integrated with anything else.

1. Some necessary methods from [kilic/bls12-381](https://github.com/kilic/bls12-381) are imported;
2. A tpke library that defines some data structures, with their constructing and encoding;
3. A keystore module that provides key management service, with encryption, decryption, and signature.