### PR TITLE
antimev: update keystore behaviors for integration

### DIFF
--- a/antimev/keygroup.go
+++ b/antimev/keygroup.go
@@ -185,10 +185,12 @@ func (tkg *thresholdKeyGroup) dkgReshare(target *thresholdKeyGroup) ([][]byte, *
 	return generateShareMessages(tkg.localSecret.Renovate(), target.holders)
 }
 
+// dkgReshareRecovered tries to recover a dkg secret, and returns an error if
+// the attempt fails when shares are not enough.
 func (tkg *thresholdKeyGroup) dkgReshareRecovered(threshold int, target *thresholdKeyGroup) ([][]byte, *tpke.PVSS, error) {
-	// Do nothing if not a receiver
-	if tkg.holderIndex(tkg.selfAddr) < 1 {
-		return nil, nil, nil
+	// Return an error if not able to recover
+	if tkg.holderIndex(tkg.selfAddr) < 1 || len(tkg.receivedSecrets) < threshold {
+		return nil, nil, ErrInvalidRecover
 	}
 	// Collect all shares
 	is := make([]int, 0)
@@ -198,9 +200,6 @@ func (tkg *thresholdKeyGroup) dkgReshareRecovered(threshold int, target *thresho
 			is = append(is, i+1)
 			fis = append(fis, ss)
 		}
-	}
-	if len(tkg.receivedSecrets) < threshold {
-		return nil, nil, ErrInvalidRecover
 	}
 	// Recover the secret
 	tkg.localSecret = tpke.RecoverSecret(is[:threshold], fis[:threshold])

--- a/antimev/keystore.go
+++ b/antimev/keystore.go
@@ -19,7 +19,8 @@ import (
 var (
 	ErrInvalidLength     = errors.New("invalid array length")
 	ErrInvalidThreshold  = errors.New("invalid threshold")
-	ErrNotParticipant    = errors.New("not dkg participant")
+	ErrInvalidSender     = errors.New("invalid message sender")
+	ErrKeyGroupNotExists = errors.New("required keygroup not found")
 	ErrUnrecoverable     = errors.New("unrecoverable sharing")
 	ErrMessageDecryption = errors.New("message decryption failed")
 )
@@ -131,41 +132,64 @@ func (ks *KeyStore) HasShared() bool {
 }
 
 // OnValidatorList initializes sharing and resharing, should be called
-// when the key group members are determined. It returns resharing
-// messages immediately.
-func (ks *KeyStore) OnValidatorList(validators []common.Address, pubkeys []*ecies.PublicKey) ([][]byte, []byte, error) {
+// when the key group members are determined. It returns sharing and
+// resharing messages immediately.
+func (ks *KeyStore) OnValidatorList(validators []common.Address, pubkeys []*ecies.PublicKey) ([][]byte, []byte, [][]byte, []byte, error) {
 	ks.mu.Lock()
 	defer ks.mu.Unlock()
 	if len(validators) != ks.size || len(pubkeys) != ks.size {
-		return nil, nil, ErrInvalidLength
+		return nil, nil, nil, nil, ErrInvalidLength
 	}
-	// Set up groups for dkg sharing and resharing
+	rMsgs, rPvss, err := ks.startReshare(validators, pubkeys)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	sMsgs, sPvss, err := ks.startShare(validators, pubkeys)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	err = ks.saveStoreAndReInitialize()
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	return sMsgs, sPvss, rMsgs, rPvss, nil
+}
+
+// startReshare initializes resharing keygroup and returns messages and pvss.
+func (ks *KeyStore) startReshare(validators []common.Address, pubkeys []*ecies.PublicKey) ([][]byte, []byte, error) {
+	// Set up groups for dkg resharing
 	if ks.shared != nil {
 		ks.resharing = ks.shared.newTemplateForReshare(validators, pubkeys)
-	}
-	ks.sharing = newThresholdKeyGroup(ks.address, validators, pubkeys)
-	// Resharing doesn't require persistence, so store here
-	err := ks.saveStoreAndReInitialize()
-	if err != nil {
-		return nil, nil, err
-	}
-	// Generate secret resharing messages and pvss
-	if ks.resharing != nil {
-		rMsgs, pvss, err := ks.shared.dkgReshare(ks.resharing)
-		if err != nil || pvss == nil {
+		// Generate secret resharing messages and pvss
+		rMsgs, rPvss, err := ks.shared.dkgReshare(ks.resharing)
+		if err != nil || rPvss == nil {
 			return nil, nil, err
 		}
-		return rMsgs, pvss.Encode(), nil
+		return rMsgs, rPvss.Encode(), nil
 	}
-	// Nothing to reshare
 	return nil, nil, nil
 }
 
-func (ks *KeyStore) OnRecoverStart(indexes []int, validators []common.Address, pubkeys []*ecies.PublicKey) ([][]byte, error) {
+// startShare initializes sharing keygroup and returns messages and pvss.
+func (ks *KeyStore) startShare(validators []common.Address, pubkeys []*ecies.PublicKey) ([][]byte, []byte, error) {
+	// Set groups for dkg sharing
+	ks.sharing = newThresholdKeyGroup(ks.address, validators, pubkeys)
+	// Generate secret sharing messages and pvss
+	sMsgs, sPvss, err := ks.sharing.dkgPrepare(ks.threshold)
+	if err != nil || sPvss == nil {
+		return nil, nil, err
+	}
+	return sMsgs, sPvss.Encode(), nil
+}
+
+// StartRecover initializes a new keygroup for recovering, should be called
+// once the resharing and sharing period finishes. Nothing happens if no
+// recovery is necessary, but returns an error if not recoverable.
+func (ks *KeyStore) StartRecover(indexes []int, validators []common.Address, pubkeys []*ecies.PublicKey) ([][]byte, error) {
 	ks.mu.Lock()
 	defer ks.mu.Unlock()
 	if ks.shared == nil {
-		return nil, nil
+		return nil, ErrKeyGroupNotExists
 	}
 	if len(validators) != len(indexes) || len(pubkeys) != len(indexes) {
 		return nil, ErrInvalidLength
@@ -189,11 +213,15 @@ func (ks *KeyStore) OnRecoverStart(indexes []int, validators []common.Address, p
 	return ks.shared.dkgRecover(indexes, pubkeys)
 }
 
-// OnRecoverFinish tries to finish ongoing recovering, should be called when
-// resharing fails. It returns resharing messages immediately if recoverd.
-func (ks *KeyStore) OnRecoverFinish() ([][]byte, []byte, error) {
+// TryRecoverReshare tries to recover a resharing message, should be called when
+// resharing fails and receives a recover message. It returns resharing messages
+// immediately if recoverd, otherwise an error.
+func (ks *KeyStore) TryRecoverReshare() ([][]byte, []byte, error) {
 	ks.mu.Lock()
 	defer ks.mu.Unlock()
+	if ks.recovering == nil {
+		return nil, nil, ErrKeyGroupNotExists
+	}
 	msgs, pvss, err := ks.recovering.dkgReshareRecovered(ks.threshold, ks.resharing)
 	if err != nil || pvss == nil {
 		return nil, nil, err
@@ -206,60 +234,68 @@ func (ks *KeyStore) OnRecoverFinish() ([][]byte, []byte, error) {
 	return msgs, pvss.Encode(), nil
 }
 
-// OnReshareFinish tries to finish ongoing resharing, should be called before
-// the new round sharing. It returns sharing messages immediately.
-func (ks *KeyStore) OnReshareFinish() ([][]byte, []byte, error) {
-	ks.mu.Lock()
-	defer ks.mu.Unlock()
-	// Check if resharing are finished and aggregate keys
-	if ks.resharing != nil {
-		err := ks.resharing.dkgAggregate(ks.scaler)
-		if err != nil {
-			return nil, nil, err
-		}
-	}
-	// Generate secret sharing messages and pvss
-	sMsgs, pvss, err := ks.sharing.dkgPrepare(ks.threshold)
-	if err != nil || pvss == nil {
-		return nil, nil, err
-	}
-	// Store only if some secret is generated
-	err = ks.saveStoreAndReInitialize()
-	if err != nil {
-		return nil, nil, err
-	}
-	return sMsgs, pvss.Encode(), nil
-}
-
-// OnEpochChange tries to finish ongoing sharing, should be called before
-// the key group is needed for encryption and signing.
+// OnEpochChange checks and settles the results of sharing and resharing, will
+// revert both of them of any of them is not successful.
+// This method should only be called in the end of dkg, otherwise use
+// AggregateShare to check if sharing is successful.
 func (ks *KeyStore) OnEpochChange() error {
-	ks.mu.Lock()
-	defer ks.mu.Unlock()
-	// Check if sharing are finished and aggregate keys
-	if ks.sharing != nil {
-		err := ks.sharing.dkgAggregate(ks.scaler)
-		if err != nil {
-			return err
-		}
+	// Revert dkg if resharing failed
+	err := ks.aggregateReshare()
+	if err != nil {
+		ks.resharing = nil
+		ks.sharing = nil
+		ks.recovering = nil
+		return ks.saveStoreAndReInitialize()
+	}
+	// Revert dkg if sharing failed
+	err = ks.aggregateShare()
+	if err != nil {
+		ks.resharing = nil
+		ks.sharing = nil
+		ks.recovering = nil
+		return ks.saveStoreAndReInitialize()
 	}
 	// Set finished dkg as current using
 	ks.reshared = ks.resharing
 	ks.resharing = nil
 	ks.shared = ks.sharing
 	ks.sharing = nil
-
+	ks.recovering = nil
 	return ks.saveStoreAndReInitialize()
+}
+
+// aggregateShare tries to check if sharing is successful and settle the result
+func (ks *KeyStore) aggregateShare() error {
+	// Check if sharing is successful and aggregate keys
+	if ks.sharing == nil {
+		return ErrKeyGroupNotExists
+	}
+	return ks.sharing.dkgAggregate(ks.scaler)
+}
+
+// aggregateReshare tries to check if resharing is successful and settle the result
+func (ks *KeyStore) aggregateReshare() error {
+	// Check if resharing is successful and aggregate keys
+	if ks.resharing != nil {
+		return ks.resharing.dkgAggregate(ks.scaler)
+	}
+	return nil
 }
 
 // ReceiveSecretShare tries to verify a sharing message array and store their data.
 func (ks *KeyStore) ReceiveSecretShare(from common.Address, ess [][]byte, pvss []byte) error {
 	ks.mu.Lock()
 	defer ks.mu.Unlock()
+	// Check if out of the period
+	if ks.sharing == nil {
+		return ErrKeyGroupNotExists
+	}
+	// Check sender's identity
 	fromIndex := ks.sharing.holderIndex(from)
 	if fromIndex > ks.size || fromIndex < 1 {
-		return ErrNotParticipant
+		return ErrInvalidSender
 	}
+	// Decode PVSS
 	p, err := new(tpke.PVSS).Decode(pvss, ks.size, ks.threshold)
 	if err != nil {
 		return ErrDKGPVSS
@@ -267,6 +303,7 @@ func (ks *KeyStore) ReceiveSecretShare(from common.Address, ess [][]byte, pvss [
 	// If is a member of receiver
 	selfIndex := ks.sharing.holderIndex(ks.address)
 	if selfIndex > 0 {
+		// Decrypt and accept the sharing message
 		ss, err := ks.decryptSecretShare(ess[selfIndex-1])
 		if err != nil {
 			return ErrDecryptionFailed
@@ -275,24 +312,30 @@ func (ks *KeyStore) ReceiveSecretShare(from common.Address, ess [][]byte, pvss [
 		if err != nil {
 			return err
 		}
-		return ks.saveStoreAndReInitialize()
 	} else {
+		// Only accept the PVSS
 		err = ks.sharing.receiveShareMessage(fromIndex, nil, p)
 		if err != nil {
 			return err
 		}
-		return ks.saveStoreAndReInitialize()
 	}
+	return ks.saveStoreAndReInitialize()
 }
 
 // ReceiveSecretReshare tries to verify a resharing message array and store their data.
 func (ks *KeyStore) ReceiveSecretReshare(from common.Address, ers [][]byte, pvss []byte) error {
 	ks.mu.Lock()
 	defer ks.mu.Unlock()
+	// Check if out of the period
+	if ks.shared == nil || ks.resharing == nil {
+		return ErrKeyGroupNotExists
+	}
+	// Check sender's identity
 	fromIndex := ks.shared.holderIndex(from)
 	if fromIndex > ks.size || fromIndex < 1 {
-		return ErrNotParticipant
+		return ErrInvalidSender
 	}
+	// Decode PVSS
 	p, err := new(tpke.PVSS).Decode(pvss, ks.size, ks.threshold)
 	if err != nil {
 		return ErrDKGPVSS
@@ -300,6 +343,7 @@ func (ks *KeyStore) ReceiveSecretReshare(from common.Address, ers [][]byte, pvss
 	// If is a member of receiver
 	selfIndex := ks.resharing.holderIndex(ks.address)
 	if selfIndex > 0 {
+		// Decrypt and accept the resharing message
 		ss, err := ks.decryptSecretShare(ers[selfIndex-1])
 		if err != nil {
 			return ErrDecryptionFailed
@@ -308,24 +352,30 @@ func (ks *KeyStore) ReceiveSecretReshare(from common.Address, ers [][]byte, pvss
 		if err != nil {
 			return err
 		}
-		return ks.saveStoreAndReInitialize()
 	} else {
+		// Only accept the PVSS
 		err = ks.resharing.receiveReshareMessage(fromIndex, nil, p)
 		if err != nil {
 			return err
 		}
-		return ks.saveStoreAndReInitialize()
 	}
+	return ks.saveStoreAndReInitialize()
 }
 
 // ReceiveRecoveredReshare tries to verify a resharing message array and store their data.
 func (ks *KeyStore) ReceiveRecoveredReshare(from common.Address, ers [][]byte, pvss []byte) error {
 	ks.mu.Lock()
 	defer ks.mu.Unlock()
+	// Check if out of the period
+	if ks.recovering == nil || ks.resharing == nil {
+		return ErrKeyGroupNotExists
+	}
+	// Check sender's identity
 	fromIndex := ks.recovering.holderIndex(from)
 	if fromIndex > ks.size || fromIndex < 1 {
-		return ErrNotParticipant
+		return ErrInvalidSender
 	}
+	// Decode PVSS
 	p, err := new(tpke.PVSS).Decode(pvss, ks.size, ks.threshold)
 	if err != nil {
 		return ErrDKGPVSS
@@ -333,6 +383,7 @@ func (ks *KeyStore) ReceiveRecoveredReshare(from common.Address, ers [][]byte, p
 	// If is a member of receiver
 	selfIndex := ks.resharing.holderIndex(ks.address)
 	if selfIndex > 0 {
+		// Decrypt and accept the recoverd resharing message
 		ss, err := ks.decryptSecretShare(ers[selfIndex-1])
 		if err != nil {
 			return ErrDecryptionFailed
@@ -341,27 +392,33 @@ func (ks *KeyStore) ReceiveRecoveredReshare(from common.Address, ers [][]byte, p
 		if err != nil {
 			return err
 		}
-		return ks.saveStoreAndReInitialize()
 	} else {
+		// Only accept the PVSS
 		err = ks.resharing.receiveReshareMessage(fromIndex, nil, p)
 		if err != nil {
 			return err
 		}
-		return ks.saveStoreAndReInitialize()
 	}
+	return ks.saveStoreAndReInitialize()
 }
 
 // ReceiveRecoverShare tries to verify a recovering message array and store their data.
 func (ks *KeyStore) ReceiveRecoverShare(from common.Address, ers []byte) error {
 	ks.mu.Lock()
 	defer ks.mu.Unlock()
+	// Check if out of the period
+	if ks.shared == nil || ks.recovering == nil {
+		return ErrKeyGroupNotExists
+	}
+	// Check sender's identity
 	fromIndex := ks.shared.holderIndex(from)
 	if fromIndex > ks.size || fromIndex < 1 {
-		return ErrNotParticipant
+		return ErrInvalidSender
 	}
 	// If is a member of receiver
 	selfIndex := ks.recovering.holderIndex(ks.address)
 	if selfIndex > 0 {
+		// Decrypt and accept the recovering message
 		ss, err := ks.decryptSecretShare(ers)
 		if err != nil {
 			return ErrDecryptionFailed

--- a/antimev/keystore_test.go
+++ b/antimev/keystore_test.go
@@ -60,7 +60,7 @@ type MockContractStorage struct {
 	recoverMsgs   [][][]byte
 }
 
-func TestDKG(t *testing.T) {
+func TestShare(t *testing.T) {
 	source := rand.NewSource(time.Now().UnixNano())
 	random := rand.New(source)
 	dir := t.TempDir()
@@ -91,12 +91,8 @@ func TestDKG(t *testing.T) {
 		valList[i] = cns[i].addr
 	}
 	for i := 0; i < size; i++ {
-		_, _, err := kss[i].OnValidatorList(valList, pubs)
-		if err != nil {
-			t.Fatalf(err.Error())
-		}
 		// No reshare to handle
-		msgs, pvss, err := kss[i].OnReshareFinish()
+		msgs, pvss, _, _, err := kss[i].OnValidatorList(valList, pubs)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -112,9 +108,14 @@ func TestDKG(t *testing.T) {
 			}
 		}
 	}
-	// Only check sharing
 	for i := 0; i < size; i++ {
-		err := kss[i].OnEpochChange()
+		// Only check sharing
+		err := kss[i].aggregateShare()
+		if err != nil {
+			t.Fatalf(err.Error())
+		}
+		// Try finish DKG without resharing
+		err = kss[i].OnEpochChange()
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -154,12 +155,8 @@ func TestReshare(t *testing.T) {
 		valList[i] = cns[i].addr
 	}
 	for i := 0; i < size; i++ {
-		_, _, err := kss[i].OnValidatorList(valList, pubs)
-		if err != nil {
-			t.Fatalf(err.Error())
-		}
-		// No reshare to handle
-		msgs, pvss, err := kss[i].OnReshareFinish()
+		// No resharing to handle
+		msgs, pvss, _, _, err := kss[i].OnValidatorList(valList, pubs)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -184,12 +181,14 @@ func TestReshare(t *testing.T) {
 	}
 	// Execute resharing this time
 	for i := 0; i < size; i++ {
-		msgs, pvss, err := kss[i].OnValidatorList(valList, pubs)
+		sMsgs, sPvss, rMsgs, rPvss, err := kss[i].OnValidatorList(valList, pubs)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
-		contract.reshareMsgs[i] = msgs
-		contract.resharePVSSes[i] = pvss
+		contract.shareMsgs[i] = sMsgs
+		contract.sharePVSSes[i] = sPvss
+		contract.reshareMsgs[i] = rMsgs
+		contract.resharePVSSes[i] = rPvss
 	}
 	// Send resharing messages
 	for i := 0; i < size; i++ {
@@ -198,11 +197,15 @@ func TestReshare(t *testing.T) {
 			if err != nil {
 				t.Fatalf(err.Error())
 			}
+			err = kss[i].ReceiveSecretShare(kss[j].address, contract.shareMsgs[j], contract.sharePVSSes[j])
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
 		}
 	}
-	// Only check resharing
+	// Check sharing and resharing
 	for i := 0; i < size; i++ {
-		_, _, err := kss[i].OnReshareFinish()
+		err := kss[i].OnEpochChange()
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -239,28 +242,28 @@ func TestGroupChange(t *testing.T) {
 	}
 	// Ignore resharing and execute sharing
 	contract := &MockContractStorage{
-		reshareMsgs:   make([][][]byte, 0),
-		resharePVSSes: make([][]byte, 0),
-		shareMsgs:     make([][][]byte, 0),
-		sharePVSSes:   make([][]byte, 0),
+		reshareMsgs:   make([][][]byte, size),
+		resharePVSSes: make([][]byte, size),
+		shareMsgs:     make([][][]byte, size),
+		sharePVSSes:   make([][]byte, size),
 	}
 	for i := 0; i < len(addrs); i++ {
-		_, _, err := kss[i].OnValidatorList(addrs[:size], pubs[:size])
+		// No resharing to handle
+		msgs, pvss, _, _, err := kss[i].OnValidatorList(addrs[:size], pubs[:size])
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
-		// No reshare to handle
-		msgs, pvss, err := kss[i].OnReshareFinish()
-		if err != nil {
-			t.Fatalf(err.Error())
+		// Sharing members
+		if i < size {
+			contract.shareMsgs[i] = msgs
+			contract.sharePVSSes[i] = pvss
 		}
-		if len(msgs) > 0 {
-			contract.sharePVSSes = append(contract.sharePVSSes, pvss)
-			contract.shareMsgs = append(contract.shareMsgs, msgs)
+		// Not a member
+		if i == size {
+			if len(msgs) > 0 || len(pvss) > 0 {
+				t.Fatalf("Only member should share secrets")
+			}
 		}
-	}
-	if len(contract.sharePVSSes) != size || len(contract.shareMsgs) != size {
-		t.Fatalf("invalid message amount")
 	}
 	// Send secret sharing messages, broadcast to all nodes
 	for i := 0; i < len(addrs); i++ {
@@ -280,17 +283,21 @@ func TestGroupChange(t *testing.T) {
 	}
 	// Execute resharing this time
 	for i := 0; i < len(addrs); i++ {
-		msgs, pvss, err := kss[i].OnValidatorList(addrs[1:], pubs[1:])
+		_, _, rMsgs, rPvss, err := kss[i].OnValidatorList(addrs[1:], pubs[1:])
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
-		if len(msgs) > 0 {
-			contract.resharePVSSes = append(contract.resharePVSSes, pvss)
-			contract.reshareMsgs = append(contract.reshareMsgs, msgs)
+		// Resharing members
+		if i < size {
+			contract.reshareMsgs[i] = rMsgs
+			contract.resharePVSSes[i] = rPvss
 		}
-	}
-	if len(contract.reshareMsgs) != size {
-		t.Fatalf("invalid message amount")
+		// Not a member
+		if i == size {
+			if len(rMsgs) > 0 || len(rPvss) > 0 {
+				t.Fatalf("Only member should reshare secrets")
+			}
+		}
 	}
 	// Send resharing messages, broadcast to all nodes
 	for i := 0; i < len(addrs); i++ {
@@ -303,7 +310,7 @@ func TestGroupChange(t *testing.T) {
 	}
 	// Only check resharing
 	for i := 0; i < len(addrs); i++ {
-		_, _, err := kss[i].OnReshareFinish()
+		err := kss[i].aggregateReshare()
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -340,29 +347,29 @@ func TestRecover(t *testing.T) {
 	}
 	// Ignore resharing and execute sharing
 	contract := &MockContractStorage{
-		reshareMsgs:   make([][][]byte, 0),
-		resharePVSSes: make([][]byte, 0),
-		shareMsgs:     make([][][]byte, 0),
-		sharePVSSes:   make([][]byte, 0),
-		recoverMsgs:   make([][][]byte, 0),
+		reshareMsgs:   make([][][]byte, size),
+		resharePVSSes: make([][]byte, size),
+		shareMsgs:     make([][][]byte, size),
+		sharePVSSes:   make([][]byte, size),
+		recoverMsgs:   make([][][]byte, size),
 	}
 	for i := 0; i < len(addrs); i++ {
-		_, _, err := kss[i].OnValidatorList(addrs[:size], pubs[:size])
+		// No resharing to handle
+		msgs, pvss, _, _, err := kss[i].OnValidatorList(addrs[:size], pubs[:size])
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
-		// No reshare to handle
-		msgs, pvss, err := kss[i].OnReshareFinish()
-		if err != nil {
-			t.Fatalf(err.Error())
+		// Sharing members
+		if i < size {
+			contract.shareMsgs[i] = msgs
+			contract.sharePVSSes[i] = pvss
 		}
-		if len(msgs) > 0 {
-			contract.sharePVSSes = append(contract.sharePVSSes, pvss)
-			contract.shareMsgs = append(contract.shareMsgs, msgs)
+		// Not a member
+		if i == size {
+			if len(msgs) > 0 || len(pvss) > 0 {
+				t.Fatalf("Only member should share secrets")
+			}
 		}
-	}
-	if len(contract.shareMsgs) != size {
-		t.Fatalf("invalid message amount")
 	}
 	// Send secret sharing messages, broadcast to all nodes
 	for i := 0; i < len(addrs); i++ {
@@ -382,19 +389,23 @@ func TestRecover(t *testing.T) {
 	}
 	// Execute resharing this time
 	for i := 0; i < len(addrs); i++ {
-		msgs, pvss, err := kss[i].OnValidatorList(addrs[1:], pubs[1:])
+		_, _, rMsgs, rPvss, err := kss[i].OnValidatorList(addrs[1:], pubs[1:])
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
-		if len(msgs) > 0 {
-			contract.reshareMsgs = append(contract.reshareMsgs, msgs)
-			contract.resharePVSSes = append(contract.resharePVSSes, pvss)
+		// Resharing members
+		if i < size {
+			contract.reshareMsgs[i] = rMsgs
+			contract.resharePVSSes[i] = rPvss
+		}
+		// Not a member
+		if i == size {
+			if len(rMsgs) > 0 || len(rPvss) > 0 {
+				t.Fatalf("Only member should reshare secrets")
+			}
 		}
 	}
-	if len(contract.reshareMsgs) != size {
-		t.Fatalf("invalid message amount")
-	}
-	// Send resharing messages, expect validator 7
+	// Send resharing messages, expect which from validator 7
 	for i := 0; i < len(addrs); i++ {
 		for j := 0; j < size-1; j++ {
 			err := kss[i].ReceiveSecretReshare(kss[j].address, contract.reshareMsgs[j], contract.resharePVSSes[j])
@@ -408,17 +419,14 @@ func TestRecover(t *testing.T) {
 	rAddrs := []common.Address{addrs[7]}
 	rPubs := []*ecies.PublicKey{pubs[7]}
 	for i := 0; i < len(addrs); i++ {
-		msgs, err := kss[i].OnRecoverStart(rIdxs, rAddrs, rPubs)
+		msgs, err := kss[i].StartRecover(rIdxs, rAddrs, rPubs)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
 		// Length of msgs is 1
 		if msgs != nil {
-			contract.recoverMsgs = append(contract.recoverMsgs, msgs)
+			contract.recoverMsgs[i] = msgs
 		}
-	}
-	if len(contract.recoverMsgs) != size {
-		t.Fatalf("invalid message amount")
 	}
 	// Send recover messages, broadcast to all nodes
 	for i := 0; i < size-1; i++ {
@@ -428,11 +436,11 @@ func TestRecover(t *testing.T) {
 		}
 	}
 	// Recover the lost resharing messages
-	msgs, pvss, err := kss[7].OnRecoverFinish()
+	msgs, pvss, err := kss[7].TryRecoverReshare()
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
-	for i := 0; i < size; i++ {
+	for i := 0; i < len(addrs); i++ {
 		err := kss[i].ReceiveRecoveredReshare(kss[7].address, msgs, pvss)
 		if err != nil {
 			t.Fatalf(err.Error())
@@ -440,7 +448,7 @@ func TestRecover(t *testing.T) {
 	}
 	// Only check resharing
 	for i := 0; i < size; i++ {
-		_, _, err := kss[i].OnReshareFinish()
+		err := kss[i].aggregateReshare()
 		if err != nil {
 			t.Fatalf(err.Error())
 		}

--- a/antimev/signature_test.go
+++ b/antimev/signature_test.go
@@ -29,7 +29,7 @@ func TestThresholdSignature(t *testing.T) {
 	source := rand.NewSource(time.Now().UnixNano())
 	random := rand.New(source)
 	dir := t.TempDir()
-
+	// Init keystores
 	cns := accounts[:size]
 	slices.SortFunc(cns, func(a, b account) int {
 		return common.Address.Cmp(a.addr, b.addr)
@@ -46,37 +46,33 @@ func TestThresholdSignature(t *testing.T) {
 		}
 		kss[i] = ks
 	}
-
-	msgbox := make([][][]byte, size)
-	pvssbox := make([][]byte, size)
+	// Ignore resharing and execute sharing
+	contract := &MockContractStorage{
+		shareMsgs:   make([][][]byte, size),
+		sharePVSSes: make([][]byte, size),
+	}
 	valList := make([]common.Address, size)
 	for i := range cns {
 		valList[i] = cns[i].addr
 	}
 	for i := 0; i < size; i++ {
 		// No reshare to handle
-		_, _, err := kss[i].OnValidatorList(valList, pubs)
+		msgs, pvss, _, _, err := kss[i].OnValidatorList(valList, pubs)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
-		// Handle share
-		msgs, pvss, err := kss[i].OnReshareFinish()
-		if err != nil {
-			t.Fatalf(err.Error())
-		}
-		msgbox[i] = msgs
-		pvssbox[i] = pvss
+		contract.shareMsgs[i] = msgs
+		contract.sharePVSSes[i] = pvss
 	}
-
+	// Send secret sharing messages
 	for i := 0; i < size; i++ {
 		for j := 0; j < size; j++ {
-			err := kss[i].ReceiveSecretShare(kss[j].address, msgbox[j], pvssbox[j])
+			err := kss[i].ReceiveSecretShare(kss[j].address, contract.shareMsgs[j], contract.sharePVSSes[j])
 			if err != nil {
 				t.Fatalf(err.Error())
 			}
 		}
 	}
-
 	for i := 0; i < size; i++ {
 		err := kss[i].OnEpochChange()
 		if err != nil {

--- a/antimev/tpke_test.go
+++ b/antimev/tpke_test.go
@@ -20,7 +20,7 @@ func TestTPKE(t *testing.T) {
 	source := rand.NewSource(time.Now().UnixNano())
 	random := rand.New(source)
 	dir := t.TempDir()
-
+	// Init keystores
 	cns := accounts[:size]
 	slices.SortFunc(cns, func(a, b account) int {
 		return common.Address.Cmp(a.addr, b.addr)
@@ -37,37 +37,33 @@ func TestTPKE(t *testing.T) {
 		}
 		kss[i] = ks
 	}
-
-	msgbox := make([][][]byte, size)
-	pvssbox := make([][]byte, size)
+	// Ignore resharing and execute sharing
+	contract := &MockContractStorage{
+		shareMsgs:   make([][][]byte, size),
+		sharePVSSes: make([][]byte, size),
+	}
 	valList := make([]common.Address, size)
 	for i := range cns {
 		valList[i] = cns[i].addr
 	}
 	for i := 0; i < size; i++ {
 		// No reshare to handle
-		_, _, err := kss[i].OnValidatorList(valList, pubs)
+		msgs, pvss, _, _, err := kss[i].OnValidatorList(valList, pubs)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
-		// Handle share
-		msgs, pvss, err := kss[i].OnReshareFinish()
-		if err != nil {
-			t.Fatalf(err.Error())
-		}
-		msgbox[i] = msgs
-		pvssbox[i] = pvss
+		contract.shareMsgs[i] = msgs
+		contract.sharePVSSes[i] = pvss
 	}
-
+	// Send secret sharing messages
 	for i := 0; i < size; i++ {
 		for j := 0; j < size; j++ {
-			err := kss[i].ReceiveSecretShare(kss[j].address, msgbox[j], pvssbox[j])
+			err := kss[i].ReceiveSecretShare(kss[j].address, contract.shareMsgs[j], contract.sharePVSSes[j])
 			if err != nil {
 				t.Fatalf(err.Error())
 			}
 		}
 	}
-
 	for i := 0; i < size; i++ {
 		err := kss[i].OnEpochChange()
 		if err != nil {
@@ -120,11 +116,10 @@ func TestBenchmark(t *testing.T) {
 	size := 7
 	threshold := 5
 
-	// DKG
 	source := rand.NewSource(time.Now().UnixNano())
 	random := rand.New(source)
 	dir := t.TempDir()
-
+	// Init keystores
 	cns := accounts[:size]
 	slices.SortFunc(cns, func(a, b account) int {
 		return common.Address.Cmp(a.addr, b.addr)
@@ -141,37 +136,33 @@ func TestBenchmark(t *testing.T) {
 		}
 		kss[i] = ks
 	}
-
-	msgbox := make([][][]byte, size)
-	pvssbox := make([][]byte, size)
+	// Ignore resharing and execute sharing
+	contract := &MockContractStorage{
+		shareMsgs:   make([][][]byte, size),
+		sharePVSSes: make([][]byte, size),
+	}
 	valList := make([]common.Address, size)
 	for i := range cns {
 		valList[i] = cns[i].addr
 	}
 	for i := 0; i < size; i++ {
 		// No reshare to handle
-		_, _, err := kss[i].OnValidatorList(valList, pubs)
+		msgs, pvss, _, _, err := kss[i].OnValidatorList(valList, pubs)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
-		// Handle share
-		msgs, pvss, err := kss[i].OnReshareFinish()
-		if err != nil {
-			t.Fatalf(err.Error())
-		}
-		msgbox[i] = msgs
-		pvssbox[i] = pvss
+		contract.shareMsgs[i] = msgs
+		contract.sharePVSSes[i] = pvss
 	}
-
+	// Send secret sharing messages
 	for i := 0; i < size; i++ {
 		for j := 0; j < size; j++ {
-			err := kss[i].ReceiveSecretShare(kss[j].address, msgbox[j], pvssbox[j])
+			err := kss[i].ReceiveSecretShare(kss[j].address, contract.shareMsgs[j], contract.sharePVSSes[j])
 			if err != nil {
 				t.Fatalf(err.Error())
 			}
 		}
 	}
-
 	for i := 0; i < size; i++ {
 		err := kss[i].OnEpochChange()
 		if err != nil {


### PR DESCRIPTION
@chenquanyu Update the keystore behaviors according to #312 and the implementation in branch antimev-integration-contract`.

- `OnValidatorList` starts a DKG and `OnEpochChange` ends it;
- `ReceiveSecretShare`, `ReceiveSecretReshare`, `ReceiveRecoverShare` and `ReceiveRecoveredReshare` handle different kinds of DKG messages;
- `StartRecover` starts a recovering period and `TryRecoverReshare` tries to get a result from recovery;
- Any CN can call above methods in correct periods without error, but the behaviors are different, depends on their roles in DKG:
  - If the caller is not a sender of sharing, resharing or recovering, the returned messages of `OnValidatorList` and `StartRecover` will be `nil`;
  - If the caller is not a receiver of sharing, resharing or recovering, only public PVSS of `ReceiveSecretShare`, `ReceiveSecretReshare` and `ReceiveRecoveredReshare` will be handled. In `OnEpochChange`, only public keys will be generated in keystore, but the local private key will be `nil`.