### PR TITLE
dbft: refactor static pool and DKG snapshot initialization

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1157,6 +1157,9 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 		if ctx.IsPrimary() && pre.finalState == nil {
 			receipts = c.sealingReceipts
 		}
+		if len(receipts) != len(pre.transactions) {
+			return fmt.Errorf("number of receipts mismatch: expected %d, actual %d", len(pre.transactions), len(receipts))
+		}
 		// No need to reinitialize static pool since it was already initialized in verifyPreBlockCb.
 		// Reset the static pool after processing all transactions.
 		for i := range pre.transactions {

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1274,8 +1274,8 @@ func newStaticPool(chain ChainHeaderReader) *legacypool.LegacyPool {
 }
 
 // initStaticPool initializes the static pool with the provided parent header.
-func (c *DBFT) initStaticPool(parent *types.Header) error {
-	return c.staticPool.InitStatic(legacypool.DefaultConfig.PriceLimit, parent, func(addr common.Address, reserve bool) error { return nil })
+func (c *DBFT) initStaticPool(parent *types.Header, state *state.StateDB) error {
+	return c.staticPool.InitStatic(legacypool.DefaultConfig.PriceLimit, parent, state, func(addr common.Address, reserve bool) error { return nil })
 }
 
 // validateDecryptedTx checks the validity of the transaction to determine whether the outer envelope transaction should be replaced.
@@ -1553,7 +1553,7 @@ func (c *DBFT) postBlock(h *types.Header, state *state.StateDB) {
 		c.lastBlockHash = h.Hash()
 		c.lastBlockSealHash, _ = honestSealHash(h) // no error expected, h is verified.
 		c.lastBlockExtra = h.Extra
-		err := c.initStaticPool(h)
+		err := c.initStaticPool(h, state)
 		if err != nil {
 			log.Crit("failed to initialize static pool",
 				"height", c.lastIndex,
@@ -2085,7 +2085,7 @@ func (c *DBFT) Start(chain ChainHeaderWriter) {
 		// miner guarantees that. We can't do it earlier because blocks chain may be out of sync compared to headers
 		// chain, ref. 3721f549.
 		if c.lastIndex == currHeader.Number.Uint64() {
-			err := c.initStaticPool(currHeader)
+			err := c.initStaticPool(currHeader, nil)
 			if err != nil {
 				log.Crit("failed to initialize static pool",
 					"height", c.lastIndex,

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -2125,19 +2125,15 @@ func (c *DBFT) Seal(chain consensus.ChainHeaderReader, b *types.Block, results c
 func (c *DBFT) waitForNewSealingProposal(desiredHeight uint64, updateContext bool) error {
 	log.Info("Fetching latest sealing proposal",
 		"desired number", desiredHeight)
-	var (
-		ok           bool
-		lastProposal *types.Block
-	)
+	var lastProposal *types.Block
 	// Wait here...
 	for {
 		c.lastProposalLock.RLock()
 		if c.lastProposal != nil && c.lastProposal.NumberU64() >= desiredHeight {
 			lastProposal = c.lastProposal
-			ok = true
 		}
 		c.lastProposalLock.RUnlock()
-		if ok {
+		if lastProposal != nil {
 			break
 		}
 		select {

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1274,8 +1274,8 @@ func newStaticPool(chain ChainHeaderReader) *legacypool.LegacyPool {
 }
 
 // initStaticPool initializes the static pool with the provided parent header.
-func (c *DBFT) initStaticPool(parent *types.Header) {
-	c.staticPool.InitStatic(legacypool.DefaultConfig.PriceLimit, parent, func(addr common.Address, reserve bool) error { return nil })
+func (c *DBFT) initStaticPool(parent *types.Header) error {
+	return c.staticPool.InitStatic(legacypool.DefaultConfig.PriceLimit, parent, func(addr common.Address, reserve bool) error { return nil })
 }
 
 // validateDecryptedTx checks the validity of the transaction to determine whether the outer envelope transaction should be replaced.
@@ -1553,7 +1553,13 @@ func (c *DBFT) postBlock(h *types.Header, state *state.StateDB) {
 		c.lastBlockHash = h.Hash()
 		c.lastBlockSealHash, _ = honestSealHash(h) // no error expected, h is verified.
 		c.lastBlockExtra = h.Extra
-		c.initStaticPool(h)
+		err := c.initStaticPool(h)
+		if err != nil {
+			log.Crit("failed to initialize static pool",
+				"height", c.lastIndex,
+				"hash", c.lastBlockHash,
+				"error", err)
+		}
 
 		// handle DKG
 		if c.lastIndex >= uint64(c.config.dkgEnablingHeight) {
@@ -2079,7 +2085,13 @@ func (c *DBFT) Start(chain ChainHeaderWriter) {
 		// miner guarantees that. We can't do it earlier because blocks chain may be out of sync compared to headers
 		// chain, ref. 3721f549.
 		if c.lastIndex == currHeader.Number.Uint64() {
-			c.initStaticPool(currHeader)
+			err := c.initStaticPool(currHeader)
+			if err != nil {
+				log.Crit("failed to initialize static pool",
+					"height", c.lastIndex,
+					"hash", c.lastBlockHash,
+					"error", err)
+			}
 			if c.lastIndex >= uint64(c.config.dkgEnablingHeight) {
 				c.lock.RLock()
 				ks := c.amevKeystore

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -914,10 +914,6 @@ func (c *DBFT) verifyPreBlockCb(b dbft.PreBlock[common.Hash]) bool {
 	}
 	ethBlock := dbftBlock.ToEthBlock()
 
-	// If is the first view of the block, then initialize static pool with fresh parent.
-	if c.dbft.Context.ViewNumber == 0 {
-		c.initStaticPool(parent)
-	}
 	errs := c.staticPool.Add(dbftBlock.transactions, false, false)
 	for i, err := range errs {
 		if err != nil {
@@ -1557,6 +1553,7 @@ func (c *DBFT) postBlock(h *types.Header, state *state.StateDB) {
 		c.lastBlockHash = h.Hash()
 		c.lastBlockSealHash, _ = honestSealHash(h) // no error expected, h is verified.
 		c.lastBlockExtra = h.Extra
+		c.initStaticPool(h)
 
 		// handle DKG
 		if c.lastIndex >= uint64(c.config.dkgEnablingHeight) {
@@ -2075,6 +2072,14 @@ func (c *DBFT) Start(chain ChainHeaderWriter) {
 				"index", c.lastIndex+1,
 				"err", err.Error())
 			return
+		}
+
+		// Manually initialize static pool in case if waitForNewSealingProposal didn't call
+		// postBlock callback. We're sure that state of the latest block is available by this moment,
+		// miner guarantees that. We can't do it earlier because blocks chain may be out of sync compared to headers
+		// chain, ref. 3721f549.
+		if c.lastIndex == currHeader.Number.Uint64() {
+			c.initStaticPool(currHeader)
 		}
 
 		log.Info("Starting dBFT engine",

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -915,6 +915,7 @@ func (c *DBFT) verifyPreBlockCb(b dbft.PreBlock[common.Hash]) bool {
 	ethBlock := dbftBlock.ToEthBlock()
 
 	errs := c.staticPool.Add(dbftBlock.transactions, false, false)
+	c.staticPool.ResetStatic()
 	for i, err := range errs {
 		if err != nil {
 			log.Warn("proposed PreBlock has invalid transaction",
@@ -925,7 +926,6 @@ func (c *DBFT) verifyPreBlockCb(b dbft.PreBlock[common.Hash]) bool {
 			return false
 		}
 	}
-	c.staticPool.ResetStatic()
 
 	state, receipts, gasUsed, err := c.chain.VerifyBlock(ethBlock, true)
 	if err != nil {

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -2074,12 +2074,24 @@ func (c *DBFT) Start(chain ChainHeaderWriter) {
 			return
 		}
 
-		// Manually initialize static pool in case if waitForNewSealingProposal didn't call
+		// Manually initialize static pool and DKG snapshot in case if waitForNewSealingProposal didn't call
 		// postBlock callback. We're sure that state of the latest block is available by this moment,
 		// miner guarantees that. We can't do it earlier because blocks chain may be out of sync compared to headers
 		// chain, ref. 3721f549.
 		if c.lastIndex == currHeader.Number.Uint64() {
 			c.initStaticPool(currHeader)
+			if c.lastIndex >= uint64(c.config.dkgEnablingHeight) {
+				c.lock.RLock()
+				ks := c.amevKeystore
+				c.lock.RUnlock()
+				err := c.handleDKG(c.dkgSnapshot, ks, currHeader, nil, false)
+				if err != nil {
+					log.Crit("Failed to initialize DKG snapshot",
+						"height", currHeader.Number.Uint64(),
+						"err", err.Error())
+					return
+				}
+			}
 		}
 
 		log.Info("Starting dBFT engine",
@@ -2144,19 +2156,6 @@ func (c *DBFT) waitForNewSealingProposal(desiredHeight uint64, updateContext boo
 			"sealing proposal index", b.NumberU64())
 		ltstHeader := c.chain.GetHeaderByNumber(b.NumberU64() - 1)
 		c.postBlock(ltstHeader, nil)
-	} else if c.lastIndex >= uint64(c.config.dkgEnablingHeight) {
-		// Manually initialize DKG snapshot based on the latest block information
-		// (we're sure that state of the latest block is available by this moment,
-		// miner guarantees that). We can't do it earlier because blocks chain
-		// may be out of sync compared to headers chain, ref. 3721f549.
-		currHeader := c.chain.GetHeaderByNumber(c.lastIndex)
-		c.lock.RLock()
-		ks := c.amevKeystore
-		c.lock.RUnlock()
-		err := c.handleDKG(c.dkgSnapshot, ks, currHeader, nil, false)
-		if err != nil {
-			return fmt.Errorf("failed to initialize DKG snapshot at height %d: %w", currHeader.Number.Uint64(), err)
-		}
 	}
 
 	if b.ParentHash().Cmp(c.lastBlockHash) != 0 {

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -325,7 +325,7 @@ func (pool *LegacyPool) Filter(tx *types.Transaction) bool {
 // goroutines will be spun up and the pool deemed operational afterwards.
 func (pool *LegacyPool) Init(gasTip uint64, head *types.Header, reserve txpool.AddressReserver) error {
 	// Do basic initializations about reserver, gas price and state
-	pool.InitStatic(gasTip, head, reserve)
+	pool.InitStatic(gasTip, head, nil, reserve)
 
 	// Start the reorg loop early, so it can handle requests generated during
 	// journal loading.
@@ -349,7 +349,7 @@ func (pool *LegacyPool) Init(gasTip uint64, head *types.Header, reserve txpool.A
 // InitStatic sets the gas price needed to keep a transaction in the pool
 // and the chain head to allow balance / nonce checks. This method doesn't
 // start loops or load journals, so the pool can be released automatically.
-func (pool *LegacyPool) InitStatic(gasTip uint64, head *types.Header, reserve txpool.AddressReserver) error {
+func (pool *LegacyPool) InitStatic(gasTip uint64, head *types.Header, statedb *state.StateDB, reserve txpool.AddressReserver) error {
 	// Set the address reserver to request exclusive access to pooled accounts
 	pool.reserve = reserve
 
@@ -359,12 +359,16 @@ func (pool *LegacyPool) InitStatic(gasTip uint64, head *types.Header, reserve tx
 	// Initialize the state with head block, or fallback to empty one in
 	// case the head state is not available (might occur when node is not
 	// fully synced).
-	statedb, err := pool.chain.StateAt(head.Root)
-	if err != nil {
-		statedb, err = pool.chain.StateAt(types.EmptyRootHash)
-	}
-	if err != nil {
-		return err
+	// If the state is provided, then use it directly.
+	var err error
+	if statedb == nil {
+		statedb, err = pool.chain.StateAt(head.Root)
+		if err != nil {
+			statedb, err = pool.chain.StateAt(types.EmptyRootHash)
+		}
+		if err != nil {
+			return err
+		}
 	}
 	pool.currentHead.Store(head)
 	pool.currentState = statedb


### PR DESCRIPTION
Close #471, a replacement of #472.

>  I've seen the problem is CV related.

@txhsl is right, to reproduce problem from #471 the CN should be shutdown, then wait until it's her turn to accept block, wait for other CNs will accept CV and then turn on the missing CN (but before other nodes will accept this block at view 1).

So this PR needs testing.