### PR TITLE
antimev: ensure decrypted tx hash matches Envelope's data

### DIFF
--- a/antimev/envelope.go
+++ b/antimev/envelope.go
@@ -51,3 +51,10 @@ func IsEnvelope(tx *types.Transaction) bool {
 
 	return true
 }
+
+// GetEncryptedHash returns the hash of inner encrypted transaction specified in an
+// unencrypted part of Envelope data. Passing non-Envelope as an argument is a no-op.
+func GetEncryptedHash(envelope *types.Transaction) common.Hash {
+	hashOffset := EncryptedDataPrefixLen + EncryptedDataRoundLen
+	return common.Hash(envelope.Data()[hashOffset : hashOffset+EncryptedDataHashLen])
+}

--- a/antimev/envelope.go
+++ b/antimev/envelope.go
@@ -37,7 +37,7 @@ var (
 	minEncryptedDataSize = EncryptedDataPrefixLen + EncryptedDataRoundLen + EncryptedDataHashLen + tpke.CipherTextSize + 105 + (aes.BlockSize - 105%aes.BlockSize)
 )
 
-// isEnvelope checks whether a transaction is an Envelope transaction. The criteria
+// IsEnvelope checks whether a transaction is an Envelope transaction. The criteria
 // include receiver's address, data prefix and data length check.
 func IsEnvelope(tx *types.Transaction) bool {
 	if tx.To() == nil || *(tx.To()) != systemcontracts.GovernanceRewardProxyHash {

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1237,11 +1237,14 @@ func (c *DBFT) validateDecryptedTx(head *types.Header, decryptedTx *types.Transa
 	if decryptedTx.Nonce() != envelope.Nonce() {
 		return fmt.Errorf("decryptedTx nonce mismatch: decryptedNonce %v, envelopeNonce %v", decryptedTx.Nonce(), envelope.Nonce())
 	}
+
 	// Ensure the gasprice is high enough to replace the envelope transaction
 	baseFee := head.BaseFee
 	if decryptedTx.EffectiveGasTipCmp(envelope, baseFee) < 0 {
 		return fmt.Errorf("decryptedTx underpriced: EffectiveGasTip needed %v, EffectiveGasTip permitted %v", envelope.EffectiveGasTipValue(baseFee), decryptedTx.EffectiveGasTipValue(baseFee))
 	}
+
+	// Ensure envelope sender matches decrypted sender.
 	envelopeFrom, err := types.Sender(c.signerConfig, envelope)
 	if err != nil {
 		return fmt.Errorf("%w: failed to retrieve envelope sender: %w", txpool.ErrInvalidSender, err)
@@ -1253,6 +1256,7 @@ func (c *DBFT) validateDecryptedTx(head *types.Header, decryptedTx *types.Transa
 	if envelopeFrom != decryptedFrom {
 		return fmt.Errorf("decryptedTx from mismatch: decryptedFrom %v, envelopeFrom %v", decryptedFrom, envelopeFrom)
 	}
+
 	return nil
 }
 

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1257,6 +1257,12 @@ func (c *DBFT) validateDecryptedTx(head *types.Header, decryptedTx *types.Transa
 		return fmt.Errorf("decryptedTx from mismatch: decryptedFrom %v, envelopeFrom %v", decryptedFrom, envelopeFrom)
 	}
 
+	// Ensure decrypted hash matches the one specified in an unencrypted part of Envelope data.
+	expectedH := antimev.GetEncryptedHash(envelope)
+	if decryptedTx.Hash().Cmp(expectedH) != 0 {
+		return fmt.Errorf("decryptedTx hash mismatch: expected %s, got %s", expectedH, decryptedTx.Hash())
+	}
+
 	return nil
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1893,8 +1893,7 @@ func SubmitTransaction(ctx context.Context, b Backend, tx *types.Transaction) (c
 
 	// If the transaction is an antimev envelope, then return the declared transaction hash instead of its own.
 	if antimev.IsEnvelope(tx) {
-		hashOffSet := antimev.EncryptedDataPrefixLen + antimev.EncryptedDataRoundLen
-		return common.Hash(tx.Data()[hashOffSet : hashOffSet+antimev.EncryptedDataHashLen]), nil
+		return antimev.GetEncryptedHash(tx), nil
 	} else {
 		return tx.Hash(), nil
 	}


### PR DESCRIPTION
Decrypted transaction hash must be checked against the hash declared in an unencrypted part of Envelope's data. Otherwise decrypted transaction is invalid and must not be accepted. Related to https://github.com/bane-labs/go-ethereum/pull/418.

@txhsl, please also review.