### PR TITLE
dbft: fix sending data on closed channels

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -2218,7 +2218,7 @@ events:
 				log.Warn("Failed to handle chain block",
 					"index", b.Block.NumberU64(),
 					"err", err.Error())
-				break events
+				go c.Close()
 			}
 		case err := <-c.chainHeadSub.Err():
 			// System has stopped.
@@ -2227,7 +2227,7 @@ events:
 				log.Info("Block subscriptions error",
 					"error", err.Error())
 			}
-			break events
+			go c.Close()
 		case ev := <-dlEventCh:
 			if ev == nil {
 				// Unsubscription done, stop listening.
@@ -2242,7 +2242,7 @@ events:
 					log.Warn("Failed to handle latest chain block",
 						"index", latest.Number.Uint64(),
 						"err", err.Error())
-					break events
+					go c.Close()
 				}
 
 			case downloader.DoneEvent:
@@ -2255,7 +2255,7 @@ events:
 					log.Warn("Failed to handle latest chain block",
 						"index", latest.Number.Uint64(),
 						"err", err.Error())
-					break events
+					go c.Close()
 				}
 			}
 		}
@@ -2276,7 +2276,8 @@ events:
 				log.Warn("Failed to handle latest chain block",
 					"index", latestBlock.Block.NumberU64(),
 					"err", err.Error())
-				break events
+				go c.Close()
+				continue
 			}
 		}
 		newView := c.dbft.ViewNumber
@@ -2289,7 +2290,8 @@ events:
 				log.Warn("Failed to fetch latest sealing proposal",
 					"index", c.dbft.Context.BlockIndex,
 					"err", err.Error())
-				break events
+				go c.Close()
+				continue
 			}
 			log.Info("Start dBFT process for updated sealing work",
 				"index", c.dbft.Context.BlockIndex,
@@ -2338,7 +2340,10 @@ func (c *DBFT) OnPayload(cp *dbftproto.Message) error {
 		return nil
 	}
 
-	c.messages <- *p
+	select {
+	case <-c.quit:
+	case c.messages <- *p:
+	}
 	return nil
 }
 
@@ -2363,7 +2368,11 @@ func (c *DBFT) OnTransaction(txs []*types.Transaction) {
 		for _, tx := range txs {
 			_, found := slices.BinarySearchFunc(cbList.([]common.Hash), tx.Hash(), common.Hash.Cmp)
 			if found {
-				c.txs <- tx
+				select {
+				case <-c.quit:
+					return
+				case c.txs <- tx:
+				}
 			}
 		}
 	}

