### PR TITLE
dbft: fix Extensible sender verification

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -460,12 +459,8 @@ func New(config *params.DBFTConfig, _ ethdb.Database) (*DBFT, error) {
 				return
 			}
 
-			var sorted = make([]common.Hash, len(hashes))
-			copy(sorted, hashes)
-			sort.Slice(sorted, func(i, j int) bool {
-				return sorted[i].Cmp(sorted[j]) < 0
-			})
-
+			sorted := slices.Clone(hashes)
+			slices.SortFunc(sorted, common.Hash.Cmp)
 			c.txCbList.Store(sorted)
 
 			c.requestTxs(sorted)
@@ -1621,11 +1616,8 @@ func (c *DBFT) OnTransaction(txs []*types.Transaction) {
 	var cbList = c.txCbList.Load()
 	if cbList != nil {
 		for _, tx := range txs {
-			var list = cbList.([]common.Hash)
-			var i = sort.Search(len(list), func(i int) bool {
-				return list[i].Cmp(tx.Hash()) >= 0
-			})
-			if i < len(list) && list[i].Cmp(tx.Hash()) == 0 {
+			_, found := slices.BinarySearchFunc(cbList.([]common.Hash), tx.Hash(), common.Hash.Cmp)
+			if found {
 				c.txs <- tx
 			}
 		}

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1669,8 +1669,8 @@ func (c *DBFT) IsExtensibleAllowed(h uint64, u common.Address) error {
 	if err != nil {
 		return fmt.Errorf("failed to get validators: %w", err)
 	}
-	n := sort.Search(len(validators), func(i int) bool { return validators[i].Cmp(u) >= 0 })
-	if n >= len(validators) {
+	_, found := slices.BinarySearchFunc(validators, u, common.Address.Cmp)
+	if !found {
 		return fmt.Errorf("address is not a validator")
 	}
 	return nil


### PR DESCRIPTION
Ported from https://github.com/nspcc-dev/neo-go/pull/3563/commits/5431b31d84e5f7c2fc0285cd02d4a33720073ac3.