### PR TITLE
core/txpool: consensus/dbft: use static legacy pool instance in dbft

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -223,6 +223,10 @@ type DBFT struct {
 	validatorsCache *lru.Cache[uint64, []common.Address]
 	// dkgIndexCache is a cache for storing the index array of the ordered validators
 	dkgIndexCache *lru.Cache[uint64, []int]
+	// staticPool is a legacy pool instance for decrypted transaction verification,
+	// which is initialized once per height at postBlock callback. It should be reset
+	// before any reusage at the same height.
+	staticPool *legacypool.LegacyPool
 
 	// The fields below are for testing only
 	fakeDiff bool // Skip difficulty verifications
@@ -910,9 +914,11 @@ func (c *DBFT) verifyPreBlockCb(b dbft.PreBlock[common.Hash]) bool {
 	}
 	ethBlock := dbftBlock.ToEthBlock()
 
-	localPool := c.newLocalPool(parent)
-	defer localPool.CloseSilently()
-	errs := localPool.Add(dbftBlock.transactions, false, false)
+	// If is the first view of the block, then initialize static pool with fresh parent.
+	if c.dbft.Context.ViewNumber == 0 {
+		c.initStaticPool(parent)
+	}
+	errs := c.staticPool.Add(dbftBlock.transactions, false, false)
 	for i, err := range errs {
 		if err != nil {
 			log.Warn("proposed PreBlock has invalid transaction",
@@ -923,6 +929,7 @@ func (c *DBFT) verifyPreBlockCb(b dbft.PreBlock[common.Hash]) bool {
 			return false
 		}
 	}
+	c.staticPool.ResetStatic()
 
 	state, receipts, gasUsed, err := c.chain.VerifyBlock(ethBlock, true)
 	if err != nil {
@@ -1122,7 +1129,6 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 			j                  int
 			txx                = make([]*types.Transaction, len(pre.transactions))
 			parent             = c.chain.GetHeader(pre.header.ParentHash, pre.header.Number.Uint64()-1)
-			localPool          = c.newLocalPool(parent)
 			fallbackToEnvelope = func(i int, incrementJ bool, reason string) bool {
 				if len(reason) != 0 {
 					log.Info("Falling back to envelope",
@@ -1130,7 +1136,7 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 						"envelope index", i,
 						"reason", reason)
 				}
-				errs := localPool.Add([]*types.Transaction{pre.transactions[i]}, false, false)
+				errs := c.staticPool.Add([]*types.Transaction{pre.transactions[i]}, false, false)
 				if errs[0] != nil {
 					log.Info("Falling back to original set of transactions",
 						"envelope hash", pre.transactions[i].Hash(),
@@ -1147,7 +1153,6 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 				return true
 			}
 		)
-		defer localPool.CloseSilently()
 
 		// If we're backup, then pre.finalReceipts are filled in during PreBlock verification;
 		// if we're primary, then reuse receipts got after PrepareRequest construction since
@@ -1156,7 +1161,8 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 		if ctx.IsPrimary() && pre.finalState == nil {
 			receipts = c.sealingReceipts
 		}
-
+		// No need to reinitialize static pool since it was already initialized in verifyPreBlockCb.
+		// Reset the static pool after processing all transactions.
 		for i := range pre.transactions {
 			var isEnvelope = j < len(pre.envelopesData) && pre.envelopesData[j].index == i
 			if !isEnvelope || // pre.transactions[i] is not an envelope, use it as-is.
@@ -1192,7 +1198,7 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 					break
 				}
 			}
-			errs := localPool.Add([]*types.Transaction{decryptedTx}, false, false)
+			errs := c.staticPool.Add([]*types.Transaction{decryptedTx}, false, false)
 			if errs[0] != nil {
 				if fallbackToEnvelope(i, true, fmt.Sprintf("decrypted transaction has pool conflicts: %s", errs[0].Error())) {
 					continue
@@ -1205,6 +1211,7 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 			hasDecryptedTxs = true
 		}
 		pre.finalTransactions = txx
+		c.staticPool.ResetStatic()
 	}
 
 	// Use cached processing results if no new transactions were included into
@@ -1250,10 +1257,10 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 	return nil
 }
 
-// newLocalPool returns an initialized instance of LegacyPool with default config
+// newStaticPool returns an initialized instance of LegacyPool with default config
 // except that locals are prohibited and journal is not stored.
-func (c *DBFT) newLocalPool(parent *types.Header) *legacypool.LegacyPool {
-	p := legacypool.New(legacypool.Config{
+func newStaticPool(chain ChainHeaderReader) *legacypool.LegacyPool {
+	return legacypool.NewStatic(legacypool.Config{
 		Locals:                  nil,
 		NoLocals:                true,
 		Journal:                 "",
@@ -1267,10 +1274,12 @@ func (c *DBFT) newLocalPool(parent *types.Header) *legacypool.LegacyPool {
 		Lifetime:                legacypool.DefaultConfig.Lifetime,
 		ReannounceTimeThreshold: legacypool.DefaultConfig.ReannounceTimeThreshold,
 		ReannounceRemotes:       false,
-	}, c.chain)
-	p.Init(legacypool.DefaultConfig.PriceLimit, parent, func(addr common.Address, reserve bool) error { return nil })
+	}, chain)
+}
 
-	return p
+// initStaticPool initializes the static pool with the provided parent header.
+func (c *DBFT) initStaticPool(parent *types.Header) {
+	c.staticPool.InitStatic(legacypool.DefaultConfig.PriceLimit, parent, func(addr common.Address, reserve bool) error { return nil })
 }
 
 // validateDecryptedTx checks the validity of the transaction to determine whether the outer envelope transaction should be replaced.
@@ -2032,6 +2041,7 @@ func (c *DBFT) Start(chain ChainHeaderWriter) {
 	if c.dbftStarted.CompareAndSwap(false, true) {
 		c.chain = chain
 		c.blockQueue.chain = chain
+		c.staticPool = newStaticPool(c.chain)
 
 		// Subscribe for minted blocks prior to accessing current chain header.
 		// Sealing proposal awaiting may take some time during which new blocks may

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -278,34 +278,33 @@ func New(config Config, chain BlockChain) *LegacyPool {
 	// Sanitize the input to ensure no vulnerable gas prices are set
 	config = (&config).sanitize()
 
-	// Create the transaction pool with its initial settings
-	pool := &LegacyPool{
-		config:          config,
-		chain:           chain,
-		chainconfig:     chain.Config(),
-		signer:          types.LatestSigner(chain.Config()),
-		pending:         make(map[common.Address]*list),
-		cached:          make(map[common.Address]*list),
-		queue:           make(map[common.Address]*list),
-		beats:           make(map[common.Address]time.Time),
-		all:             newLookup(),
-		reqResetCh:      make(chan *txpoolResetRequest),
-		reqPromoteCh:    make(chan *accountSet),
-		queueTxEventCh:  make(chan *types.Transaction),
-		reorgDoneCh:     make(chan chan struct{}),
-		reorgShutdownCh: make(chan struct{}),
-		initDoneCh:      make(chan struct{}),
-	}
-	pool.locals = newAccountSet(pool.signer)
-	for _, addr := range config.Locals {
-		log.Info("Setting new local account", "address", addr)
-		pool.locals.add(addr)
-	}
-	pool.priced = newPricedList(pool.all)
-
+	// Create the transaction pool and its channels
+	pool := NewStatic(config, chain)
+	pool.reqResetCh = make(chan *txpoolResetRequest)
+	pool.reqPromoteCh = make(chan *accountSet)
+	pool.queueTxEventCh = make(chan *types.Transaction)
+	pool.reorgDoneCh = make(chan chan struct{})
+	pool.reorgShutdownCh = make(chan struct{})
+	pool.initDoneCh = make(chan struct{})
 	if !config.NoLocals && config.Journal != "" {
 		pool.journal = newTxJournal(config.Journal)
 	}
+	return pool
+}
+
+// NewStatic creates a new transaction pool without any channel
+// and journal. A pool created in this way should only be inited
+// with InitStatic.
+func NewStatic(config Config, chain BlockChain) *LegacyPool {
+	// Create the transaction pool with its initial settings
+	pool := &LegacyPool{
+		config:      config,
+		chain:       chain,
+		chainconfig: chain.Config(),
+		signer:      types.LatestSigner(chain.Config()),
+	}
+	pool.setEmptyLists()
+	pool.setInitialLocals()
 	return pool
 }
 
@@ -325,6 +324,32 @@ func (pool *LegacyPool) Filter(tx *types.Transaction) bool {
 // from disk and filtered based on the provided starting settings. The internal
 // goroutines will be spun up and the pool deemed operational afterwards.
 func (pool *LegacyPool) Init(gasTip uint64, head *types.Header, reserve txpool.AddressReserver) error {
+	// Do basic initializations about reserver, gas price and state
+	pool.InitStatic(gasTip, head, reserve)
+
+	// Start the reorg loop early, so it can handle requests generated during
+	// journal loading.
+	pool.wg.Add(1)
+	go pool.scheduleReorgLoop()
+
+	// If local transactions and journaling is enabled, load from disk
+	if pool.journal != nil {
+		if err := pool.journal.load(pool.addLocals); err != nil {
+			log.Warn("Failed to load transaction journal", "err", err)
+		}
+		if err := pool.journal.rotate(pool.local()); err != nil {
+			log.Warn("Failed to rotate transaction journal", "err", err)
+		}
+	}
+	pool.wg.Add(1)
+	go pool.loop()
+	return nil
+}
+
+// InitStatic sets the gas price needed to keep a transaction in the pool
+// and the chain head to allow balance / nonce checks. This method doesn't
+// start loops or load journals, so the pool can be released automatically.
+func (pool *LegacyPool) InitStatic(gasTip uint64, head *types.Header, reserve txpool.AddressReserver) error {
 	// Set the address reserver to request exclusive access to pooled accounts
 	pool.reserve = reserve
 
@@ -344,24 +369,34 @@ func (pool *LegacyPool) Init(gasTip uint64, head *types.Header, reserve txpool.A
 	pool.currentHead.Store(head)
 	pool.currentState = statedb
 	pool.pendingNonces = newNoncer(statedb)
-
-	// Start the reorg loop early, so it can handle requests generated during
-	// journal loading.
-	pool.wg.Add(1)
-	go pool.scheduleReorgLoop()
-
-	// If local transactions and journaling is enabled, load from disk
-	if pool.journal != nil {
-		if err := pool.journal.load(pool.addLocals); err != nil {
-			log.Warn("Failed to load transaction journal", "err", err)
-		}
-		if err := pool.journal.rotate(pool.local()); err != nil {
-			log.Warn("Failed to rotate transaction journal", "err", err)
-		}
-	}
-	pool.wg.Add(1)
-	go pool.loop()
 	return nil
+}
+
+// ResetStatic reverts any transaction insertion to a pool created by NewStatic
+// and inited by InitStatic, so that the pool can be reused as only initialized.
+func (pool *LegacyPool) ResetStatic() {
+	pool.setEmptyLists()
+	pool.setInitialLocals()
+	pool.pendingNonces = newNoncer(pool.currentState)
+}
+
+// setEmptyLists sets all transaction records of the pool to empty.
+func (pool *LegacyPool) setEmptyLists() {
+	pool.pending = make(map[common.Address]*list)
+	pool.cached = make(map[common.Address]*list)
+	pool.queue = make(map[common.Address]*list)
+	pool.beats = make(map[common.Address]time.Time)
+	pool.all = newLookup()
+	pool.priced = newPricedList(pool.all)
+}
+
+// setInitialLocals resets the local accounts of the pool to initially configured.
+func (pool *LegacyPool) setInitialLocals() {
+	pool.locals = newAccountSet(pool.signer)
+	for _, addr := range pool.config.Locals {
+		log.Info("Setting new local account", "address", addr)
+		pool.locals.add(addr)
+	}
 }
 
 // loop is the transaction pool's main event loop, waiting for and reacting to
@@ -475,9 +510,9 @@ func (pool *LegacyPool) loop() {
 	}
 }
 
-// CloseSilently is the same as Close(), but doesn't log. Intended to be used
-// for short-lived verification pools (not the main node tx pool).
-func (pool *LegacyPool) CloseSilently() {
+// Close terminates the transaction pool. If the pool is created through NewStatic
+// and inited through InitStatic, then this operation is not necessary.
+func (pool *LegacyPool) Close() error {
 	// Terminate the pool reorger and return
 	close(pool.reorgShutdownCh)
 	pool.wg.Wait()
@@ -485,11 +520,6 @@ func (pool *LegacyPool) CloseSilently() {
 	if pool.journal != nil {
 		pool.journal.close()
 	}
-}
-
-// Close terminates the transaction pool.
-func (pool *LegacyPool) Close() error {
-	pool.CloseSilently()
 	log.Info("Transaction pool stopped")
 	return nil
 }
@@ -1184,6 +1214,10 @@ func (pool *LegacyPool) Add(txs []*types.Transaction, local, sync bool) []error 
 		}
 		errs[nilSlot] = err
 		nilSlot++
+	}
+	// Return if no channel is initialized, ref NewStatic and InitStatic
+	if pool.reqPromoteCh == nil {
+		return errs
 	}
 	// Reorg the pool internals if needed and return
 	done := pool.requestPromoteExecutables(dirtyAddrs)


### PR DESCRIPTION
Close #341. Replace #464. Ref https://github.com/bane-labs/go-ethereum/pull/464#pullrequestreview-2820164035.

Since we only add new transactions to an empty `LegacyPool` instance in dBFT verification and check its errors, this PR simplify the pool construction and initialization, and remove unused maintenance loops.