### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,49 @@
 
 This document outlines major changes between releases.
 
+## 0.4.0 "Karstification" (20 Jun 2025)
+
+This version introduces a preview of ZK-based DKG signature verification added to
+KeyManagement system contract and the support of ZK-based DKG signature generation
+at the dBFT side (this feature will be auto-enabled by dBFT once KeyManagement
+contract is upgraded by the network maintainers). Note that this feature is not yet
+finalized and is a subject of polishing for further releases. Also, this version adds
+a support for `NeoXEthSig` fork that switches to a canonical form of TPKE block
+signatures. In addition to that, this version contains a set of optimisations improving
+the efficiency of block producing process and a set of dBFT-related bug fixes.
+
+This version is fully compatible with v0.3.2 and does not require DB resync. For TestNet
+nodes upgrade, the DB reinitialization with updated genesis configuration is required
+(`NeoXEthSig` fork is scheduled at block 3750000 of TestNet). To upgrade MainNet nodes
+from v0.2.2, no DB reinitialization is required (since we don't yet enable `NeoXDKG`,
+`NeoXAMEV` and `NeoXEthSig` forks on MainNet), but anti-MEV keystore should be generated
+and provided to the node on startup following the notes from v0.3.0 release.
+
+New features:
+ * `NeoXEthSig` hardfork fixing the format of TPKE block signature (#463)
+ * ZK-based DKG signature verification support in KeyManagement contract (#442, #470)
+ * ZK-based DKG signature generation support in dBFT (#444)
+
+Behaviour changes:
+ * `txpool.signaturecache` CLI flag is renamed to `txpool.amevcache` (#457)
+
+Improvements:
+ * configurable dBFT status statistics period (#449)
+ * documentation improvements (#457)
+ * refactoring of encrypted transactions pool (#468)
+ * optimize conversion of dBFT CN index to DKG CN index (#458)
+ * use local mempool for dBFT proposal verification (#466, #476)
+
+Bugs fixed:
+ * panic in encrypted transactions pool on attempt to remove expired transaction (#447)
+ * empty pending consensus list on new epoch start in Governance contract (#460)
+ * DKG routine is not synchronized with miner interruption (#475)
+ * panic on dBFT payload processing during miner node shutdown (#467)
+ * non-canonical format of TPKE block signature (#463)
+ * panic in dBFT on PreBlock verification (#473)
+ * consensus doesn't work on single-node privnet (#315)
+ * inability to retrieve ZK version from old KeyManagement implementation (#478)
+
 ## 0.3.2 "Ionization" (20 Mar 2025)
 
 This is an urgent patch-release fixing a panic happened on primary CN during decrypted

--- a/config/genesis_testnet.json
+++ b/config/genesis_testnet.json
@@ -17,6 +17,7 @@
     "shanghaiTime": 0,
     "neoXDKGBlock": 1990080,
     "neoXAMEVBlock": 2088000,
+    "neoXEthSigBlock": 3750000,
     "dbft": {
       "period": 5,
       "standbyValidators": [

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 0          // Major version component of the current release
-	VersionMinor = 3          // Minor version component of the current release
-	VersionPatch = 3          // Patch version component of the current release
-	VersionMeta  = "unstable" // Version metadata to append to the version string
+	VersionMajor = 0        // Major version component of the current release
+	VersionMinor = 4        // Minor version component of the current release
+	VersionPatch = 0        // Patch version component of the current release
+	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
Mainnet synchronization with the updated binary and old genesis config is OK:
```
INFO [06-17|13:38:43.631] Imported new chain segment               number=2,870,741 hash=faf292..3431ed blocks=1    txs=0    mgas=0.000   elapsed=9.717ms     mgasps=0.000  snapdiffs=1.78MiB    triedirty=0.00B
INFO [06-17|13:38:43.632] New block in the chain                   "dbft index"=2,870,741 "chain index"=2,870,741 hash=0xfaf292cb1d5525c252daa102bb26ac2ba0fa2e884f6de63cab5e9b31f53431ed "parent hash"=0x175a88e8cfff3726d9bd3d1e69fac4689d8ad98e2e6eb73785f7fc6a38575b31 primary=6 coinbase=0x1212000000000000000000000000000000000003 "mix digest"=0xeb59c093e3a02bfa4e0d4677d4769022cd9399bbc8b93ad1e892acd6a08aa533
INFO [06-17|13:38:43.632] Fetching latest sealing proposal         "desired number"=2,870,742
INFO [06-17|13:38:43.632] Commit new sealing work                  number=2,870,742 sealhash=d64650..f0d999 "parent hash"=faf292..3431ed etherbase=0x1212000000000000000000000000000000000003 txs=0    gas=0       fees=0          elapsed="462.668µs"
INFO [06-17|13:38:44.632] Sealing proposal updated                 number=2,870,742 sealhash=d64650..f0d999 "parent hash"=faf292..3431ed txs=0
2025-06-17T13:38:44.632+0300	INFO	initializing dbft	{"height": 2870742, "view": 0, "index": -1, "role": "WatchOnly"}
```

Testnet syncronisation is still in progress.