### PR TITLE
dbft: fix ZK version initialization

### DIFF
--- a/consensus/dbft/dkg.go
+++ b/consensus/dbft/dkg.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 
 	zkdkg "github.com/bane-labs/zk-dkg"
 	"github.com/bane-labs/zk-dkg/circuit"
@@ -993,6 +994,10 @@ func getZKVersion(backend *ethapi.Backend, state *state.StateDB, header *types.H
 	err := readFromContract(&result, backend, systemcontracts.KeyManagementProxyHash, systemcontracts.KeyManagementABIBasic,
 		state, header, "ZK_VERSION")
 	if err != nil {
+		if strings.Contains(err.Error(), "abi: attempting to unmarshal an empty string while arguments are expected") {
+			// Old KeyManagement version doesn't contain ZK_VERSION method in fact, so treat this error as zero version.
+			return 0, nil
+		}
 		return 0, err
 	}
 	return result.Uint64(), nil


### PR DESCRIPTION
Old version of KeyManagement contract doesn't contain ZK_VERSION method which leads to the failure on node restart (if we're syncing full Testnet node from genesis):
```
INFO [06-20|11:05:30.808] Initializing BFT consensus               account=0x8156CE2D0bba0f12891B2E072c0107fb969Aa654
INFO [06-20|11:05:30.808] DKG task watcher started
INFO [06-20|11:05:30.808] DKG task executor started
INFO [06-20|11:05:30.809] Fetching latest sealing proposal         "desired number"=3,634,404
INFO [06-20|11:05:30.809] Commit new sealing work                  number=3,634,404 sealhash=ae6a8e..06a856 "parent hash"=806695..8351fc etherbase=0x1212000000000000000000000000000000000003 txs=0 gas=0 fees=0 elapsed=1.276ms
INFO [06-20|11:05:31.340] New local node record                    seq=1,750,157,418,527 id=fbeb94ff58a385e0 ip=65.21.181.87 udp=30301 tcp=30301
INFO [06-20|11:05:31.816] Sealing proposal updated                 number=3,634,404 sealhash=ae6a8e..06a856 "parent hash"=806695..8351fc txs=0
CRIT [06-20|11:05:31.818] Failed to initialize DKG snapshot        height=3,634,403 err="failed to fetch ZK version: abi: attempting to unmarshal an empty string while arguments are expected"
```

We should preserve backward compatibility and treat missing ZK_VERSION as zero version. Otherwise it's impossible to synchronize the new Testnet node from scratch.