### PR TITLE
consensus/dbft: prevent keystore persistence when suspended as fix

### DIFF
--- a/consensus/dbft/dkg.go
+++ b/consensus/dbft/dkg.go
@@ -333,8 +333,10 @@ func (c *DBFT) handleDKG(snapshot *Snapshot, keystore *antimev.KeyStore, h *type
 		snapshot.ReshareRecoverTasked = true
 	}
 
-	if err := keystore.Persist(); err != nil {
-		return fmt.Errorf("failed to persist keystore, err: %v", err)
+	if !suspended {
+		if err := keystore.Persist(); err != nil {
+			return fmt.Errorf("failed to persist keystore, err: %v", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Fix a mistake in #388 which persists antimev keystore to the file even with a `suspended` flag.