### PR TITLE
dbft: disable decryption shares construction if enforceECDSASignatures

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -430,9 +430,10 @@ func New(chainCfg *params.ChainConfig, _ ethdb.Database) (*DBFT, error) {
 			// Manually update header's fields based on fresh state. Avoid changing
 			// the original PreBlock.
 			finalBlock := &PreBlock{
-				header:       pre.header,
-				transactions: pre.finalTransactions,
-				withdrawals:  pre.withdrawals,
+				header:                 pre.header,
+				transactions:           pre.finalTransactions,
+				withdrawals:            pre.withdrawals,
+				enforceECDSASignatures: c.config.enforceECDSASignatures,
 			}
 			ethBlock := finalBlock.ToEthBlock()
 			h := ethBlock.Header()
@@ -779,7 +780,7 @@ func New(chainCfg *params.ChainConfig, _ ethdb.Database) (*DBFT, error) {
 			}
 
 			// Cache processing result for further usage in case if there's no envelopes
-			// in the block.
+			// in the block or fallback signing scheme is used.
 			pre := b.(*PreBlock)
 			pre.finalState = state
 			pre.finalReceipts = receipts
@@ -995,9 +996,10 @@ func New(chainCfg *params.ChainConfig, _ ethdb.Database) (*DBFT, error) {
 			// Process state with constructed list of transactions to fill state-dependent
 			// block fields.
 			finalBlock := &PreBlock{
-				header:       pre.header,
-				transactions: pre.finalTransactions,
-				withdrawals:  pre.withdrawals,
+				header:                 pre.header,
+				transactions:           pre.finalTransactions,
+				withdrawals:            pre.withdrawals,
+				enforceECDSASignatures: c.config.enforceECDSASignatures,
 			}
 			ethBlock := finalBlock.ToEthBlock()
 			state, receipts, _, gasUsed, err := c.chain.ProcessState(ethBlock, nil)
@@ -1105,7 +1107,10 @@ func (c *DBFT) newPreBlockFromContext(sealingProposal *types.Header) *PreBlock {
 	// (dBFT has only the full set of their hashes). Once all transactions are
 	// fetched and the commits are collected, SetTransactions callback will be
 	// called by dBFT library to properly initialize PreBlock's transactions.
-	res := &PreBlock{header: h}
+	res := &PreBlock{
+		header:                 h,
+		enforceECDSASignatures: c.config.enforceECDSASignatures,
+	}
 	// Withdrawals are temporary empty if Shanghai is passed.
 	if c.chain.Config().IsShanghai(h.Number, h.Time) {
 		res.withdrawals = emptyWithdrawals

--- a/consensus/dbft/preblock.go
+++ b/consensus/dbft/preblock.go
@@ -22,8 +22,13 @@ type PreBlock struct {
 	localShares  []byte
 
 	// envelopesData is the ordered list of decoded content of Envelopes
-	// transactions of the proposed PreBlock.
+	// transactions of the proposed PreBlock. In case if enforceECDSASignatures
+	// is enabled, an attempt to decode Envelope transactions won't be taken, hence
+	// envelopesData will be empty.
 	envelopesData []envelopeData
+	// enforceECDSASignatures reflects whether dBFT uses backup multisignature
+	// block signing scheme.
+	enforceECDSASignatures bool
 
 	// finalTransactions is the cached final list of transactions formed after TPKE
 	// decryption of Envelopes content. This list includes both simple standard and
@@ -41,13 +46,17 @@ func (p *PreBlock) Data() []byte { return p.localShares }
 
 // SetData implements [dbft.PreBlock] interface.
 func (p *PreBlock) SetData(pk dbft.PrivateKey) error {
-	encryptedKeys := make([]*tpke.CipherText, len(p.envelopesData))
-	for i := range p.envelopesData {
-		encryptedKeys[i] = p.envelopesData[i].encryptedKey
-	}
-	shares, err := pk.(*Signer).AmevKeystore.DecryptWithShare(encryptedKeys)
-	if err != nil {
-		return fmt.Errorf("failed to construct shares: %w", err)
+	var shares []*tpke.DecryptionShare
+	if !p.enforceECDSASignatures {
+		encryptedKeys := make([]*tpke.CipherText, len(p.envelopesData))
+		for i := range p.envelopesData {
+			encryptedKeys[i] = p.envelopesData[i].encryptedKey
+		}
+		var err error
+		shares, err = pk.(*Signer).AmevKeystore.DecryptWithShare(encryptedKeys)
+		if err != nil {
+			return fmt.Errorf("failed to construct decryption shares: %w", err)
+		}
 	}
 
 	p.localShares = encodeShares(shares)
@@ -58,10 +67,10 @@ func (p *PreBlock) SetData(pk dbft.PrivateKey) error {
 func (p *PreBlock) Verify(_ dbft.PublicKey, data []byte) error {
 	shares, err := decodeShares(data)
 	if err != nil {
-		return fmt.Errorf("decode shares: %w", err)
+		return fmt.Errorf("failed to decode decryption shares: %w", err)
 	}
 	if len(shares) != len(p.envelopesData) {
-		return fmt.Errorf("invalid Envelopes count: expected %d, got %d", len(p.envelopesData), len(shares))
+		return fmt.Errorf("invalid decryption shares count: expected %d, got %d", len(p.envelopesData), len(shares))
 	}
 	return nil
 }
@@ -86,7 +95,7 @@ func (b *PreBlock) SetTransactions(txx []dbft.Transaction[common.Hash]) {
 	)
 	for i, tx := range txx {
 		txs[i] = tx.(*Transaction).Tx
-		if isEnvelope(txs[i]) {
+		if !b.enforceECDSASignatures && isEnvelope(txs[i]) {
 			d, err := decodeEnvelopeData(txs[i].Data())
 			if err != nil {
 				// Not an Envelope in fact since it contains malformed data. Include


### PR DESCRIPTION
If enforceECDSASignatures is on, then:

1. Don't decode Envelopes.
2. Disable construction of decryption shares at PreCommit constructor level.
3. Verify PreCommits of other CNs against the actual list of actual decoded Envelops count.

Close #382.

Tested on 4-nodes privnet, works as expected (Envelope is accepted instead of decrypted inner tx). @songb2, @txhsl  please ensure/test that it also works for your case.