### PR TITLE
antimev: enforce keystore consistency with system contract

### DIFF
--- a/antimev/keygroup.go
+++ b/antimev/keygroup.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 
 	"github.com/bane-labs/zk-dkg/encryption"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto/ecies"
 	"github.com/ethereum/go-ethereum/crypto/tpke"
 )
@@ -21,8 +20,9 @@ var (
 // thresholdKeyGroup records the process and result of a round of dkg.
 // PVSS is verified in DKG contract and used as input parameters here.
 type thresholdKeyGroup struct {
-	localSecret     *tpke.Secret // The local random secret
-	receivedSecrets []*big.Int   // Received secret sharings
+	localSecret     *tpke.Secret   // The final local random secret
+	pendingSecrets  []*tpke.Secret // Pending secrets which may get confirmed by contract
+	receivedSecrets []*big.Int     // Received secret sharings
 
 	globalPubKey *tpke.PublicKey  // The aggregated global public key
 	localPrvKey  *tpke.PrivateKey // The aggregated local secret key
@@ -31,6 +31,7 @@ type thresholdKeyGroup struct {
 // newThresholdKeyGroup returns a new key group with the input address list.
 func newThresholdKeyGroup(size int) *thresholdKeyGroup {
 	return &thresholdKeyGroup{
+		pendingSecrets:  make([]*tpke.Secret, 0),
 		receivedSecrets: make([]*big.Int, size),
 	}
 }
@@ -47,9 +48,21 @@ func (tkg *thresholdKeyGroup) newTemplateForReshare(size int) *thresholdKeyGroup
 // prepare generates local secrets and returns sharing messages.
 func (tkg *thresholdKeyGroup) prepare(threshold int, messagePubKeys []*ecies.PublicKey) ([][]byte, *tpke.PVSS, error) {
 	// Generate local secret
-	tkg.localSecret = tpke.RandomSecret(threshold)
+	secret := tpke.RandomSecret(threshold)
+	tkg.pendingSecrets = append(tkg.pendingSecrets, secret)
 	// Generate and encrypt messages to share the secret
-	return generateShareMessages(tkg.localSecret, messagePubKeys)
+	return generateShareMessages(secret, messagePubKeys)
+}
+
+// confirmSecret requires the final contract-received PVSS to confirm the secret.
+func (tkg *thresholdKeyGroup) confirmSecret(pvss *tpke.PVSS) error {
+	for _, secret := range tkg.pendingSecrets {
+		if pvss.IsFrom(secret) {
+			tkg.localSecret = secret
+			return nil
+		}
+	}
+	return ErrDKGSecret
 }
 
 // aggregate aggregates received secrets and commitments to get global
@@ -192,9 +205,9 @@ func (tkg *thresholdKeyGroup) receiveRecoverMessage(fromIndex int, rs *big.Int, 
 
 // thresholdKeyGroupAux is an auxiliary structure for thresholdKeyGroup JSON marshalling.
 type thresholdKeyGroupAux struct {
-	SelfAddr        common.Address `json:"self_addr"`        // Self address
-	LocalSecret     []*big.Int     `json:"local_secret"`     // The local random secret
-	ReceivedSecrets []*big.Int     `json:"received_secrets"` // Received secret sharings
+	LocalSecret     []*big.Int   `json:"local_secret"`     // The local random secret
+	PendingSecrets  [][]*big.Int `json:"pending_secrets"`  // Sent-but-pending secrets
+	ReceivedSecrets []*big.Int   `json:"received_secrets"` // Received secret sharings
 
 	GlobalPubKey string `json:"global_pubkey"` // The aggregated global public key
 	LocalPrvKey  string `json:"local_prvkey"`  // The aggregated local secret key
@@ -209,6 +222,12 @@ func (tkg *thresholdKeyGroup) toAux() *thresholdKeyGroupAux {
 	// Possible be nil when dkg is undergoing
 	if tkg.localSecret != nil {
 		aux.LocalSecret = tkg.localSecret.ToBigIntArray()
+	}
+	aux.PendingSecrets = make([][]*big.Int, 0)
+	if len(tkg.pendingSecrets) > 0 {
+		for _, secret := range tkg.pendingSecrets {
+			aux.PendingSecrets = append(aux.PendingSecrets, secret.ToBigIntArray())
+		}
 	}
 	if tkg.globalPubKey != nil {
 		aux.GlobalPubKey = hex.EncodeToString(tkg.globalPubKey.Bytes())
@@ -226,6 +245,14 @@ func (tkg *thresholdKeyGroup) fromAux(aux *thresholdKeyGroupAux) error {
 	if aux.LocalSecret != nil {
 		tkg.localSecret = new(tpke.Secret)
 		tkg.localSecret.FromBigIntArray(aux.LocalSecret)
+	}
+	tkg.pendingSecrets = make([]*tpke.Secret, 0)
+	if len(aux.PendingSecrets) > 0 {
+		for _, arr := range aux.PendingSecrets {
+			secret := new(tpke.Secret)
+			secret.FromBigIntArray(arr)
+			tkg.pendingSecrets = append(tkg.pendingSecrets, secret)
+		}
 	}
 	if len(aux.GlobalPubKey) > 0 {
 		pubBytes, err := hex.DecodeString(aux.GlobalPubKey)

--- a/antimev/keystore.go
+++ b/antimev/keystore.go
@@ -279,16 +279,22 @@ func (ks *KeyStore) RevertRound() error {
 
 // OnEpochChange checks and settles the results of sharing and resharing, will
 // revert both of them of any of them is not successful.
-func (ks *KeyStore) OnEpochChange(aggregatedCmt []byte, isMemberOfNewGroup bool) error {
+func (ks *KeyStore) OnEpochChange(selfPvss []byte, aggregatedCmt []byte, isMemberOfNewGroup bool) error {
 	// Revert dkg if contract doesn't give a aggregated commitment
 	if len(aggregatedCmt) == 0 {
 		return ks.RevertRound()
+	}
+	if isMemberOfNewGroup && len(selfPvss) == 0 {
+		return ErrLengthMismatch
+	}
+	if !isMemberOfNewGroup && len(selfPvss) > 0 {
+		return ErrLengthMismatch
 	}
 	// If code reaches here, then dkg is successful in contract
 	if err := ks.aggregateReshare(isMemberOfNewGroup); err != nil {
 		return err
 	}
-	if err := ks.aggregateShare(aggregatedCmt, isMemberOfNewGroup); err != nil {
+	if err := ks.aggregateShare(selfPvss, aggregatedCmt, isMemberOfNewGroup); err != nil {
 		return err
 	}
 	// Set finished dkg as current using
@@ -302,10 +308,21 @@ func (ks *KeyStore) OnEpochChange(aggregatedCmt []byte, isMemberOfNewGroup bool)
 }
 
 // aggregateShare tries to check if sharing is successful and settle the result
-func (ks *KeyStore) aggregateShare(aggregatedCmt []byte, isParticipant bool) error {
+func (ks *KeyStore) aggregateShare(selfPvss []byte, aggregatedCmt []byte, isParticipant bool) error {
 	// Check if sharing is successful and aggregate keys
 	if ks.sharing == nil {
 		return ErrKeyGroupNotExists
+	}
+	// Check which secret is finally confirmed by contract
+	if isParticipant {
+		p, err := new(tpke.PVSS).Decode(selfPvss, ks.size, ks.threshold)
+		if err != nil {
+			return ErrInvalidDKGPVSS
+		}
+		err = ks.sharing.confirmSecret(p)
+		if err != nil {
+			return err
+		}
 	}
 	return ks.sharing.aggregate(ks.scaler, aggregatedCmt, isParticipant)
 }

--- a/antimev/keystore_test.go
+++ b/antimev/keystore_test.go
@@ -136,7 +136,7 @@ func TestShare(t *testing.T) {
 	}
 	for i := 0; i < size; i++ {
 		// Try finish DKG without resharing
-		err := kss[i].OnEpochChange(encodePointG1(cmt), true)
+		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), true)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -204,7 +204,7 @@ func TestReshare(t *testing.T) {
 	}
 	// Finalize dkg
 	for i := 0; i < size; i++ {
-		err := kss[i].OnEpochChange(encodePointG1(cmt), true)
+		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), true)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -256,7 +256,7 @@ func TestReshare(t *testing.T) {
 	}
 	// Check sharing and resharing
 	for i := 0; i < size; i++ {
-		err := kss[i].OnEpochChange(encodePointG1(cmt), true)
+		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), true)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -327,11 +327,15 @@ func TestGroupChange(t *testing.T) {
 		cmt = new(bls12381.G1Affine).Add(cmt, pg1)
 	}
 	// Finalize dkg
-	for i := 0; i < len(addrs); i++ {
-		err := kss[i].OnEpochChange(encodePointG1(cmt), i != 7)
+	for i := 0; i < size; i++ {
+		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), true)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
+	}
+	err := kss[7].OnEpochChange(nil, encodePointG1(cmt), false)
+	if err != nil {
+		t.Fatalf(err.Error())
 	}
 	// Execute resharing this time
 	for i := 0; i < len(addrs); i++ {
@@ -386,8 +390,12 @@ func TestGroupChange(t *testing.T) {
 		cmt = new(bls12381.G1Affine).Add(cmt, pg1)
 	}
 	// Check sharing and resharing
-	for i := 0; i < len(addrs); i++ {
-		err := kss[i].OnEpochChange(encodePointG1(cmt), i != 0)
+	err = kss[0].OnEpochChange(nil, encodePointG1(cmt), false)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	for i := 1; i <= size; i++ {
+		err := kss[i].OnEpochChange(contract.sharePVSSes[i-1], encodePointG1(cmt), i != 0)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -459,11 +467,15 @@ func TestRecover(t *testing.T) {
 		cmt = new(bls12381.G1Affine).Add(cmt, pg1)
 	}
 	// Finalize dkg
-	for i := 0; i < len(addrs); i++ {
-		err := kss[i].OnEpochChange(encodePointG1(cmt), i != 7)
+	for i := 0; i < size; i++ {
+		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), true)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
+	}
+	err := kss[7].OnEpochChange(nil, encodePointG1(cmt), false)
+	if err != nil {
+		t.Fatalf(err.Error())
 	}
 	// Execute resharing this time
 	for i := 0; i < len(addrs); i++ {

--- a/antimev/signature_test.go
+++ b/antimev/signature_test.go
@@ -84,7 +84,7 @@ func TestThresholdSignature(t *testing.T) {
 		cmt = new(bls12381.G1Affine).Add(cmt, pg1)
 	}
 	for i := 0; i < size; i++ {
-		err := kss[i].OnEpochChange(encodePointG1(cmt), true)
+		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), true)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}

--- a/antimev/tpke_test.go
+++ b/antimev/tpke_test.go
@@ -78,7 +78,7 @@ func TestTPKE(t *testing.T) {
 		cmt = new(bls12381.G1Affine).Add(cmt, pg1)
 	}
 	for i := 0; i < size; i++ {
-		err := kss[i].OnEpochChange(encodePointG1(cmt), true)
+		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), true)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}
@@ -260,7 +260,7 @@ func TestBenchmark(t *testing.T) {
 		cmt = new(bls12381.G1Affine).Add(cmt, pg1)
 	}
 	for i := 0; i < size; i++ {
-		err := kss[i].OnEpochChange(encodePointG1(cmt), true)
+		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), true)
 		if err != nil {
 			t.Fatalf(err.Error())
 		}

--- a/consensus/dbft/dkg.go
+++ b/consensus/dbft/dkg.go
@@ -41,9 +41,7 @@ type Snapshot struct {
 	EpochStartHeight     uint64
 	Round                uint64 // Starts from 1
 	CurrentCNs           []common.Address
-	ReshareMessageKeys   []*ecies.PublicKey
 	PendingCNs           []common.Address
-	ShareMessageKeys     []*ecies.PublicKey
 	IndexNeedRecover     []uint64
 	ShareTasked          bool
 	RecoverTasked        bool
@@ -65,7 +63,6 @@ func (c *DBFT) newSnapshot(h *types.Header, state *state.StateDB, height uint64)
 		return nil, err
 	}
 	snap.PendingCNs = make([]common.Address, 0)
-	snap.ShareMessageKeys = make([]*ecies.PublicKey, 0)
 	snap.IndexNeedRecover = make([]uint64, 0)
 	snap.ShareTasked = false
 	snap.RecoverTasked = false
@@ -91,11 +88,11 @@ func (c *DBFT) handleDKG(h *types.Header, state *state.StateDB) error {
 	}
 	epochDuration, err := c.epochDuration(state, h)
 	if err != nil {
-		return fmt.Errorf("failed to call epochDuration: %v", err)
+		return fmt.Errorf("failed to fetch epoch duration: %v", err)
 	}
 	sharePeriodDuration, err := c.sharePeriodDuration(state, h)
 	if err != nil {
-		return fmt.Errorf("failed to call sharePeriodDuration: %v", err)
+		return fmt.Errorf("failed to fetch share period duration: %v", err)
 	}
 
 	// If there is an ongoing round and it's time to epoch change
@@ -107,22 +104,28 @@ func (c *DBFT) handleDKG(h *types.Header, state *state.StateDB) error {
 				return fmt.Errorf("failed to sync recovered secrets, err: %v", err)
 			}
 		}
-		aggregatedCommitments, err := c.aggregatedCommitments(c.dkgSnapshot.Round, state, h)
+		// if indexOfSharing is 0, then selfPvss should be nil
+		// Ref https://github.com/bane-labs/go-ethereum/blob/4c9105ea2bc246729db0540fce2df02074e21087/contracts/solidity/KeyManagement.sol#L113
+		selfPvss, err := c.spvss(c.dkgSnapshot.Round, uint64(indexOfSharing), state, h)
 		if err != nil {
-			return fmt.Errorf("failed to call aggregatedCommitments, err: %v", err)
+			return fmt.Errorf("failed to fetch spvss, err: %v", err)
 		}
-		err = c.amevKeystore.OnEpochChange(aggregatedCommitments, indexOfSharing > 0)
+		aggregatedCommitment, err := c.aggregatedCommitment(c.dkgSnapshot.Round, state, h)
 		if err != nil {
-			return fmt.Errorf("failed to call amevKeystore.OnEpochChange, err: %v", err)
+			return fmt.Errorf("failed to fetch aggregated commitment, err: %v", err)
 		}
-		log.Info("DKG reached targetHeight", "round", c.dkgSnapshot.Round, "currentHeight", currentHeight, "aggregatedCommitments", hex.EncodeToString(aggregatedCommitments))
+		err = c.amevKeystore.OnEpochChange(selfPvss, aggregatedCommitment, indexOfSharing > 0)
+		if err != nil {
+			return fmt.Errorf("failed to change keystore epoch, err: %v", err)
+		}
+		log.Info("DKG reached targetHeight", "round", c.dkgSnapshot.Round, "currentHeight", currentHeight, "aggregatedCommitment", hex.EncodeToString(aggregatedCommitment))
 		c.dkgSnapshot = nil
 	}
 
 	// If there is not a snapshot of current epoch, then new
 	epochStartHeight, err := c.currentEpochStartHeight(state, h)
 	if err != nil {
-		return fmt.Errorf("failed to call currentEpochStartHeight: %v", err)
+		return fmt.Errorf("failed to fetch current epoch start height: %v", err)
 	}
 	if c.dkgSnapshot == nil {
 		s, err := c.newSnapshot(h, state, epochStartHeight)
@@ -187,14 +190,20 @@ func (c *DBFT) handleDKG(h *types.Header, state *state.StateDB) error {
 				log.Warn("failed to sync shared DKG", "err", err)
 			}
 		}
-		aggregatedCommitments, err := c.aggregatedCommitments(c.dkgSnapshot.Round-1, state, h)
+		// if indexOfSharing is 0, then selfPvss should be nil
+		// Ref https://github.com/bane-labs/go-ethereum/blob/4c9105ea2bc246729db0540fce2df02074e21087/contracts/solidity/KeyManagement.sol#L113
+		selfPvss, err := c.spvss(c.dkgSnapshot.Round, uint64(indexOfSharing), state, h)
 		if err != nil {
-			return fmt.Errorf("failed to call aggregatedCommitments, err: %v", err)
+			return fmt.Errorf("failed to fetch spvsses, err: %v", err)
 		}
-		if err := c.amevKeystore.OnEpochChange(aggregatedCommitments, indexOfSharing > 0); err != nil {
+		aggregatedCommitment, err := c.aggregatedCommitment(c.dkgSnapshot.Round-1, state, h)
+		if err != nil {
+			return fmt.Errorf("failed to fetch aggregated commitment, err: %v", err)
+		}
+		if err := c.amevKeystore.OnEpochChange(selfPvss, aggregatedCommitment, indexOfSharing > 0); err != nil {
 			return fmt.Errorf("failed to sync shared DKG, err: %v", err)
 		}
-		log.Info("DKG sync to", "round", c.dkgSnapshot.Round-1, "currentHeight", currentHeight, "aggregatedCommitments", hex.EncodeToString(aggregatedCommitments))
+		log.Info("DKG sync to", "round", c.dkgSnapshot.Round-1, "currentHeight", currentHeight, "aggregatedCommitment", hex.EncodeToString(aggregatedCommitment))
 	}
 
 	// DKG checkpoint handling, also syncs the dkg process if keystore is out-of-date
@@ -202,7 +211,7 @@ func (c *DBFT) handleDKG(h *types.Header, state *state.StateDB) error {
 		// Send share and reshare tx when currentHeight == shareStartHeight
 		c.dkgSnapshot.PendingCNs, err = c.getPendingConsensus(state, h)
 		if err != nil {
-			return fmt.Errorf("failed to call getPendingConsensus: %v", err)
+			return fmt.Errorf("failed to fetch pending consensus: %v", err)
 		}
 		// Prepare and start a DKG
 		if !c.amevKeystore.IsSharing() {
@@ -214,19 +223,19 @@ func (c *DBFT) handleDKG(h *types.Header, state *state.StateDB) error {
 		if currentHeight < recoverStartHeight {
 			// If is a member of pending consensus
 			indexOfSharing := slices.Index(c.dkgSnapshot.PendingCNs, amevAddress) + 1
-			c.dkgSnapshot.ShareMessageKeys, err = c.messagePubkeys(c.dkgSnapshot.PendingCNs, state, h)
+			receiverMessageKeys, err := c.messagePubkeys(c.dkgSnapshot.PendingCNs, state, h)
 			if err != nil {
-				return fmt.Errorf("failed to get message keys for sharing, err: %v", err)
+				return fmt.Errorf("failed to get message keys, err: %v", err)
 			}
 			if indexOfSharing > 0 {
-				if err = c.taskShare(c.dkgSnapshot.ShareMessageKeys, currentHeight, recoverStartHeight, watchList); err != nil {
+				if err = c.taskShare(receiverMessageKeys, currentHeight, recoverStartHeight, watchList); err != nil {
 					return fmt.Errorf("failed to task DKG share, err: %v", err)
 				}
 			}
 			// If is a member of current consensus, try reshare but give up if error
 			indexOfResharing := slices.Index(c.dkgSnapshot.CurrentCNs, amevAddress) + 1
 			if indexOfResharing > 0 && c.dkgSnapshot.Round > 1 {
-				if err = c.taskReshare(c.dkgSnapshot.ShareMessageKeys, currentHeight, recoverStartHeight, watchList); err != nil {
+				if err = c.taskReshare(receiverMessageKeys, currentHeight, recoverStartHeight, watchList); err != nil {
 					c.dkgSnapshot.ShareTasked = true
 					return fmt.Errorf("failed to task DKG reshare, err: %v", err)
 				}
@@ -239,7 +248,7 @@ func (c *DBFT) handleDKG(h *types.Header, state *state.StateDB) error {
 		// Check isShareReady at height recoverStartHeight
 		ready, err := c.isShareReady(state, h)
 		if err != nil {
-			return fmt.Errorf("failed to call isShareReady: %v", err)
+			return fmt.Errorf("failed to check if sharing is ready: %v", err)
 		}
 		if !ready {
 			c.dkgSnapshot.RecoverTasked = true
@@ -255,7 +264,7 @@ func (c *DBFT) handleDKG(h *types.Header, state *state.StateDB) error {
 		}
 		c.dkgSnapshot.IndexNeedRecover, err = c.indexCurrentNeedRecovering(state, h)
 		if err != nil {
-			return fmt.Errorf("failed to call indexCurrentNeedRecovering, err: %v", err)
+			return fmt.Errorf("failed to fecth index need recovering, err: %v", err)
 		}
 		// If the period finished, then skip sending a transaction
 		if len(c.dkgSnapshot.IndexNeedRecover) > 0 {
@@ -300,7 +309,11 @@ func (c *DBFT) handleDKG(h *types.Header, state *state.StateDB) error {
 			if err := c.syncRecoveredSecrets(c.dkgSnapshot, indexOfSharing, state, h); err != nil {
 				return fmt.Errorf("failed to sync recovering DKG, err: %v", err)
 			}
-			if err := c.taskReshareRecover(c.dkgSnapshot.ShareMessageKeys, currentHeight, targetHeight, watchList); err != nil {
+			receiverMessageKeys, err := c.messagePubkeys(c.dkgSnapshot.PendingCNs, state, h)
+			if err != nil {
+				return fmt.Errorf("failed to fecth message keys, err: %v", err)
+			}
+			if err := c.taskReshareRecover(receiverMessageKeys, currentHeight, targetHeight, watchList); err != nil {
 				return fmt.Errorf("failed to task DKG reshare recover, err: %v", err)
 			}
 		}
@@ -403,7 +416,7 @@ func (c *DBFT) downloadAndReceiveShare(round uint64, fromIndex int, selfIndex in
 	if err != nil {
 		return err
 	}
-	spvss, err := c.spvsses(round, uint64(fromIndex), state, header)
+	spvss, err := c.spvss(round, uint64(fromIndex), state, header)
 	if err != nil {
 		return err
 	}
@@ -416,7 +429,7 @@ func (c *DBFT) downloadAndReceiveShare(round uint64, fromIndex int, selfIndex in
 
 func (c *DBFT) downloadAndReceiveReshare(round uint64, fromIndex int, selfIndex int, state *state.StateDB, header *types.Header) error {
 	// Call ReceiveSecretReshare
-	rpvss, err := c.rpvsses(round, uint64(fromIndex), state, header)
+	rpvss, err := c.rpvss(round, uint64(fromIndex), state, header)
 	if err != nil {
 		return err
 	}
@@ -436,7 +449,7 @@ func (c *DBFT) downloadAndReceiveReshare(round uint64, fromIndex int, selfIndex 
 
 // syncRecoveredSecrets downloads DKG recoverings and related PVSS, and sends to keystore
 func (c *DBFT) syncRecoveredSecrets(snap *Snapshot, selfIndex int, state *state.StateDB, header *types.Header) error {
-	pvss, err := c.spvsses(snap.Round-1, uint64(selfIndex), state, header)
+	pvss, err := c.spvss(snap.Round-1, uint64(selfIndex), state, header)
 	if err != nil {
 		return err
 	}
@@ -459,7 +472,7 @@ func (c *DBFT) syncRecoveredSecrets(snap *Snapshot, selfIndex int, state *state.
 func (c *DBFT) syncRecoveredReshares(snap *Snapshot, selfIndex int, state *state.StateDB, header *types.Header) error {
 	for _, index := range snap.IndexNeedRecover {
 		// Call ReceiveSecretReshare
-		rpvss, err := c.rpvsses(snap.Round, index, state, header)
+		rpvss, err := c.rpvss(snap.Round, index, state, header)
 		if err != nil {
 			return err
 		}
@@ -690,7 +703,7 @@ func (c *DBFT) getReshareMsgs(round, index uint64, state *state.StateDB, header 
 	return result, nil
 }
 
-func (c *DBFT) rpvsses(round, index uint64, state *state.StateDB, header *types.Header) ([]byte, error) {
+func (c *DBFT) rpvss(round, index uint64, state *state.StateDB, header *types.Header) ([]byte, error) {
 	var result []byte
 	err := c.readContract(&result, systemcontracts.KeyManagementProxyHash, systemcontracts.KeyManagementABI,
 		state, header, "rpvsses", big.NewInt(int64(round)), big.NewInt(int64(index)))
@@ -710,7 +723,7 @@ func (c *DBFT) getShareMsgs(round, index uint64, state *state.StateDB, header *t
 	return result, nil
 }
 
-func (c *DBFT) spvsses(round, index uint64, state *state.StateDB, header *types.Header) ([]byte, error) {
+func (c *DBFT) spvss(round, index uint64, state *state.StateDB, header *types.Header) ([]byte, error) {
 	var result []byte
 	err := c.readContract(&result, systemcontracts.KeyManagementProxyHash, systemcontracts.KeyManagementABI,
 		state, header, "spvsses", big.NewInt(int64(round)), big.NewInt(int64(index)))
@@ -730,7 +743,7 @@ func (c *DBFT) recoverMsgs(round, senderIndex, arrIndex uint64, state *state.Sta
 	return result, nil
 }
 
-func (c *DBFT) aggregatedCommitments(round uint64, state *state.StateDB, header *types.Header) ([]byte, error) {
+func (c *DBFT) aggregatedCommitment(round uint64, state *state.StateDB, header *types.Header) ([]byte, error) {
 	var result []byte
 	err := c.readContract(&result, systemcontracts.KeyManagementProxyHash, systemcontracts.KeyManagementABI,
 		state, header, "aggregatedCommitments", big.NewInt(int64(round)))

--- a/crypto/tpke/pvss.go
+++ b/crypto/tpke/pvss.go
@@ -39,6 +39,11 @@ func GenerateSecretShares(r *big.Int, size int, secret *Secret) (*PVSS, []*big.I
 
 func (pvss *PVSS) GetCommitment() *Commitment { return pvss.commitment }
 
+// IsFrom verifies if a PVSS is generated from input secret
+func (pvss *PVSS) IsFrom(secret *Secret) bool {
+	return pvss.commitment.Equals(secret.Commitment())
+}
+
 func (pvss *PVSS) Encode() []byte {
 	arr := make([]byte, 0)
 	arr = append(arr, pvss.commitment.Encode()...)


### PR DESCRIPTION
Close #367.

- Add a pending field to cache generated secrets, and a confirm operation to determine which one is finally accepted by contract;
- Fix some confusing namings and error messages.