### PR TITLE
dbft: fix TestRecoverMessage_RLP

### DIFF
--- a/consensus/dbft/recovery_message_test.go
+++ b/consensus/dbft/recovery_message_test.go
@@ -48,7 +48,14 @@ func TestRecoverMessage_RLP(t *testing.T) {
 	rm := &recoveryMessage{
 		PreparationHashExt: &common.Hash{1, 2},
 		PreparationPayloads: []*preparationCompact{
-			{ValidatorIndex: 1, InvocationScript: []byte{1, 2, 3}}},
+			{ValidatorIndex: 1, InvocationScript: []byte{1, 2, 3}},
+		},
+		PreCommitPayloads: []*preCommitCompact{{
+			ViewNumber:       1,
+			ValidatorIndex:   2,
+			Data:             []byte{1, 2, 3},
+			InvocationScript: []byte{3, 4, 5},
+		}},
 		CommitPayloads:     []*commitCompact{{ViewNumber: 1, ValidatorIndex: 1, Signature: sign, InvocationScript: []byte{1, 2, 3, 4, 5}}},
 		ChangeViewPayloads: []*changeViewCompact{{ValidatorIndex: 1, OriginalViewNumber: 2, Timestamp: 3, InvocationScript: []byte{1, 2, 3, 4, 5, 6}}},
 		PrepareRequest: &message{


### PR DESCRIPTION
```
--- FAIL: TestRecoverMessage_RLP (0.00s)
    recovery_message_test.go:69:
        	Error Trace:	/home/anna/Documents/GitProjects/bane-labs/go-ethereum/consensus/dbft/recovery_message_test.go:69
        	Error:      	Not equal:
        	            	expected: &dbft.recoveryMessage{PreparationPayloads:[]*dbft.preparationCompact{(*dbft.preparationCompact)(0xc00049a560)}, PreCommitPayloads:[]*dbft.preCommitCompact(nil), CommitPayloads:[]*dbft.commitCompact{(*dbft.commitCompact)(0xc0000a1020)}, ChangeViewPayloads:[]*dbft.changeViewCompact{(*dbft.changeViewCompact)(0xc0000b96b0)}, PreparationHashExt:0x0102000000000000000000000000000000000000000000000000000000000000, PrepareRequest:(*dbft.message)(0xc0000b96e0)}
        	            	actual  : &dbft.recoveryMessage{PreparationPayloads:[]*dbft.preparationCompact{(*dbft.preparationCompact)(0xc00049a700)}, PreCommitPayloads:[]*dbft.preCommitCompact{}, CommitPayloads:[]*dbft.commitCompact{(*dbft.commitCompact)(0xc0000a1b00)}, ChangeViewPayloads:[]*dbft.changeViewCompact{(*dbft.changeViewCompact)(0xc00049f440)}, PreparationHashExt:0x0102000000000000000000000000000000000000000000000000000000000000, PrepareRequest:(*dbft.message)(0xc00049f4a0)}

        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -9,3 +9,4 @@
        	            	  },
        	            	- PreCommitPayloads: ([]*dbft.preCommitCompact) <nil>,
        	            	+ PreCommitPayloads: ([]*dbft.preCommitCompact) {
        	            	+ },
        	            	  CommitPayloads: ([]*dbft.commitCompact) (len=1) {
        	Test:       	TestRecoverMessage_RLP
FAIL

```