### PR TITLE
dbft: fix panic during decrypted transaction validation

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1115,6 +1115,15 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 			}
 		)
 		defer localPool.CloseSilently()
+
+		// If we're backup, then pre.finalReceipts are filled in during PreBlock verification;
+		// if we're primary, then reuse receipts got after PrepareRequest construction since
+		// PreBlock verification code is not executed by block proposer.
+		var receipts = pre.finalReceipts
+		if ctx.IsPrimary() && pre.finalState == nil {
+			receipts = c.sealingReceipts
+		}
+
 		for i := range pre.transactions {
 			var isEnvelope = j < len(pre.envelopesData) && pre.envelopesData[j].index == i
 			if !isEnvelope || // pre.transactions[i] is not an envelope, use it as-is.
@@ -1142,7 +1151,7 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 					break
 				}
 			}
-			err = c.validateDecryptedTx(parent, decryptedTx, pre.transactions[i], pre.finalReceipts[i])
+			err = c.validateDecryptedTx(parent, decryptedTx, pre.transactions[i], receipts[i])
 			if err != nil {
 				if fallbackToEnvelope(i, true, fmt.Sprintf("decrypted transaction verification failed: %s", err)) {
 					continue


### PR DESCRIPTION
### Problem:

Panic on primary CN during decrypted transaction validation (#438) at line:
https://github.com/bane-labs/go-ethereum/blob/443ad2d9ff649d7f0e42a193affbb35119436ee6/consensus/dbft/dbft.go#L1145

```
1742457125743	INFO [03-20|07:52:05.742] Change view detected, waiting for new sealing task to be submitted by miner "old view"=0 "new view"=1
1742457125743	2025-03-20T07:52:05.742Z	INFO	changing dbft view	{"height": 2099552, "view": 1, "index": 6, "role": "Primary"}
1742457125958	2025-03-20T07:52:05.958Z	DEBUG	timeout	{"height": 2099552, "view": 1}
1742457125958	INFO [03-20|07:52:05.958] Start dBFT process for updated sealing work index=2,099,552 view=1
1742457125958	INFO [03-20|07:52:05.958] Sealing proposal updated                 number=2,099,552 sealhash=74d992..895c98 "parent hash"=55b27c..dfbc98 txs=1

...

1742457126998	2025-03-20T07:52:06.997Z	DEBUG	not enough PreCommits to process PreBlock	{"count": 4}
1742457126999	2025-03-20T07:52:06.999Z	DEBUG	received message	{"type": "PreCommit", "from": 1, "height": 2099552, "view": 1, "my_height": 2099552, "my_view": 1}
1742457127000	2025-03-20T07:52:07.000Z	DEBUG	received message	{"type": "PreCommit", "from": 2, "height": 2099552, "view": 1, "my_height": 2099552, "my_view": 1}
1742457127000	2025-03-20T07:52:07.000Z	INFO	received PreCommit	{"validator": 2}
1742457127000	2025-03-20T07:52:07.000Z	INFO	processing PreBlock	{"height": 2099552, "view": 1, "tx_count": 1, "preCommit_count": 5}
1742457127006	INFO [03-20|07:52:07.006] Envelope data decrypted                  "envelope hash"=7da704..15165e "envelope index"=0 data=02f87883ba930481a18509502f90008509502f9000825208942e211b562507169e1c444ba39d77fed711a69a89880de0b6b3a764000080c080a043b5c23944e6b7d85acc43142c0582ea80e937998ed378393e7aab96ea21f830a0446be83c66974f4a2ad450a2fd6a7a3a266713eccdbae2008dd80b8767647650
1742457127009	goroutine 4589 [running]:
1742457127009	panic: runtime error: index out of range [0] with length 0
1742457127009		github.com/ethereum/go-ethereum/consensus/dbft/dbft.go:1145 +0x2b54
1742457127009		github.com/ethereum/go-ethereum/consensus/dbft/dbft.go:2007 +0x4d6
1742457127009	created by github.com/ethereum/go-ethereum/consensus/dbft.(*DBFT).Start in goroutine 4579
1742457127009		github.com/ethereum/go-ethereum/consensus/dbft/dbft.go:2185 +0xb1d
1742457127009	github.com/ethereum/go-ethereum/consensus/dbft.(*DBFT).eventLoop(0xc000141d48)
1742457127009		github.com/nspcc-dev/dbft@v0.3.2/dbft.go:560 +0xd99
1742457127009	github.com/nspcc-dev/dbft.(*DBFT[...]).onPreCommit(0x1fe3da0, {0x1fc8f90, 0xc0048a6510})
1742457127009		github.com/nspcc-dev/dbft@v0.3.2/check.go:79 +0x705
1742457127009	github.com/nspcc-dev/dbft.(*DBFT[...]).checkPreCommit(0x1fe3da0)
1742457127009		github.com/nspcc-dev/dbft@v0.3.2/dbft.go:281 +0xe75
1742457127009	github.com/nspcc-dev/dbft.(*DBFT[...]).OnReceive(0x1fe3da0, {0x1fc8f90, 0xc0048a6510})
1742457127009	github.com/ethereum/go-ethereum/consensus/dbft.(*DBFT).processPreBlockCb(0xc000141d48, {0x1fbdc40?, 0xc010db9810?})
```

### Solution:

The panic is caused by the fact that `pre.finalReceipts` is nil on Primary node. It is expected, because Primary doesn't verify its own PreBlock and hence, doesn't re-process PreBlock's state. Reprocessing is not needed because Primary already has up-to-date state got after PrepareRequest construction. See 08e47a51 for more details.

The solution is to take receipts from the sealing proposal in case of Primary node (like it is done in all other similar places).

The problem itself is introduced by https://github.com/bane-labs/go-ethereum/pull/422, this change is relatively recent and I just suppose that it wasn't tested properly, because the problem itself is reproducible on every Primary node if at least one correct Envelope presented in the block.

Close #438.

@txhsl, welcome to review. @songb2 I'd ask you to reproduce this problem on fresh `bane-main` and ensure that this PR fixes the problem. To reproduce this problem we need to include at least one valid Envelope to block, and Primary must fail with panic every time when it tries to process this PreBlock. I'll also try to test this fix on privnet right now.