### PR TITLE
dBFT: fix possibility of missing chain events and state NPE during PreBlock processing

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -405,6 +405,13 @@ func (c *DBFT) processBlockCb(b dbft.Block[common.Hash]) error {
 	if uint64(dbftBlock.Index()) <= c.lastIndex {
 		return nil
 	}
+	if dbftBlock.state == nil {
+		// We're toast, proposal was invalid (likely just outdated), the node doesn't have relevant
+		// block state, hence can't continue block processing. In good scenario (if proposal is valid but outdated)
+		// new block arrival will trigger dBFT initialization at new height, hence don't stop the node immediately.
+		log.Warn("can't process block due to missing state: proposal verification failed")
+		return nil
+	}
 
 	// Avoid copying and may safely change the block itself, as this part
 	// of code is guaranteed to be called once by dBFT.
@@ -482,6 +489,14 @@ func (c *DBFT) newBlockFromContextCb(ctx *dbft.Context[common.Hash]) dbft.Block[
 			state:               c.sealingState,
 			receipts:            c.sealingReceipts,
 		}
+	}
+
+	if pre.finalState == nil {
+		// We're toast, proposal was invalid (likely just outdated), the node doesn't have relevant
+		// block state, hence can't continue consensus. In good scenario (if proposal is valid but outdated)
+		// new block arrival will trigger dBFT initialization at new height, hence don't stop the node immediately.
+		log.Warn("can't construct block due to missing state: proposal verification failed")
+		return nil
 	}
 
 	// Manually update header's fields based on fresh state. Avoid changing

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1852,6 +1852,13 @@ func (c *DBFT) Start(chain ChainHeaderWriter) {
 		c.chain = chain
 		c.blockQueue.chain = chain
 
+		// Subscribe for minted blocks prior to accessing current chain header.
+		// Sealing proposal awaiting may take some time during which new blocks may
+		// arrive via P2P, which may lead to the fact that c.last* fields and dBFT
+		// state are out-of-date comparing to the chain's state by the end of Start.
+		// Early subscription allows to ensure that no blocks can be missed by eventLoop.
+		c.chainHeadSub = c.chain.SubscribeChainHeadEvent(c.chainHeadEvents)
+
 		// Start DKG task dispatcher prior to sealing proposal awaiting since new
 		// block may be discovered during awaiting which may lead to DKG-related
 		// transactions submission.
@@ -1882,9 +1889,6 @@ func (c *DBFT) Start(chain ChainHeaderWriter) {
 			"last height", c.lastIndex,
 			"last timestamp", c.lastTimestamp)
 		c.dbft.Start(c.lastTimestamp * NsInS)
-
-		// Subscribe for minted blocks.
-		c.chainHeadSub = c.chain.SubscribeChainHeadEvent(c.chainHeadEvents)
 
 		go c.eventLoop()
 	}

--- a/consensus/dbft/dkg.go
+++ b/consensus/dbft/dkg.go
@@ -343,6 +343,9 @@ func (c *DBFT) handleDKG(snapshot *Snapshot, keystore *antimev.KeyStore, h *type
 
 // loopTaskList retries every task in tx watch list
 func (c *DBFT) loopTaskList() {
+	log.Info("DKG events dispatcher started")
+	defer log.Info("DKG events dispatcher stopped")
+
 	for watchList := range c.loopTaskChan {
 		log.Info("DKG loopTaskList", "CurrentHeight", watchList.CurrentHeight, "WatchListLength", len(watchList.WatchList))
 		currentHeight := watchList.CurrentHeight


### PR DESCRIPTION
A tricky one, close #395. Both fixes are explained in the commit messages.

@txhsl, @chenquanyu welcome to review. @songb2, please read the description of bugs and try to test these fixes. I've tested it on privnet and wasn't able to reproduce these bugs anymore. But I'm afraid that there's a tiny chance to introduce deadlock with the second commit (try to start a CN that is far behind the chain, so that Downloader is started and check that CN is able to properly sync), I will also test this case and get back with the resiult.