### PR TITLE
dbft: support cross-epoch Envelope decryption

### DIFF
--- a/antimev/tpke.go
+++ b/antimev/tpke.go
@@ -2,6 +2,7 @@ package antimev
 
 import (
 	"errors"
+	"fmt"
 	"math"
 
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
@@ -66,11 +67,11 @@ func (ks *KeyStore) AggregateAndDecryptWithShare(cts []*tpke.CipherText, msg [][
 		return nil, ErrNoPubKey
 	}
 	if len(cts) != len(msg) {
-		return nil, ErrLengthMismatch
+		return nil, fmt.Errorf("%w: %d encrypted keys vs %d encrypted messages", ErrLengthMismatch, len(cts), len(msg))
 	}
-	for _, v := range inputs {
+	for i, v := range inputs {
 		if len(v) != len(cts) {
-			return nil, ErrLengthMismatch
+			return nil, fmt.Errorf("%w: validator %d: %d decryption shares vs %d encrypted keys", ErrLengthMismatch, i, len(v), len(cts))
 		}
 	}
 	// Try decrypt the aes keys, err will be nil if the provided shares are valid,

--- a/antimev/tpke_test.go
+++ b/antimev/tpke_test.go
@@ -2,6 +2,7 @@ package antimev
 
 import (
 	"bytes"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"math/big"
@@ -128,6 +129,9 @@ func TestInitKeyStores(t *testing.T) {
 
 // TestGenerateEncryptedTx generates an encrypted transaction using 7-nodes
 func TestGenerateEncryptedTx(t *testing.T) {
+	// epoch is an epoch of Envelope data encryption. The resulting encrypted transaction can be
+	// decrypted only during this or next epoch.
+	const epoch = 1
 	require.Equal(t, 7, size, "refactor test if different number of CNs is needed")
 
 	// Retrieve and decrypt the set of anti-MEV key storages.
@@ -148,7 +152,11 @@ func TestGenerateEncryptedTx(t *testing.T) {
 		t.Fatalf("invalid ciphertext")
 	}
 	// Generate envelope.
-	var envelopeData = []byte{0xff, 0xff, 0xff, 0xff}
+	var envelopeData = []byte{
+		0xff, 0xff, 0xff, 0xff, // version
+		0, 0, 0, 0, // epoch
+	}
+	binary.LittleEndian.PutUint32(envelopeData[4:8], epoch)
 	envelopeData = append(envelopeData, encryptedKey.ToBytes()...)
 	envelopeData = append(envelopeData, encryptedMsg...)
 	t.Logf("encryptedKey: %s\nencryptedMsg: %s\nenvelopeData: 0x%s\nencrypted tx hash: %s\n",

--- a/consensus/dbft/amev.go
+++ b/consensus/dbft/amev.go
@@ -3,6 +3,7 @@ package dbft
 import (
 	"bytes"
 	"crypto/aes"
+	"encoding/binary"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/core/systemcontracts"
@@ -20,13 +21,17 @@ var (
 	// encryptedDataPrefixLen is the length of encryptedDataPrefix.
 	encryptedDataPrefixLen = len(encryptedDataPrefix)
 
+	// encryptedDataRoundLen is the amount of bytes that encoded DKG round of transaction
+	// encryption takes in the Envelope's data byte slice (the size of Uint64).
+	encryptedDataRoundLen = 4
+
 	// minEncryptedDataSize is the minimum size of encrypted data stored in the
 	// Envelope transaction. It consists of the constant-length prefix,
 	// constant-length CipherText and variable-length encrypted message. The size of
 	// a simple gas transfer with 1 gwei (105 bytes) is taken as a reference point
 	// for evaluation of variable-length part; it is padded to be even to the AES
 	// block size as required by AES encryption rules.
-	minEncryptedDataSize = encryptedDataPrefixLen + tpke.CipherTextSize + 105 + (aes.BlockSize - 105%aes.BlockSize)
+	minEncryptedDataSize = encryptedDataPrefixLen + encryptedDataRoundLen + tpke.CipherTextSize + 105 + (aes.BlockSize - 105%aes.BlockSize)
 )
 
 // isEnvelope checks whether a transaction is an Envelope transaction. The criteria
@@ -52,6 +57,9 @@ type envelopeData struct {
 	index int
 	// prefix is a 4-bytes prefix used for Envelope's data versioning.
 	prefix []byte
+	// dkgRound is a DKG round index by the moment Envelope's data was encrypted
+	// according to the KeyManagement system contract.
+	dkgRound uint32
 	// encryptedKey is a tpke.CipherText provided by the sender of encrypted
 	// transaction.
 	encryptedKey *tpke.CipherText
@@ -62,15 +70,24 @@ type envelopeData struct {
 // decodeEnvelopeData decodes envelopeData from the provided slice. It's a no-op to
 // pass not an Envelope's data.
 func decodeEnvelopeData(buf []byte) (envelopeData, error) {
-	var key = new(tpke.CipherText)
+	var (
+		key              = new(tpke.CipherText)
+		keyOffset        = encryptedDataPrefixLen + encryptedDataRoundLen
+		cipherTextOffset = keyOffset + tpke.CipherTextSize
+	)
 	// It's guaranteed by Envelope definition that buf has a proper length.
-	_, err := key.FromBytes(buf[encryptedDataPrefixLen : encryptedDataPrefixLen+tpke.CipherTextSize])
+	_, err := key.FromBytes(buf[keyOffset:cipherTextOffset])
 	if err != nil {
 		return envelopeData{}, fmt.Errorf("failed to decode TPKE cipher text: %w", err)
 	}
+	round := binary.LittleEndian.Uint32(buf[encryptedDataPrefixLen:keyOffset])
+	if round == 0 {
+		return envelopeData{}, fmt.Errorf("invalid TPKE cipher text: invalid round %d", round)
+	}
 	return envelopeData{
 		prefix:       buf[:encryptedDataPrefixLen],
+		dkgRound:     round,
 		encryptedKey: key,
-		encryptedMsg: buf[encryptedDataPrefixLen+tpke.CipherTextSize:],
+		encryptedMsg: buf[cipherTextOffset:],
 	}, nil
 }

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1958,7 +1958,7 @@ func (c *DBFT) waitForNewSealingProposal(desiredHeight uint64, updateContext boo
 		c.lock.RUnlock()
 		err := c.handleDKG(c.dkgSnapshot, ks, currHeader, nil, false)
 		if err != nil {
-			return fmt.Errorf("failed to initialize DKG snapshot at height %d: %w", err)
+			return fmt.Errorf("failed to initialize DKG snapshot at height %d: %w", currHeader.Number.Uint64(), err)
 		}
 	}
 

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -90,6 +90,11 @@ const (
 	// blocks to effectivaly verify dBFT payloads travelling through the network and
 	// properly initialize dBFT at the latest height.
 	validatorsCacheCap = 3
+	// crossEpochDecryptionStartRound is the number of DKG round (as denoted in KeyManagement
+	// system contract) starting from which continuous cross-epoch Envelopes decryption is supported.
+	// First DKG round setups sharing key, second DKG round setups resharing key, hence resharing
+	// key may be used for decryption starting from the third round.
+	crossEpochDecryptionStartRound = 3
 )
 
 // Various error messages to mark blocks invalid. These should be private to
@@ -505,6 +510,7 @@ func (c *DBFT) newBlockFromContextCb(ctx *dbft.Context[common.Hash]) dbft.Block[
 		header:                 pre.header,
 		transactions:           pre.finalTransactions,
 		withdrawals:            pre.withdrawals,
+		dkgRound:               pre.dkgRound,
 		enforceECDSASignatures: c.config.enforceECDSASignatures,
 	}
 	ethBlock := finalBlock.ToEthBlock()
@@ -972,39 +978,91 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 	if len(pre.envelopesData) == 0 {
 		pre.finalTransactions = pre.transactions
 	} else {
-		shares := make(map[int][]*tpke.DecryptionShare)
+		var (
+			encryptedKeysCurr = make([]*tpke.CipherText, 0, len(pre.envelopesData))
+			encryptedKeysPrev []*tpke.CipherText
+			encryptedMsgsCurr = make([][]byte, 0, len(pre.envelopesData))
+			encryptedMsgsPrev [][]byte
+			currSharesCnt     int
+			prevSharesCnt     int
+		)
+		for _, d := range pre.envelopesData {
+			if d.dkgRound == pre.dkgRound {
+				encryptedKeysCurr = append(encryptedKeysCurr, d.encryptedKey)
+				encryptedMsgsCurr = append(encryptedMsgsCurr, d.encryptedMsg)
+				currSharesCnt++
+			} else {
+				encryptedKeysPrev = append(encryptedKeysPrev, d.encryptedKey)
+				encryptedMsgsPrev = append(encryptedMsgsPrev, d.encryptedMsg)
+				prevSharesCnt++
+			}
+		}
+
+		var (
+			sharesCurr = make(map[int][]*tpke.DecryptionShare, ctx.M())
+			sharesPrev = make(map[int][]*tpke.DecryptionShare)
+			blockNum   = pre.header.Number.Uint64() - 1
+		)
 		for _, preC := range ctx.PreCommitPayloads {
 			if preC != nil && preC.ViewNumber() == ctx.ViewNumber {
-				blockNum := pre.header.Number.Uint64() - 1
 				dkgIndex, err := c.getDKGIndex(int(preC.ValidatorIndex()), blockNum)
 				if err != nil {
 					return fmt.Errorf("get DKG index failed: ValidatorIndex %d, block height %d", int(preC.ValidatorIndex()), blockNum)
 				}
-				// Indexes in shares map must use dkg index.
-				shares[dkgIndex] = preC.GetPreCommit().(*preCommit).Shares()
+				curr, prev := preC.GetPreCommit().(*preCommit).Shares()
+				if len(curr) == currSharesCnt {
+					// Indexes in shares map must use DKG index.
+					sharesCurr[dkgIndex] = curr
+				} else {
+					log.Error("number of shares for the current round mismatch",
+						"round", pre.dkgRound,
+						"validator", preC.ValidatorIndex(),
+						"validator DKG index", dkgIndex,
+						"expected", currSharesCnt,
+						"actual", len(curr))
+				}
+				if len(prev) == prevSharesCnt {
+					// Indexes in shares map must use DKG index.
+					sharesPrev[dkgIndex] = prev
+				} else {
+					log.Error("number of shares for the previous round mismatch",
+						"round", pre.dkgRound-1,
+						"validator", preC.ValidatorIndex(),
+						"validator DKG index", dkgIndex,
+						"expected", prevSharesCnt,
+						"actual", len(prev))
+				}
 			}
 		}
-		var (
-			encryptedKeys = make([]*tpke.CipherText, len(pre.envelopesData))
-			encryptedMsgs = make([][]byte, len(pre.envelopesData))
-		)
-		for i := range pre.envelopesData {
-			encryptedKeys[i] = pre.envelopesData[i].encryptedKey
-			encryptedMsgs[i] = pre.envelopesData[i].encryptedMsg
-		}
+
 		c.lock.RLock()
 		ks := c.amevKeystore
 		c.lock.RUnlock()
-
-		decryptedTxsBytes, err := ks.AggregateAndDecryptWithShare(encryptedKeys, encryptedMsgs, shares)
+		decryptedTxsBytes, err := ks.AggregateAndDecryptWithShare(encryptedKeysCurr, encryptedMsgsCurr, sharesCurr)
 		if err != nil {
 			// Some shares are invalid, valid shares isn't enough to decrypt, wait for more shares to be collected.
-			return fmt.Errorf("failed to decrypt Encrypted transactions, not enough valid shares: %w", err)
+			return fmt.Errorf("failed to decrypt Encrypted transactions for the current DKG round %d, not enough valid shares: %w", pre.dkgRound, err)
+		}
+		var decryptedTxsBytesPrev [][]byte
+		if pre.dkgRound >= crossEpochDecryptionStartRound {
+			decryptedTxsBytesPrev, err = ks.AggregateAndDecryptWithReshare(encryptedKeysPrev, encryptedMsgsPrev, sharesPrev)
+			if err != nil {
+				// Some shares are invalid, valid shares isn't enough to decrypt, wait for more shares to be collected.
+				return fmt.Errorf("failed to decrypt Encrypted transactions for the previous DKG round %d, not enough valid shares: %w", pre.dkgRound-1, err)
+			}
 		}
 
-		if len(decryptedTxsBytes) != len(pre.envelopesData) {
+		// Merge two slices of decrypted transactions into a single slice preserving original Envelopes order.
+		if len(decryptedTxsBytes)+len(decryptedTxsBytesPrev) != len(pre.envelopesData) {
 			// Some shares are invalid, valid shares isn't enough to decrypt, wait for more shares to be collected.
-			return fmt.Errorf("invalid number of Decrypted transactions: expected %d, actual %d", len(pre.envelopesData), len(decryptedTxsBytes))
+			return fmt.Errorf("invalid number of Decrypted transactions: expected %d, actual %d", len(pre.envelopesData), len(decryptedTxsBytes)+len(decryptedTxsBytesPrev))
+		}
+		var prevI int
+		for i, d := range pre.envelopesData {
+			if d.dkgRound != pre.dkgRound {
+				decryptedTxsBytes = slices.Insert(decryptedTxsBytes, i, decryptedTxsBytesPrev[prevI])
+				prevI++
+			}
 		}
 
 		var (
@@ -1098,7 +1156,8 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 		header:                 pre.header,
 		transactions:           pre.finalTransactions,
 		withdrawals:            pre.withdrawals,
-		enforceECDSASignatures: c.config.enforceECDSASignatures,
+		dkgRound:               pre.dkgRound,
+		enforceECDSASignatures: pre.enforceECDSASignatures,
 	}
 	ethBlock := finalBlock.ToEthBlock()
 	state, receipts, _, gasUsed, err := c.chain.ProcessState(ethBlock, nil)
@@ -1201,6 +1260,7 @@ func (c *DBFT) newPreBlockFromContext(sealingProposal *types.Header) *PreBlock {
 	// called by dBFT library to properly initialize PreBlock's transactions.
 	res := &PreBlock{
 		header:                 h,
+		dkgRound:               uint32(c.dkgSnapshot.Round),
 		enforceECDSASignatures: c.config.enforceECDSASignatures,
 	}
 	// Withdrawals are temporary empty if Shanghai is passed.

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1947,7 +1947,7 @@ func (c *DBFT) waitForNewSealingProposal(desiredHeight uint64, updateContext boo
 			"sealing proposal index", b.NumberU64())
 		ltstHeader := c.chain.GetHeaderByNumber(b.NumberU64() - 1)
 		c.postBlock(ltstHeader, nil)
-	} else {
+	} else if c.lastIndex >= uint64(c.config.dkgEnablingHeight) {
 		// Manually initialize DKG snapshot based on the latest block information
 		// (we're sure that state of the latest block is available by this moment,
 		// miner guarantees that). We can't do it earlier because blocks chain

--- a/consensus/dbft/dkg.go
+++ b/consensus/dbft/dkg.go
@@ -182,7 +182,7 @@ func (c *DBFT) handleDKG(snapshot *Snapshot, keystore *antimev.KeyStore, h *type
 	keystoreRound := keystore.Round()
 	// If keystore has a round of future, then return an error
 	if keystoreRound >= int(snapshot.Round) {
-		return fmt.Errorf("invalid antimev keystore round index: %v", keystoreRound)
+		return fmt.Errorf("invalid antimev keystore round index: expected %d, got %d", snapshot.Round, keystoreRound)
 	}
 	// If this round failed but keystore is still in a sharing state
 	if keystoreRound == int(snapshot.Round)-1 && currentHeight < shareStartHeight && keystore.IsSharing() {

--- a/consensus/dbft/dkg.go
+++ b/consensus/dbft/dkg.go
@@ -40,7 +40,7 @@ type TxWatchList struct {
 // Snapshot is a temporary record to save progress of a DKG round
 type Snapshot struct {
 	EpochStartHeight     uint64
-	Round                uint64 // Starts from 1
+	Round                uint64 // Starts from 1, points to the next round if initDone.
 	CurrentCNs           []common.Address
 	PendingCNs           []common.Address
 	IndexNeedRecover     []uint64

--- a/consensus/dbft/preblock.go
+++ b/consensus/dbft/preblock.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/tpke"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/nspcc-dev/dbft"
 )
 
@@ -19,7 +20,10 @@ type PreBlock struct {
 	header       *types.Header
 	withdrawals  []*types.Withdrawal
 	transactions []*types.Transaction
-	localShares  []byte
+	// localShares holds serialized local TPKE shares containing two entries:
+	// encoded slice of the current round shares followed by encoded slice of
+	// the previous round shares.
+	localShares []byte
 
 	// envelopesData is the ordered list of decoded content of Envelopes
 	// transactions of the proposed PreBlock. In case if enforceECDSASignatures
@@ -29,6 +33,9 @@ type PreBlock struct {
 	// enforceECDSASignatures reflects whether dBFT uses backup multisignature
 	// block signing scheme.
 	enforceECDSASignatures bool
+	// dkgRound is the index of DKG round for the current proposal according to
+	// KeyManagement system contract.
+	dkgRound uint32
 
 	// finalTransactions is the cached final list of transactions formed after TPKE
 	// decryption of Envelopes content. This list includes both simple standard and
@@ -46,31 +53,63 @@ func (p *PreBlock) Data() []byte { return p.localShares }
 
 // SetData implements [dbft.PreBlock] interface.
 func (p *PreBlock) SetData(pk dbft.PrivateKey) error {
-	var shares []*tpke.DecryptionShare
+	var (
+		sharesCurr []*tpke.DecryptionShare
+		sharesPrev []*tpke.DecryptionShare
+	)
 	if !p.enforceECDSASignatures {
-		encryptedKeys := make([]*tpke.CipherText, len(p.envelopesData))
-		for i := range p.envelopesData {
-			encryptedKeys[i] = p.envelopesData[i].encryptedKey
+		var (
+			// The most common usage scenario is decryption of transactions from the same
+			// DKG epoch, hence, don't allocate the list of encryptedKeysPrev in advance.
+			encryptedKeysCurr = make([]*tpke.CipherText, 0, len(p.envelopesData))
+			encryptedKeysPrev []*tpke.CipherText
+			err               error
+		)
+		for _, d := range p.envelopesData {
+			if d.dkgRound == p.dkgRound {
+				encryptedKeysCurr = append(encryptedKeysCurr, d.encryptedKey)
+			} else {
+				encryptedKeysPrev = append(encryptedKeysPrev, d.encryptedKey)
+			}
 		}
-		var err error
-		shares, err = pk.(*Signer).AmevKeystore.DecryptWithShare(encryptedKeys)
+
+		// Use "try our best" approach and proceed without decryption if error happens.
+		sharesCurr, err = pk.(*Signer).AmevKeystore.DecryptWithShare(encryptedKeysCurr)
 		if err != nil {
-			return fmt.Errorf("failed to construct decryption shares: %w", err)
+			log.Error("failed to construct decryption shares for the current DKG round, skipping",
+				"round", p.dkgRound,
+				"error", err)
+		}
+		if p.dkgRound >= crossEpochDecryptionStartRound {
+			sharesPrev, err = pk.(*Signer).AmevKeystore.DecryptWithReshare(encryptedKeysPrev)
+			if err != nil {
+				log.Error("failed to construct decryption shares for the previous DKG round, skipping",
+					"round", p.dkgRound-1,
+					"error", err)
+			}
 		}
 	}
 
-	p.localShares = encodeShares(shares)
+	p.localShares = encodeShares(sharesCurr, sharesPrev)
 	return nil
 }
 
 // Verify implements [dbft.PreBlock] interface.
-func (p *PreBlock) Verify(_ dbft.PublicKey, data []byte) error {
-	shares, err := decodeShares(data)
+func (p *PreBlock) Verify(pub dbft.PublicKey, data []byte) error {
+	sharesCurr, sharesPrev, err := decodeShares(data)
 	if err != nil {
 		return fmt.Errorf("failed to decode decryption shares: %w", err)
 	}
-	if len(shares) != len(p.envelopesData) {
-		return fmt.Errorf("invalid decryption shares count: expected %d, got %d", len(p.envelopesData), len(shares))
+	n := len(sharesCurr) + len(sharesPrev)
+	if n > len(p.envelopesData) {
+		return fmt.Errorf("invalid decryption shares count: expected not more than %d, got %d/%d", len(p.envelopesData), len(sharesCurr), len(sharesPrev))
+	}
+	if n != len(p.envelopesData) {
+		log.Error("some decryption shares are missing",
+			"validator", pub.(*PublicKey).Account,
+			"expected", len(p.envelopesData),
+			"got for current round", len(sharesCurr),
+			"got for previous round", len(sharesPrev))
 	}
 	return nil
 }
@@ -100,6 +139,10 @@ func (b *PreBlock) SetTransactions(txx []dbft.Transaction[common.Hash]) {
 			if err != nil {
 				// Not an Envelope in fact since it contains malformed data. Include
 				// it as a simple transaction.
+				continue
+			}
+			if d.dkgRound < min(1, b.dkgRound-1) || b.dkgRound < d.dkgRound {
+				// Envelope not from current/previous DKG round, won't be decoded.
 				continue
 			}
 			d.index = i

--- a/consensus/dbft/precommit.go
+++ b/consensus/dbft/precommit.go
@@ -2,7 +2,6 @@ package dbft
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 
@@ -26,8 +25,9 @@ type preCommit struct {
 	dataExt []byte
 
 	// cached indicates whether shares content is decoded from dataExt.
-	cached bool
-	shares []*tpke.DecryptionShare
+	cached     bool
+	sharesCurr []*tpke.DecryptionShare
+	sharesPrev []*tpke.DecryptionShare
 }
 
 // preCommitAux is an auxiliary structure used for preCommit RLP encoding.
@@ -51,63 +51,91 @@ func (m *preCommit) EncodeRLP(w io.Writer) error {
 
 // DecodeRLP decodes preCommit from RLP.
 func (m *preCommit) DecodeRLP(s *rlp.Stream) error {
-	var aux preCommitAux
-	if err := s.Decode(&aux); err != nil {
+	var (
+		aux preCommitAux
+		err error
+	)
+	if err = s.Decode(&aux); err != nil {
 		return err
 	}
 
 	m.dataExt = aux.DataExt
-	shares, err := decodeShares(m.dataExt)
+	m.sharesCurr, m.sharesPrev, err = decodeShares(m.dataExt)
 	if err != nil {
-		return fmt.Errorf("decode shares: %w", err)
+		return fmt.Errorf("failed to decode shares: %w", err)
 	}
-	m.shares = shares
 	m.cached = true
 
 	return nil
 }
 
 // Shares returns the slice of tpke.DecryptionShare that preCommit carries.
-func (m *preCommit) Shares() []*tpke.DecryptionShare {
+func (m *preCommit) Shares() ([]*tpke.DecryptionShare, []*tpke.DecryptionShare) {
 	if !m.cached {
-		shares, err := decodeShares(m.dataExt)
+		var err error
+		m.sharesCurr, m.sharesPrev, err = decodeShares(m.dataExt)
 		if err != nil {
 			panic(fmt.Errorf("bug: invalid locally constructed shares: %w", err))
 		}
-		m.shares = shares
 		m.cached = true
 	}
-	return m.shares
+	return m.sharesCurr, m.sharesPrev
 }
 
 // encodeShares encodes the slice of tpke.DecryptionShare in the same way as it's
 // required by preCommit serialization rules.
-func encodeShares(shares []*tpke.DecryptionShare) []byte {
-	var res = make([]byte, 4, tpke.DecryptionShareSize*len(shares)+4)
-	binary.LittleEndian.PutUint32(res, uint32(len(shares)))
-	for i := range shares {
-		res = append(res, shares[i].ToBytes()...)
+func encodeShares(sharesCurr []*tpke.DecryptionShare, sharesPrev []*tpke.DecryptionShare) []byte {
+	var res = make([]byte, 4*2, 4*2+tpke.DecryptionShareSize*(len(sharesCurr)+len(sharesPrev)))
+	binary.LittleEndian.PutUint32(res, uint32(len(sharesCurr)))
+	binary.LittleEndian.PutUint32(res[4:], uint32(len(sharesPrev)))
+	for i := range sharesCurr {
+		res = append(res, sharesCurr[i].ToBytes()...)
+	}
+	for i := range sharesPrev {
+		res = append(res, sharesPrev[i].ToBytes()...)
 	}
 	return res
 }
 
 // decodeShares decodes the list of tpke.DecryptionShare from the provided
 // data following preCommit serialization rules.
-func decodeShares(data []byte) ([]*tpke.DecryptionShare, error) {
-	if len(data) < 4 {
-		return nil, errors.New("shares slice is too short")
+func decodeShares(data []byte) ([]*tpke.DecryptionShare, []*tpke.DecryptionShare, error) {
+	offset := 8
+	if len(data) < offset {
+		return nil, nil, fmt.Errorf("shares slice is too short: expected at least %d bytes, got %d", offset, len(data))
 	}
-	n := binary.LittleEndian.Uint32(data[:4])
+
+	nCurr := binary.LittleEndian.Uint32(data[:4])
+	nPrev := binary.LittleEndian.Uint32(data[4:offset])
+	n := nCurr + nPrev
 	if n > maxDecryptionSharesPerBlock {
-		return nil, fmt.Errorf("too many shares: got %d, allowed %d", n, maxDecryptionSharesPerBlock)
+		return nil, nil, fmt.Errorf("too many shares: got %d/%d, allowed %d at max", nCurr, nPrev, maxDecryptionSharesPerBlock)
 	}
-	shares := make([]*tpke.DecryptionShare, n)
-	for i := range shares {
-		shares[i] = &tpke.DecryptionShare{}
-		_, err := shares[i].FromBytes(data[4+i*tpke.DecryptionShareSize : 4+(i+1)*tpke.DecryptionShareSize])
+	expectedLen := offset + int(n*tpke.DecryptionShareSize)
+	if len(data) != expectedLen {
+		return nil, nil, fmt.Errorf("shares slise has invalid length: expected %d, got %d", expectedLen, len(data))
+	}
+
+	var (
+		curr = make([]*tpke.DecryptionShare, nCurr)
+		prev = make([]*tpke.DecryptionShare, nPrev)
+	)
+	for i := range curr {
+		curr[i] = &tpke.DecryptionShare{}
+		_, err := curr[i].FromBytes(data[offset : offset+tpke.DecryptionShareSize])
 		if err != nil {
-			fmt.Errorf("share %d: %w", i, err)
+			fmt.Errorf("decoding current round share %d: %w", i, err)
 		}
+		offset += tpke.DecryptionShareSize
 	}
-	return shares, nil
+	for i := range prev {
+		prev[i] = &tpke.DecryptionShare{}
+		_, err := prev[i].FromBytes(data[offset : offset+tpke.DecryptionShareSize])
+		if err != nil {
+			fmt.Errorf("decoding previous round share %d: %w", i, err)
+		}
+		offset += tpke.DecryptionShareSize
+	}
+
+	return curr, prev, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mattn/go-isatty v0.0.20
 	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
-	github.com/nspcc-dev/dbft v0.3.2-0.20241205125914-b2ba0cd4b763
+	github.com/nspcc-dev/dbft v0.3.2
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/peterh/liner v1.1.1-0.20190123174540-a2c9a5303de7
 	github.com/protolambda/bls12-381-util v0.0.0-20220416220906-d8552aa452c7

--- a/go.sum
+++ b/go.sum
@@ -495,8 +495,8 @@ github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo
 github.com/nats-io/nats.go v1.8.1/go.mod h1:BrFz9vVn0fU3AcH9Vn4Kd7W0NpJ651tD5omQ3M8LwxM=
 github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7TDb/4=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
-github.com/nspcc-dev/dbft v0.3.2-0.20241205125914-b2ba0cd4b763 h1:y6zIB4a0dIblQY+NWFcv6CNcd1JL8UAiPCTnYAN04x8=
-github.com/nspcc-dev/dbft v0.3.2-0.20241205125914-b2ba0cd4b763/go.mod h1:BNvJkPKTE28r+qRaAk2C3VoL2J9qzox3fvEeJbh7EWE=
+github.com/nspcc-dev/dbft v0.3.2 h1:8AFRpV6JZFn1kEPJB7fVQKUm06PzJ69jFxSdOhTEfJo=
+github.com/nspcc-dev/dbft v0.3.2/go.mod h1:tpBE0IRebgucPzKGGxv2Iy7s4knpKqODv157Gc/m1RE=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=

--- a/privnet/four/genesis_privnet.json
+++ b/privnet/four/genesis_privnet.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "chainId": 2312051114,
+    "chainId": 2312251829,
     "homesteadBlock": 0,
     "eip150Block": 0,
     "eip155Block": 0,

--- a/privnet/four/genesis_privnet.json
+++ b/privnet/four/genesis_privnet.json
@@ -31,6 +31,9 @@
   "difficulty": "1",
   "gasLimit": "30000000",
   "alloc": {
+    "0x5e6D9680428e6fe62a09BBb6AC23Df5bFE069AE8": {
+      "balance": "1000000000000000000000"
+    },
     "0x74f4effb0b538baec703346b03b6d9292f53a4cd": {
       "balance": "10000000000000000000000000"
     },

--- a/privnet/seven/genesis_privnet.json
+++ b/privnet/seven/genesis_privnet.json
@@ -34,6 +34,9 @@
   "difficulty": "1",
   "gasLimit": "30000000",
   "alloc": {
+    "0x5e6D9680428e6fe62a09BBb6AC23Df5bFE069AE8": {
+      "balance": "1000000000000000000000"
+    },
     "0x74f4effb0b538baec703346b03b6d9292f53a4cd": {
       "balance": "10000000000000000000000000"
     },

--- a/privnet/single/genesis_privnet.json
+++ b/privnet/single/genesis_privnet.json
@@ -28,6 +28,9 @@
   "difficulty": "1",
   "gasLimit": "30000000",
   "alloc": {
+    "0x5e6D9680428e6fe62a09BBb6AC23Df5bFE069AE8": {
+      "balance": "1000000000000000000000"
+    },
     "0x74f4effb0b538baec703346b03b6d9292f53a4cd": {
       "balance": "10000000000000000000000000"
     },

--- a/privnet/single/genesis_privnet.json
+++ b/privnet/single/genesis_privnet.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "chainId": 2312051126,
+    "chainId": 2312251829,
     "homesteadBlock": 0,
     "eip150Block": 0,
     "eip155Block": 0,


### PR DESCRIPTION
Close #362, close #151.

@txhsl, @songb2 you need to update your JS library that generates Envelope transactions because we've changed the format of Envelope's data to include 4-bytes prefix (DKG epoch of transaction encryption, uint32 in LE form).