### PR TITLE
contracts: move encrypted tx gas limit check to consensus level

### DIFF
--- a/antimev/envelope.go
+++ b/antimev/envelope.go
@@ -9,7 +9,13 @@ import (
 	"github.com/ethereum/go-ethereum/core/systemcontracts"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto/tpke"
+	"github.com/ethereum/go-ethereum/params"
 )
+
+// MinEncryptedGasLimit is the minimum required gas limit for encrypted transaction.
+// It is set to be equal to a simple transfer execution cost since it is assumed that
+// minimum valid encrypted transaction structure is a simple transfer.
+const MinEncryptedGasLimit = uint32(params.TxGas)
 
 var (
 	// EncryptedDataPrefix is the prefix of Envelope transaction's data. It's used to
@@ -75,7 +81,7 @@ func GetEncryptedHash(envelope *types.Transaction) common.Hash {
 
 // GetEncryptedGas returns the gas limit of inner encrypted transaction specified in an
 // unencrypted part of Envelope data. Passing non-Envelope as an argument is a no-op.
-func GetEncryptedGas(envelope *types.Transaction) uint32 {
+func GetEncryptedGas(envelopeData []byte) uint32 {
 	gasOffset := EncryptedDataPrefixLen + EncryptedDataRoundLen
-	return binary.BigEndian.Uint32(envelope.Data()[gasOffset : gasOffset+EncryptedDataGasLen])
+	return binary.BigEndian.Uint32(envelopeData[gasOffset : gasOffset+EncryptedDataGasLen])
 }

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1263,7 +1263,7 @@ func (c *DBFT) validateDecryptedTx(head *types.Header, decryptedTx *types.Transa
 		return fmt.Errorf("decryptedTx hash mismatch: expected %s, got %s", expectedH, decryptedTx.Hash())
 	}
 	// Ensure decrypted gas limit is the same as the envelope declared
-	expectedG := antimev.GetEncryptedGas(envelope)
+	expectedG := antimev.GetEncryptedGas(envelope.Data())
 	if decryptedTx.Gas() != uint64(expectedG) {
 		return fmt.Errorf("decryptedTx gas limit mismatch: expected %v, got %v", expectedG, decryptedTx.Gas())
 	}

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -335,6 +335,16 @@ func (st *StateTransition) preCheck() error {
 						return fmt.Errorf("%w: address %v, gasLimit %v, policy maxEnvelopeGasLimit %v, ", ErrGasLimitReached, msg.From.Hex(), msg.GasLimit,
 							envelopeGasLimit)
 					}
+					// Check that encrypted transaction gas limit satisfies the minimum required gas limit.
+					encryptedGasLimit := antimev.GetEncryptedGas(msg.Data)
+					if encryptedGasLimit < antimev.MinEncryptedGasLimit {
+						return fmt.Errorf("invalid encrypted transaction gas limit: required at least %v, got %v", antimev.MinEncryptedGasLimit, encryptedGasLimit)
+					}
+					// The gas limit of Envelope transaction should be enough to cover encrypted transaction
+					// execution.
+					if msg.GasLimit < uint64(encryptedGasLimit) {
+						return fmt.Errorf("invalid envelope gas limit: at least %d is required for encrypted transaction execution, have %d", encryptedGasLimit, msg.GasLimit)
+					}
 					var envelopeFee = st.state.GetState(systemcontracts.PolicyProxyHash, systemcontracts.GetEnvelopeFeeStateHash()).Big()
 					minGasTipCap.Add(minGasTipCap, envelopeFee)
 				}

--- a/core/txpool/errors.go
+++ b/core/txpool/errors.go
@@ -45,6 +45,10 @@ var (
 	// maximum allowance of the current block.
 	ErrGasLimit = errors.New("exceeds block gas limit")
 
+	// ErrEnvelopeGasLimit is returned if an Envelope transaction's requested gas limit
+	// doesn't satisfy verification criteria.
+	ErrEnvelopeGasLimit = errors.New("invalid Envelope gas limit")
+
 	// ErrNegativeValue is a sanity error to ensure no one is able to specify a
 	// transaction with a negative value.
 	ErrNegativeValue = errors.New("negative value")

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -220,7 +220,18 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 	if antimev.IsEnvelope(tx) {
 		var envelopeGasLimit = opts.State.GetState(systemcontracts.PolicyProxyHash, systemcontracts.GetMaxEnvelopeGasLimitStateHash()).Big()
 		if new(big.Int).SetUint64(tx.Gas()).Cmp(envelopeGasLimit) > 0 {
-			return fmt.Errorf("%w: policy maxEnvelopeGasLimit allowed %v, gas %v", ErrGasLimit, envelopeGasLimit, tx.Gas())
+			return fmt.Errorf("%w: policy maxEnvelopeGasLimit allowed %v, gas %v", ErrEnvelopeGasLimit, envelopeGasLimit, tx.Gas())
+		}
+		// Assuming that encrypted transaction is at least a simple transfer, its gas limit
+		// must be enough to cover simple transfer execution.
+		encryptedGasLimit := antimev.GetEncryptedGas(tx.Data())
+		if encryptedGasLimit < antimev.MinEncryptedGasLimit {
+			return fmt.Errorf("invalid encrypted transaction gas limit: required at least %v, got %v", antimev.MinEncryptedGasLimit, encryptedGasLimit)
+		}
+		// The gas limit of Envelope transaction should be enough to cover encrypted transaction
+		// execution.
+		if tx.Gas() < uint64(encryptedGasLimit) {
+			return fmt.Errorf("%w: at least %d is required for encrypted transaction execution, have %d", ErrEnvelopeGasLimit, encryptedGasLimit, tx.Gas())
 		}
 		// Add envelope fee on top of minGasTipCap check
 		var envelopeFee = opts.State.GetState(systemcontracts.PolicyProxyHash, systemcontracts.GetEnvelopeFeeStateHash()).Big()


### PR DESCRIPTION
This commit solves two problems:
1. By the moment of GovReward contract execution we must be sure that encrypted transaction gas limit satisfies minimum required value.
2. By the same moment we must be sure that Envelope transaction has enough gas limit to pay for execution of decrypted transaction.

If these two constrains are violated, contract itself can't do anything about it, the Envelope execution will be aborted, but still, Envelope will be accepted to the chain since we don't filter out failed Envelopes (and we shouldn't do that, ref. https://github.com/bane-labs/go-ethereum/pull/422#discussion_r1971545809).

However, the check is still needed because otherwise it's easy for the user to accidently send an invalid Envelope spending user's funds for nothing. I won't say that it's a vector of attack because small Envelope fee will lead to the fact that encrypted tx execution itself will be restricted by this value and hence it's not critical for the system and doesn't bring any profit to the user.

This commit moves these two checks to mempool and state transition level so that it's impossible to submit Envelope that is improperly constructed.

@txhsl need your review.