--- a/consensus/dbft/dkg.go
+++ b/consensus/dbft/dkg.go
@@ -174,7 +174,10 @@ func (c *DBFT) handleDKG(snapshot *Snapshot, keystore *antimev.KeyStore, h *type
 	if !suspended && currentHeight >= shareStartHeight && currentHeight < targetHeight {
 		// Send watch task list to loopTaskChan when handleDKG finished
 		defer func() {
-			c.loopTaskChan <- watchList
+			select {
+			case <-c.quit:
+			case c.loopTaskChan <- watchList:
+			}
 		}()
 	}
 
@@ -346,58 +349,63 @@ func (c *DBFT) loopTaskList() {
 	log.Info("DKG events dispatcher started")
 	defer log.Info("DKG events dispatcher stopped")
 
-	for watchList := range c.loopTaskChan {
-		log.Info("DKG loopTaskList", "CurrentHeight", watchList.CurrentHeight, "WatchListLength", len(watchList.WatchList))
-		currentHeight := watchList.CurrentHeight
-		// append watchList from loopTaskChan to c.txWatchList
-		for i := range watchList.WatchList {
-			c.txWatchList = append(c.txWatchList, &watchList.WatchList[i])
-		}
+	for {
+		select {
+		case <-c.quit:
+			return
+		case watchList := <-c.loopTaskChan:
+			log.Info("DKG loopTaskList", "CurrentHeight", watchList.CurrentHeight, "WatchListLength", len(watchList.WatchList))
+			currentHeight := watchList.CurrentHeight
+			// append watchList from loopTaskChan to c.txWatchList
+			for i := range watchList.WatchList {
+				c.txWatchList = append(c.txWatchList, &watchList.WatchList[i])
+			}
 
-		// loop tasks in c.txWatchList
-		var retryList []*TxWatchRetry
-		if len(c.txWatchList) > 0 {
-			for _, item := range c.txWatchList {
-				if currentHeight < item.EndHeight && !item.ConfirmedSuccess {
-					needRetry := false
-					// Send failed, just resend and set txHash
-					if item.TxHash == nil {
-						needRetry = true
-					}
-
-					// Send successfully, wait 3 blocks to check tx status
-					if item.TxHash != nil && currentHeight-item.SendHeight == 3 {
-						receipt, err := c.txAPI.GetTransactionReceipt(context.Background(), *item.TxHash)
-						if err != nil {
+			// loop tasks in c.txWatchList
+			var retryList []*TxWatchRetry
+			if len(c.txWatchList) > 0 {
+				for _, item := range c.txWatchList {
+					if currentHeight < item.EndHeight && !item.ConfirmedSuccess {
+						needRetry := false
+						// Send failed, just resend and set txHash
+						if item.TxHash == nil {
 							needRetry = true
-							log.Error("DKG get transaction receipt failed", "err", err, "txHash", item.TxHash)
 						}
-						if receipt["status"] != types.ReceiptStatusSuccessful {
-							needRetry = true
-							log.Error("DKG get transaction receipt status error", "txHash", item.TxHash, "status", receipt["status"])
-						}
-					}
 
-					var err error
-					if needRetry {
-						item.TxHash, err = sendTxToKeyManagement(c.txAPI, c.signer, item.Method, item.Params...)
-						if err != nil {
-							retryList = append(retryList, item)
-							log.Error("DKG retry sending transaction failed", "currentHeight", currentHeight, "method", item.Method, "err", err)
-							continue
+						// Send successfully, wait 3 blocks to check tx status
+						if item.TxHash != nil && currentHeight-item.SendHeight == 3 {
+							receipt, err := c.txAPI.GetTransactionReceipt(context.Background(), *item.TxHash)
+							if err != nil {
+								needRetry = true
+								log.Error("DKG get transaction receipt failed", "err", err, "txHash", item.TxHash)
+							}
+							if receipt["status"] != types.ReceiptStatusSuccessful {
+								needRetry = true
+								log.Error("DKG get transaction receipt status error", "txHash", item.TxHash, "status", receipt["status"])
+							}
+						}
+
+						var err error
+						if needRetry {
+							item.TxHash, err = sendTxToKeyManagement(c.txAPI, c.signer, item.Method, item.Params...)
+							if err != nil {
+								retryList = append(retryList, item)
+								log.Error("DKG retry sending transaction failed", "currentHeight", currentHeight, "method", item.Method, "err", err)
+								continue
+							} else {
+								item.SendHeight = currentHeight
+								retryList = append(retryList, item)
+								log.Info("DKG retry transaction sent", "method", item.Method, "txHash", item.TxHash)
+							}
 						} else {
-							item.SendHeight = currentHeight
-							retryList = append(retryList, item)
-							log.Info("DKG retry transaction sent", "method", item.Method, "txHash", item.TxHash)
+							item.ConfirmedSuccess = true
+							log.Info("DKG get transaction receipt successfully", "method", item.Method, "txHash", item.TxHash)
 						}
-					} else {
-						item.ConfirmedSuccess = true
-						log.Info("DKG get transaction receipt successfully", "method", item.Method, "txHash", item.TxHash)
 					}
 				}
+				// Only keep retry failed and not reach max retry times
+				c.txWatchList = retryList
 			}
-			// Only keep retry failed and not reach max retry times
-			c.txWatchList = retryList
 		}
 	}
 }


### PR DESCRIPTION
Close #452. 

I can't reproduce this bug now, except to change from `break events` to `Close` in the goroutine where the error occurs, and to listen to the exit signal of the `quit` channel when the channel sends data.