### PR TITLE
core/txpool: consensus/dbft: check static pool state before using among CVs

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -915,7 +915,7 @@ func (c *DBFT) verifyPreBlockCb(b dbft.PreBlock[common.Hash]) bool {
 	ethBlock := dbftBlock.ToEthBlock()
 
 	// If is the first view of the block, then initialize static pool with fresh parent.
-	if c.dbft.Context.ViewNumber == 0 {
+	if c.dbft.Context.ViewNumber == 0 || !c.staticPool.StaticInited() {
 		c.initStaticPool(parent)
 	}
 	errs := c.staticPool.Add(dbftBlock.transactions, false, false)

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -372,6 +372,11 @@ func (pool *LegacyPool) InitStatic(gasTip uint64, head *types.Header, reserve tx
 	return nil
 }
 
+// StaticInited returns whether the pool is initialized with InitStatic.
+func (pool *LegacyPool) StaticInited() bool {
+	return pool.currentState != nil
+}
+
 // ResetStatic reverts any transaction insertion to a pool created by NewStatic
 // and inited by InitStatic, so that the pool can be reused as only initialized.
 func (pool *LegacyPool) ResetStatic() {


### PR DESCRIPTION
Close #471.