### PR TITLE
workflow: remove global ssh settings that caused a runner issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,21 +60,8 @@ jobs:
           go-version: '1.22'
           cache: true
 
-      - name: Install SSH Key
-        uses: shimataro/ssh-key-action@v2.7.0
-        with:
-          key: ${{ secrets.ZK_DKG_DEPLOY_KEY }}
-          known_hosts: ${{ secrets.GIT_KNOWN_HOSTS }}
-
-      - name: Enforce Git SSH
-        run: |
-          git config --global url."git@github.com:".insteadOf "https://github.com/"
-
       - name: Build Alltools
-        run: |
-          make all
-        env:
-          GOPRIVATE: github.com/bane-labs
+        run: make all
 
       - name: Prepare Geth and Alltools target binaries
         run: |
@@ -124,22 +111,10 @@ jobs:
           go-version: '1.22'
           cache: true
 
-      - name: Install SSH Key
-        uses: shimataro/ssh-key-action@v2.7.0
-        with:
-          key: ${{ secrets.ZK_DKG_DEPLOY_KEY }}
-          known_hosts: ${{ secrets.GIT_KNOWN_HOSTS }}
-
-      - name: Enforce Git SSH
-        run: |
-          git config --global url."git@github.com:".insteadOf "https://github.com/"
-
       - name: Build geth
         run: |
           make geth
           ./build/bin/geth --version
-        env:
-          GOPRIVATE: github.com/bane-labs
 
       - name: Set env
         id: setvars


### PR DESCRIPTION
These newly introduced codes in #363 changed the global settings of our Github Action runner, caused a failure with following error messages.

```
/usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
Host key verification failed.
Error: fatal: Could not read from remote repository.
  
Please make sure you have the correct access rights
and the repository exists.
The process '/usr/bin/git' failed with exit code 128
Waiting 15 seconds before trying again
```