### PR TITLE
dbft: always reuse state for block processing

### DIFF
--- a/consensus/dbft/blockqueue.go
+++ b/consensus/dbft/blockqueue.go
@@ -43,7 +43,8 @@ func (bq *blockQueue) PutBlock(b *types.Block, state *state.StateDB, receipts []
 		return nil
 	}
 
-	// Short circuit if we don't have pre-calculated state.
+	// Short circuit if we don't have pre-calculated state (it's possible only in case of
+	// reorg if dBFT tries to insert new parent during PrepareRequest construction).
 	if state == nil {
 		_, err := bq.chain.InsertChain(types.Blocks{b})
 		if err != nil {

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -467,7 +467,7 @@ func New(chainCfg *params.ChainConfig, _ ethdb.Database) (*DBFT, error) {
 
 			// Short path if we're primary and there's no Envelopes in the block:
 			// reuse state got after PrepareRequest construction.
-			if ctx.PrimaryIndex == uint(ctx.MyIndex) && pre.finalState == nil {
+			if ctx.IsPrimary() && pre.finalState == nil {
 				return &Block{
 					header:              c.sealingBlock.Header(),
 					withdrawals:         c.sealingBlock.Withdrawals(),

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -454,6 +454,13 @@ func New(chainCfg *params.ChainConfig, _ ethdb.Database) (*DBFT, error) {
 					header:      pre.header,
 					withdrawals: pre.withdrawals,
 				}
+
+				// If we're primary, then reuse sealing state got after PrepareRequest
+				// construction.
+				if ctx.IsPrimary() {
+					res.state = c.sealingState
+					res.receipts = c.sealingReceipts
+				}
 				return res
 			}
 			pre := ctx.PreBlock().(*PreBlock)


### PR DESCRIPTION
Problem:

With NeoXAMEV fork disabled, Primary node don't have the state of accepting block attached to the dBFT's proposal. Whereas both Backup and WatchOnly nodes already have this state got after proposal verification (from WithVerifyBlock dBFT callback).

Strictly speaking, it's not a bug because BlockQueue code is able to process missing block state. However, it's a nice enhancement that allows to reduce the number of state recalculation for Primary nodes. Also, this enhancement is required for #332 to work properly.

Solution:

Attach the state of the accepting block got after PrepareRequest construction to the proposal context for Primary node in case of NeoXAMEV fork disabled. Reuse this state during block insertion into chain.

@txhsl, rebase #332 onto this PR and check your state-related code one more time. With this fix it should work as expected. Welcome to review. Also @songb2, please test this patch and ensure that Primary nodes always have valid receipts and valid stateroot for their blocks, and stateroot/receipts can be fetched via RPC using block hash / block number.