### PR TITLE
dbft: dispose intermediate state DB copies

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -462,7 +462,9 @@ func (c *DBFT) processBlockCb(b dbft.Block[common.Hash]) error {
 		return fmt.Errorf("failed to construct block witness: %w", err)
 	}
 	dbftBlock.header.Extra = append(dbftBlock.header.Extra, witness...) // Extra version isn't changed, validators addresses and signatures are added.
+	// TODO: here snapshot usage is impossible since PutBlock modifies&finalize state.
 	state := dbftBlock.state.Copy()
+	defer state.Dispose()
 	res := types.NewBlockWithHeader(dbftBlock.header).WithBody(dbftBlock.transactions, nil).WithWithdrawals(dbftBlock.withdrawals)
 
 	// Firstly, notify chain about new block.
@@ -2730,7 +2732,9 @@ func (c *DBFT) getGlobalPublicKey(h *types.Header, s *state.StateDB) (*tpke.Publ
 	keystore := c.amevKeystore.Copy()
 	c.lock.RUnlock()
 
-	err := c.handleDKG(snapshot, keystore, h, s.Copy(), true)
+	cp := s.Copy()
+	defer cp.Dispose()
+	err := c.handleDKG(snapshot, keystore, h, cp, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to handle DKG at %d: %w", h.Number.Uint64(), err)
 	}
@@ -2752,7 +2756,13 @@ func (c *DBFT) getGlobalPublicKey(h *types.Header, s *state.StateDB) (*tpke.Publ
 func (c *DBFT) getNextConsensus(h *types.Header, s *state.StateDB) (common.Hash, common.Hash) {
 	var multisig, threshold common.Hash
 
-	nextVals, err := c.getValidatorsSorted(nil, s.Copy(), h)
+	// TODO: consider using snapshots instead of the full state copy, it must save us plenty of resources:
+	// id := cp.Snapshot()
+	// ...
+	// cp.RevertToSnapshot(id)
+	cp := s.Copy()
+	defer cp.Dispose()
+	nextVals, err := c.getValidatorsSorted(nil, cp, h)
 	if err != nil {
 		log.Crit("Failed to compute next block validators",
 			"err", err)

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -2732,9 +2732,9 @@ func (c *DBFT) getGlobalPublicKey(h *types.Header, s *state.StateDB) (*tpke.Publ
 	keystore := c.amevKeystore.Copy()
 	c.lock.RUnlock()
 
-	cp := s.Copy()
-	defer cp.Dispose()
-	err := c.handleDKG(snapshot, keystore, h, cp, true)
+	id := s.Snapshot()
+	defer s.RevertToSnapshot(id)
+	err := c.handleDKG(snapshot, keystore, h, s, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to handle DKG at %d: %w", h.Number.Uint64(), err)
 	}
@@ -2760,9 +2760,9 @@ func (c *DBFT) getNextConsensus(h *types.Header, s *state.StateDB) (common.Hash,
 	// id := cp.Snapshot()
 	// ...
 	// cp.RevertToSnapshot(id)
-	cp := s.Copy()
-	defer cp.Dispose()
-	nextVals, err := c.getValidatorsSorted(nil, cp, h)
+	id := s.Snapshot()
+	defer s.RevertToSnapshot(id)
+	nextVals, err := c.getValidatorsSorted(nil, s, h)
 	if err != nil {
 		log.Crit("Failed to compute next block validators",
 			"err", err)

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -867,7 +867,7 @@ func (s *StateDB) Finalise(deleteEmptyObjects bool) {
 }
 
 func (s *StateDB) Dispose() {
-	// TODO: consider reusing Finalise before prefetchers disposal
+	s.Finalise(true)
 	if s.prefetcher != nil {
 		s.prefetcher.close()
 		s.prefetcher = nil

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -866,6 +866,14 @@ func (s *StateDB) Finalise(deleteEmptyObjects bool) {
 	s.clearJournalAndRefund()
 }
 
+func (s *StateDB) Dispose() {
+	// TODO: consider reusing Finalise before prefetchers disposal
+	if s.prefetcher != nil {
+		s.prefetcher.close()
+		s.prefetcher = nil
+	}
+}
+
 // IntermediateRoot computes the current root hash of the state trie.
 // It is called in between transactions to get the root hash that
 // goes into transaction receipts.


### PR DESCRIPTION
Properly finalize prefetcher routines, otherwise they consume memory and lead to OOM.

Close #386.

WIP: it's just an idea and I need to check how some parts of StateDB work, but in general I'd expect this patch at least partially solve #386. @songb2, @txhsl could you please run this patch for a while using the same environment as in #386 and #414 and check the resulting memory consumption?