### PR TITLE
contracts: remove governance lock and distribute voter reward immediately

### DIFF
--- a/contracts/solidity/Governance.sol
+++ b/contracts/solidity/Governance.sol
@@ -64,7 +64,7 @@ contract Governance is IGovernance, ReentrancyGuard, GovProxyUpgradeable {
     mapping(address => uint) public candidateGasPerVote;
     // voter=>number
     mapping(address => uint) public voterGasPerVote;
-    // voter=>height
+    // voter=>height, deprecated
     mapping(address => uint) public voteHeight;
     // candidate=>height=>number
     mapping(address => mapping(uint => uint)) public epochStartGasPerVote;
@@ -75,13 +75,6 @@ contract Governance is IGovernance, ReentrancyGuard, GovProxyUpgradeable {
     uint public sharePeriodDuration;
     // the pending group of block validators
     address[] public pendingConsensus;
-    // the lock for dkg pending sharing
-    bool public electionLocked;
-
-    modifier onlyElectionNotLocked() {
-        if (electionLocked) revert Errors.ElectionLocked();
-        _;
-    }
 
     // Only for precompiled uups implementation in genesis file, need to be removed when upgrading the contract.
     // This override is added because "immutable __self" in UUPSUpgradeable is not avaliable in precompiled contract.
@@ -104,7 +97,7 @@ contract Governance is IGovernance, ReentrancyGuard, GovProxyUpgradeable {
     }
 
     // Only for Governance upgrading for the new KeyManagement contract
-    function setInitialSharePeriodDuration(uint _sharePeriodDuration) external onlyAdmin() {
+    function setInitialSharePeriodDuration(uint _sharePeriodDuration) external onlyAdmin {
         sharePeriodDuration = _sharePeriodDuration;
     }
 
@@ -133,9 +126,7 @@ contract Governance is IGovernance, ReentrancyGuard, GovProxyUpgradeable {
         return candidateList.values();
     }
 
-    function registerCandidate(
-        uint shareRate
-    ) external payable onlyElectionNotLocked {
+    function registerCandidate(uint shareRate) external payable {
         if (tx.origin != msg.sender) revert Errors.OnlyEOA();
         if (msg.value != registerFee) revert Errors.InsufficientValue();
         if (shareRate > 1000) revert Errors.InvalidShareRate();
@@ -151,7 +142,7 @@ contract Governance is IGovernance, ReentrancyGuard, GovProxyUpgradeable {
         candidateBalanceOf[msg.sender] = msg.value;
     }
 
-    function exitCandidate() external onlyElectionNotLocked {
+    function exitCandidate() external {
         if (!_deactivateCandidate(msg.sender))
             revert Errors.CandidateNotExists();
     }
@@ -175,9 +166,7 @@ contract Governance is IGovernance, ReentrancyGuard, GovProxyUpgradeable {
         _safeTransferETH(msg.sender, amount);
     }
 
-    function vote(
-        address candidateTo
-    ) external payable nonReentrant onlyElectionNotLocked {
+    function vote(address candidateTo) external payable nonReentrant {
         if (msg.value < minVoteAmount) revert Errors.InsufficientValue();
         if (!candidateList.contains(candidateTo))
             revert Errors.CandidateNotExists();
@@ -199,19 +188,17 @@ contract Governance is IGovernance, ReentrancyGuard, GovProxyUpgradeable {
         votedAmount[msg.sender] += msg.value;
         receivedVotes[candidateTo] += msg.value;
         totalVotes += msg.value;
-        // NOTE: the left reward in the first epoch of first vote will be unclaimable.
-        if (votedCandidate == address(0)) {
-            voteHeight[msg.sender] = block.number;
-        }
 
         emit Vote(msg.sender, candidateTo, msg.value);
         if (unclaimedReward > 0) _safeTransferETH(msg.sender, unclaimedReward);
     }
 
-    function revokeVote() external nonReentrant onlyElectionNotLocked {
+    function revokeVote(uint amount) external nonReentrant {
         address candidateFrom = votedTo[msg.sender];
-        uint amount = votedAmount[msg.sender];
-        if (candidateFrom == address(0) || amount <= 0) revert Errors.NoVote();
+        uint leftAmount = votedAmount[msg.sender];
+        if (candidateFrom == address(0) || leftAmount <= 0)
+            revert Errors.NoVote();
+        if (amount > leftAmount) revert Errors.InsufficientValue();
 
         // settle reward here
         uint unclaimedReward = _settleReward(msg.sender, candidateFrom);
@@ -222,20 +209,21 @@ contract Governance is IGovernance, ReentrancyGuard, GovProxyUpgradeable {
         if (candidateList.contains(candidateFrom)) {
             totalVotes -= amount;
         }
-        delete votedTo[msg.sender];
-        delete votedAmount[msg.sender];
-
-        // delete tag value
-        delete voterGasPerVote[msg.sender];
-        delete voteHeight[msg.sender];
+        if (amount == leftAmount) {
+            // delete tag value
+            delete votedTo[msg.sender];
+            delete votedAmount[msg.sender];
+            delete voterGasPerVote[msg.sender];
+            delete voteHeight[msg.sender];
+        } else {
+            votedAmount[msg.sender] -= amount;
+        }
 
         emit Revoke(msg.sender, candidateFrom, amount);
         _safeTransferETH(msg.sender, amount + unclaimedReward);
     }
 
-    function transferVote(
-        address candidateTo
-    ) external nonReentrant onlyElectionNotLocked {
+    function transferVote(address candidateTo) external nonReentrant {
         address candidateFrom = votedTo[msg.sender];
         uint amount = votedAmount[msg.sender];
         if (candidateFrom == address(0) || amount <= 0) revert Errors.NoVote();
@@ -254,7 +242,6 @@ contract Governance is IGovernance, ReentrancyGuard, GovProxyUpgradeable {
         }
         votedTo[msg.sender] = candidateTo;
         voterGasPerVote[msg.sender] = candidateGasPerVote[candidateTo];
-        voteHeight[msg.sender] = block.number;
 
         emit Revoke(msg.sender, candidateFrom, amount);
         emit Vote(msg.sender, candidateTo, amount);
@@ -320,20 +307,6 @@ contract Governance is IGovernance, ReentrancyGuard, GovProxyUpgradeable {
             } else {
                 pendingConsensus = _computeConsensus(candidates);
             }
-            // lock election if consensus members are going to change
-            for (uint i = 0; i < consensusSize; i++) {
-                bool notChanged;
-                for (uint j = 0; j < consensusSize; j++) {
-                    if (pendingConsensus[i] == currentConsensus[j]) {
-                        notChanged = true;
-                        break;
-                    }
-                }
-                if (!notChanged) {
-                    electionLocked = true;
-                    break;
-                }
-            }
             emit Persist(pendingConsensus);
         }
         if (block.number < currentEpochStartHeight + epochDuration) return;
@@ -351,7 +324,6 @@ contract Governance is IGovernance, ReentrancyGuard, GovProxyUpgradeable {
         }
         // reset pending value and start a new epoch
         delete pendingConsensus;
-        delete electionLocked;
         emit Persist(currentConsensus);
     }
 
@@ -400,19 +372,8 @@ contract Governance is IGovernance, ReentrancyGuard, GovProxyUpgradeable {
         address candidate
     ) internal view returns (uint) {
         // NOTE: suppose onPersist always happens at the beginning of every block, then latestGasPerVote is always the latest
-        uint height = voteHeight[voter];
-        if (currentEpochStartHeight <= height) return 0;
         uint lastGasPerVote = voterGasPerVote[voter];
         uint latestGasPerVote = candidateGasPerVote[candidate];
-
-        // NOTE: suppose epoch change always happens at the beginning of a block, then vote in that block should wait another epoch to farm reward
-        uint voteEpochEndGasPerVote = epochStartGasPerVote[candidate][
-            height / epochDuration + 1
-        ];
-        if (voteEpochEndGasPerVote > lastGasPerVote) {
-            lastGasPerVote = voteEpochEndGasPerVote;
-        }
-
         return
             (votedAmount[voter] * (latestGasPerVote - lastGasPerVote)) /
             SCALE_FACTOR;

--- a/contracts/solidity/interfaces/IGovernance.sol
+++ b/contracts/solidity/interfaces/IGovernance.sol
@@ -23,7 +23,7 @@ interface IGovernance {
     function vote(address to) external payable;
 
     // revoke votes and claim rewards
-    function revokeVote() external;
+    function revokeVote(uint amount) external;
 
     // revoke votes, claim rewards and vote to another candidate
     function transferVote(address candidateTo) external;

--- a/contracts/test/Governance.ts
+++ b/contracts/test/Governance.ts
@@ -496,25 +496,6 @@ describe("Governance", function () {
             expect(await Governance.getCurrentConsensus()).to.deep.equal(STANDBY_VALIDATORS);
         });
 
-        it("Should not lock election if dkg is enabled but pending consensus is the same as current consensus", async function () {
-            await mine(EPOCH_DURATION - 2 * SHARE_PERIOD);
-            await MockSysCall.call_onPersistV2(Governance);
-
-            expect(await Governance.electionLocked()).to.equal(false);
-        });
-
-        it("Should lock election if dkg is enabled and pending consensus is different with current consensus", async function () {
-            let signers = await ethers.getSigners();
-            for (let i = 0; i < CONSENSUS_SIZE; i++) {
-                await Governance.connect(signers[i]).registerCandidate(500, { value: REGISTER_FEE });
-                await Governance.connect(signers[i]).vote(signers[i], { value: VOTE_TARGET_AMOUNT });
-            }
-            await mine(EPOCH_DURATION - 2 * SHARE_PERIOD);
-            await MockSysCall.call_onPersistV2(Governance);
-
-            expect(await Governance.electionLocked()).to.equal(true);
-        });
-
         it("Should take standby validators as consensus if candidate amount not meets threshold", async function () {
             // Register only 1 candidate but vote
             await Governance.connect(candidate1).registerCandidate(500, { value: REGISTER_FEE });
@@ -588,9 +569,6 @@ describe("Governance", function () {
             expect(await Governance.receivedVotes(candidate1.address)).to.eq(MIN_VOTE_AMOUNT);
             expect(await Governance.votedTo(candidate1.address)).to.eq(candidate1.address);
             expect(await Governance.votedAmount(candidate1.address)).to.eq(MIN_VOTE_AMOUNT);
-            expect(await Governance.voteHeight(candidate1.address)).to.eq(
-                await ethers.provider.getBlockNumber()
-            );
         });
 
         it("Should emit an event when a voter votes", async function () {
@@ -607,7 +585,7 @@ describe("Governance", function () {
     describe("revokeVote", function () {
         it("Should revert if the sender has not voted", async function () {
             await expect(
-                Governance.connect(candidate1).revokeVote()
+                Governance.connect(candidate1).revokeVote(0)
             ).to.be.revertedWithCustomError(Governance, ERRORS.NO_VOTE);
         });
 
@@ -620,7 +598,7 @@ describe("Governance", function () {
 
             const balanceBefore = await ethers.provider.getBalance(candidate1.address);
             await expect(
-                Governance.connect(candidate1).revokeVote()
+                Governance.connect(candidate1).revokeVote(MIN_VOTE_AMOUNT)
             ).not.to.be.reverted;
             const balanceAfter = await ethers.provider.getBalance(candidate1.address);
             expect(balanceAfter).to.gt(balanceBefore);
@@ -633,13 +611,12 @@ describe("Governance", function () {
                 Governance.connect(candidate1).vote(candidate1, { value: MIN_VOTE_AMOUNT })
             ).not.to.be.reverted;
             await expect(
-                Governance.connect(candidate1).revokeVote()
+                Governance.connect(candidate1).revokeVote(MIN_VOTE_AMOUNT)
             ).not.to.be.reverted;
 
             expect(await Governance.receivedVotes(candidate1.address)).to.eq(0);
             expect(await Governance.votedTo(candidate1.address)).to.eq(ethers.ZeroAddress);
             expect(await Governance.votedAmount(candidate1.address)).to.eq(0);
-            expect(await Governance.voteHeight(candidate1.address)).to.eq(0);
         });
 
         it("Should emit an event when a voter revokes", async function () {
@@ -648,7 +625,7 @@ describe("Governance", function () {
                 Governance.connect(candidate1).vote(candidate1, { value: MIN_VOTE_AMOUNT })
             ).not.to.be.reverted;
             await expect(
-                Governance.connect(candidate1).revokeVote()
+                Governance.connect(candidate1).revokeVote(MIN_VOTE_AMOUNT)
             ).emit(Governance, "Revoke");
         });
     });
@@ -697,7 +674,6 @@ describe("Governance", function () {
             expect(await Governance.receivedVotes(candidate2.address)).to.eq(MIN_VOTE_AMOUNT);
             expect(await Governance.votedTo(candidate1.address)).to.eq(candidate2.address);
             expect(await Governance.votedAmount(candidate1.address)).to.eq(MIN_VOTE_AMOUNT);
-            expect(await Governance.voteHeight(candidate1.address)).to.eq(await ethers.provider.getBlockNumber());
         });
 
         it("Should update total votes if transfer from a deactivated candidate", async function () {


### PR DESCRIPTION
Close #222, revert parts of #312.

Now voters start to receive rewards ASA they vote somebody elected, and will loss nothing when `transferVote`. And a flexible `revokeVote` is provided.

The new logic and storage management should be compatible with Mainnet and Testnet release (https://github.com/bane-labs/go-ethereum/commit/922a976e6fcc742a1ddaac949872ee920de1f794).