### PR TITLE
workflow: add https settings for accessing private packages under bane-labs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,8 +60,26 @@ jobs:
           go-version: '1.22'
           cache: true
 
+      - name: Create GitHub App Token
+        uses: actions/create-github-app-token@v1.11.1
+        id: app-token
+        with:
+          app-id: ${{ vars.BANE_CROSS_REPO_ACCESS_APP_ID }}
+          private-key: ${{ secrets.BANE_CROSS_REPO_ACCESS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Setup netrc
+        uses: extractions/netrc@v2
+        with:
+          machine: github.com
+          username: ${{ steps.app-token.outputs.app-slug }}[bot]
+          password: ${{ steps.app-token.outputs.token }}
+
       - name: Build Alltools
         run: make all
+        env:
+          GOPRIVATE: github.com/bane-labs
+          GOINSECURE: github.com/bane-labs
 
       - name: Prepare Geth and Alltools target binaries
         run: |


### PR DESCRIPTION
Ref #363 and #373.

This is an HTTPS based scheme to allow `go get` in GitHub Action to access any possible private packages under organization `bane-labs`.
- A non-code GitHub App [`Bane Cross Repo Access`](https://github.com/organizations/bane-labs/settings/apps/bane-cross-repo-access) is created by `bane-labs`;
- This App has been installed, and can only be installed by `bane-labs`;
- This App uses its private key to generate tokens, which permission is `Read access to code, metadata, and packages`;
- The workflow set this token to `./netrc`, so that cmds `make all` and `go get` can work with private repositories.