### PR TITLE
contracts: fix dkg contract getter parameter naming

### DIFF
--- a/contracts/solidity/KeyManagement.sol
+++ b/contracts/solidity/KeyManagement.sol
@@ -381,16 +381,16 @@ contract KeyManagement is GovProxyUpgradeable, IKeyManagement {
     }
 
     function getShareMsgs(
-        uint height,
+        uint round,
         uint index
     ) external view override returns (bytes[] memory) {
-        return shareMsgs[height][index];
+        return shareMsgs[round][index];
     }
 
     function getReshareMsgs(
-        uint height,
+        uint round,
         uint index
     ) external view override returns (bytes[] memory) {
-        return reshareMsgs[height][index];
+        return reshareMsgs[round][index];
     }
 }

--- a/contracts/solidity/interfaces/IKeyManagement.sol
+++ b/contracts/solidity/interfaces/IKeyManagement.sol
@@ -70,43 +70,43 @@ interface IKeyManagement {
     // get public key of addr
     function messagePubkeys(address addr) external view returns (bytes memory);
 
-    // get share msgs by height and index
+    // get share msgs by round and index
     function getShareMsgs(
-        uint height,
+        uint round,
         uint index
     ) external view returns (bytes[] memory);
 
-    // get share pvss by height and index
+    // get share pvss by round and index
     function spvsses(
-        uint height,
+        uint round,
         uint index
     ) external view returns (bytes memory);
 
-    // get reshare msgs by height and index
+    // get reshare msgs by round and index
     function getReshareMsgs(
-        uint height,
+        uint round,
         uint index
     ) external view returns (bytes[] memory);
 
-    // get reshare pvss by height and index
+    // get reshare pvss by round and index
     function rpvsses(
-        uint height,
+        uint round,
         uint index
     ) external view returns (bytes memory);
 
-    // get recover msg by height, indexSend and indexReceive
+    // get recover msg by round, indexSend and indexReceive
     function recoverMsgs(
-        uint height,
+        uint round,
         uint indexSend,
         uint indexReceive
     ) external view returns (bytes memory);
 
-    // get shared public key by height and index
+    // get shared public key by round and index
     function sharedPubs(
-        uint height,
+        uint round,
         uint index
     ) external view returns (bytes memory);
 
-    // get aggregated commitment by height
-    function aggregatedCommitments(uint height) external view returns (bytes memory);
+    // get aggregated commitment by round
+    function aggregatedCommitments(uint round) external view returns (bytes memory);
 }


### PR DESCRIPTION
Related to #332, there are some getters' parameters using incorrect namings, but they are used correctly by Geth node. So this PR only changes their namings, which make no difference in their functionalities.

It is not necessary to update privnet genesis, because I checked the compiled byte code, it keeps the same.

The abi in `core/systemcontracts/contracts.go` still works, I may update it next time in zk PR.