### PR TITLE
antimev: allow startup with an empty backup keystore

### DIFF
--- a/antimev/keygroup.go
+++ b/antimev/keygroup.go
@@ -70,15 +70,6 @@ func (tkg *thresholdKeyGroup) copy() *thresholdKeyGroup {
 	return res
 }
 
-// prepare generates local secrets and returns sharing messages.
-func (tkg *thresholdKeyGroup) prepare(size int, threshold int) ([]*big.Int, *tpke.PVSS) {
-	// Generate local secret
-	secret := tpke.RandomSecret(threshold)
-	tkg.pendingSecrets = append(tkg.pendingSecrets, secret)
-	// Generate and encrypt messages to share the secret
-	return generateShares(secret, size)
-}
-
 // confirmSecret requires the final contract-received PVSS to confirm the secret.
 func (tkg *thresholdKeyGroup) confirmSecret(pvss *tpke.PVSS) error {
 	for _, secret := range tkg.pendingSecrets {
@@ -127,7 +118,16 @@ func (tkg *thresholdKeyGroup) recover(secretIndexs []int) ([]*big.Int, error) {
 	return ss, nil
 }
 
-// reshare does almost the same as dkgPrepare, but local secret is reused to
+// share generates local secrets and returns sharing messages.
+func (tkg *thresholdKeyGroup) share(size int, threshold int) ([]*big.Int, *tpke.PVSS) {
+	// Generate local secret
+	secret := tpke.RandomSecret(threshold)
+	tkg.pendingSecrets = append(tkg.pendingSecrets, secret)
+	// Generate and encrypt messages to share the secret
+	return generateShares(secret, size)
+}
+
+// reshare does almost the same as share, but local secret is reused to
 // produce the same global public key.
 func (tkg *thresholdKeyGroup) reshare(size int) ([]*big.Int, *tpke.PVSS, error) {
 	// Check if has a local secret
@@ -169,9 +169,9 @@ func generateShares(secret *tpke.Secret, size int) ([]*big.Int, *tpke.PVSS) {
 	return ss, pvss
 }
 
-// receiveShareMessage verifies received sharing messages. It verifies shared
-// secret if is a member, otherwise only the pvss. Received data will be stored
-// in thresholdKeyGroup for further aggregation.
+// receiveShareMessage verifies received sharing/resharing messages. It verifies
+// shared secret if is a member, otherwise only the pvss. Received data will be
+// stored in thresholdKeyGroup for further aggregation.
 func (tkg *thresholdKeyGroup) receiveShareMessage(fromIndex int, ss *big.Int, pvss *tpke.PVSS, selfIndex int) error {
 	// Transform dkg index to array index
 	arrIndex := fromIndex - 1
@@ -184,25 +184,10 @@ func (tkg *thresholdKeyGroup) receiveShareMessage(fromIndex int, ss *big.Int, pv
 	return nil
 }
 
-// receiveReshareMessage verifies received resharing messages. It verifies shared
-// secret if is a member, otherwise only the pvss. Received data will be stored
-// in thresholdKeyGroup for further aggregation.
-func (tkg *thresholdKeyGroup) receiveReshareMessage(fromIndex int, rs *big.Int, pvss *tpke.PVSS, selfIndex int) error {
-	// Transform dkg index to array index
-	arrIndex := fromIndex - 1
-	// Verify with pvss
-	if !pvss.VerifySecret(selfIndex-1, rs) {
-		return ErrInvalidSecret
-	}
-	// Store ss for local secret key generation
-	tkg.receivedSecrets[arrIndex] = rs
-	return nil
-}
-
 // receiveRecoverMessage verifies received recovering messages. It verifies shared
 // secret if is a member, with the existing pvss. Received data will be stored
 // in thresholdKeyGroup for further aggregation.
-func (tkg *thresholdKeyGroup) receiveRecoverMessage(fromIndex int, rs *big.Int, pvss *tpke.PVSS, selfIndex int) error {
+func (tkg *thresholdKeyGroup) receiveRecoverMessage(fromIndex int, rs *big.Int, pvss *tpke.PVSS) error {
 	// Transform dkg index to array index
 	arrIndex := fromIndex - 1
 	// Verify with pvss

--- a/antimev/keygroup.go
+++ b/antimev/keygroup.go
@@ -9,10 +9,11 @@ import (
 )
 
 var (
-	ErrDKGSecret            = errors.New("invalid dkg secret")
-	ErrNoSecretToReshare    = errors.New("no secret to reshare")
+	ErrInvalidSecret = errors.New("invalid dkg secret")
+	ErrInvalidPVSS   = errors.New("invalid dkg pvss")
+
+	ErrSecretNotFound       = errors.New("secret not found")
 	ErrInvalidRecover       = errors.New("invalid recover")
-	ErrInvalidMessageKey    = errors.New("invalid message key")
 	ErrSecretShareNotEnough = errors.New("secret share not enough")
 )
 
@@ -86,7 +87,7 @@ func (tkg *thresholdKeyGroup) confirmSecret(pvss *tpke.PVSS) error {
 			return nil
 		}
 	}
-	return ErrDKGSecret
+	return ErrSecretNotFound
 }
 
 // aggregate aggregates received secrets and commitments to get global
@@ -131,7 +132,7 @@ func (tkg *thresholdKeyGroup) recover(secretIndexs []int) ([]*big.Int, error) {
 func (tkg *thresholdKeyGroup) reshare(size int) ([]*big.Int, *tpke.PVSS, error) {
 	// Check if has a local secret
 	if tkg.localSecret == nil {
-		return nil, nil, ErrNoSecretToReshare
+		return nil, nil, ErrSecretNotFound
 	}
 	// Generate and encrypt messages to share the secret
 	ss, pvss := generateShares(tkg.localSecret.Renovate(), size)
@@ -176,7 +177,7 @@ func (tkg *thresholdKeyGroup) receiveShareMessage(fromIndex int, ss *big.Int, pv
 	arrIndex := fromIndex - 1
 	// Verify with pvss
 	if !pvss.VerifySecret(selfIndex-1, ss) {
-		return ErrDKGSecret
+		return ErrInvalidSecret
 	}
 	// Store ss for local secret key generation
 	tkg.receivedSecrets[arrIndex] = ss
@@ -191,7 +192,7 @@ func (tkg *thresholdKeyGroup) receiveReshareMessage(fromIndex int, rs *big.Int, 
 	arrIndex := fromIndex - 1
 	// Verify with pvss
 	if !pvss.VerifySecret(selfIndex-1, rs) {
-		return ErrDKGSecret
+		return ErrInvalidSecret
 	}
 	// Store ss for local secret key generation
 	tkg.receivedSecrets[arrIndex] = rs
@@ -206,7 +207,7 @@ func (tkg *thresholdKeyGroup) receiveRecoverMessage(fromIndex int, rs *big.Int, 
 	arrIndex := fromIndex - 1
 	// Verify with pvss
 	if !pvss.VerifySecret(arrIndex, rs) {
-		return ErrDKGSecret
+		return ErrInvalidSecret
 	}
 	// Store rs for local secret key recovery
 	tkg.receivedSecrets[arrIndex] = rs

--- a/antimev/keystore.go
+++ b/antimev/keystore.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/crypto/ecies"
 	"github.com/ethereum/go-ethereum/crypto/tpke"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/google/uuid"
 	keystorev4 "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
 )
@@ -200,10 +201,13 @@ func (ks *KeyStore) IsRecovering() bool {
 
 // OnValidatorList initializes sharing and resharing, should be called
 // when the key group members are determined. It initializes 1 or 2 key groups.
-func (ks *KeyStore) OnSharePeriodStart() {
+func (ks *KeyStore) OnSharePeriodStart(forceInitReshare bool) {
 	// Set up groups for dkg resharing
 	if ks.shared != nil {
 		ks.resharing = ks.shared.newTemplateForReshare(ks.size)
+	}
+	if ks.resharing == nil && forceInitReshare {
+		ks.resharing = newThresholdKeyGroup(ks.size)
 	}
 	// Set groups for dkg sharing
 	ks.sharing = newThresholdKeyGroup(ks.size)
@@ -276,7 +280,7 @@ func (ks *KeyStore) RevertRound() {
 
 // OnEpochChange checks and settles the results of sharing and resharing, will
 // revert both of them of any of them is not successful.
-func (ks *KeyStore) OnEpochChange(selfPvss []byte, aggregatedCmt []byte, isMemberOfNewGroup bool) error {
+func (ks *KeyStore) OnEpochChange(selfPvss []byte, aggregatedCmt []byte, lastRoundCmt []byte, isMemberOfNewGroup bool) error {
 	// Revert dkg if contract doesn't give a aggregated commitment
 	if len(aggregatedCmt) == 0 {
 		ks.RevertRound()
@@ -286,7 +290,7 @@ func (ks *KeyStore) OnEpochChange(selfPvss []byte, aggregatedCmt []byte, isMembe
 		return ErrLengthMismatch
 	}
 	// If code reaches here, then dkg is successful in contract
-	if err := ks.aggregateReshare(isMemberOfNewGroup); err != nil {
+	if err := ks.aggregateReshare(lastRoundCmt, isMemberOfNewGroup); err != nil {
 		return err
 	}
 	if err := ks.aggregateShare(selfPvss, aggregatedCmt, isMemberOfNewGroup); err != nil {
@@ -316,19 +320,19 @@ func (ks *KeyStore) aggregateShare(selfPvss []byte, aggregatedCmt []byte, isPart
 		}
 		err = ks.sharing.confirmSecret(p)
 		if err != nil {
-			return err
+			log.Error("Failed to confirm secret share", "error", err)
 		}
 	}
 	return ks.sharing.aggregate(ks.scaler, aggregatedCmt, isParticipant)
 }
 
 // aggregateReshare tries to check if resharing is successful and settle the result
-func (ks *KeyStore) aggregateReshare(isReceiver bool) error {
+func (ks *KeyStore) aggregateReshare(aggregatedCmt []byte, isReceiver bool) error {
 	// Check if resharing is successful and aggregate keys
 	if ks.resharing == nil {
 		return nil
 	}
-	return ks.resharing.aggregate(ks.scaler, nil, isReceiver)
+	return ks.resharing.aggregate(ks.scaler, aggregatedCmt, isReceiver)
 }
 
 // ReceiveSecretShare tries to verify a sharing message array and store their data.

--- a/antimev/keystore.go
+++ b/antimev/keystore.go
@@ -237,7 +237,7 @@ func (ks *KeyStore) DKGShare() ([]*big.Int, []byte, error) {
 		return nil, nil, ErrKeyGroupNotExists
 	}
 	// Generate sharing secrets and pvss
-	ss, sPvss := ks.sharing.prepare(ks.size, ks.threshold)
+	ss, sPvss := ks.sharing.share(ks.size, ks.threshold)
 	return ss, sPvss.Encode(), nil
 }
 
@@ -282,10 +282,7 @@ func (ks *KeyStore) OnEpochChange(selfPvss []byte, aggregatedCmt []byte, isMembe
 		ks.RevertRound()
 		return nil
 	}
-	if isMemberOfNewGroup && len(selfPvss) == 0 {
-		return ErrLengthMismatch
-	}
-	if !isMemberOfNewGroup && len(selfPvss) > 0 {
+	if (isMemberOfNewGroup && len(selfPvss) == 0) || (!isMemberOfNewGroup && len(selfPvss) > 0) {
 		return ErrLengthMismatch
 	}
 	// If code reaches here, then dkg is successful in contract
@@ -383,7 +380,7 @@ func (ks *KeyStore) ReceiveSecretReshare(selfIndex int, fromIndex int, ers [][]b
 	if err != nil {
 		return ErrMessageDecryption
 	}
-	err = ks.resharing.receiveReshareMessage(fromIndex, ss, p, selfIndex)
+	err = ks.resharing.receiveShareMessage(fromIndex, ss, p, selfIndex)
 	if err != nil {
 		return err
 	}
@@ -407,7 +404,7 @@ func (ks *KeyStore) ReceiveRecoverShare(selfIndex int, fromIndex int, ers []byte
 	if err != nil {
 		return ErrMessageDecryption
 	}
-	err = ks.recovering.receiveRecoverMessage(fromIndex, ss, p, selfIndex)
+	err = ks.recovering.receiveRecoverMessage(fromIndex, ss, p)
 	if err != nil {
 		return err
 	}

--- a/antimev/keystore.go
+++ b/antimev/keystore.go
@@ -18,16 +18,13 @@ import (
 )
 
 var (
-	ErrInvalidLength     = errors.New("invalid array length")
 	ErrInvalidThreshold  = errors.New("invalid threshold")
-	ErrInvalidDKGPVSS    = errors.New("invalid dkg pvss")
 	ErrKeyGroupNotExists = errors.New("required keygroup not found")
-	ErrNoNeedToRecover   = errors.New("no need to recover")
 	ErrUnrecoverable     = errors.New("unrecoverable sharing")
 	ErrMessageDecryption = errors.New("message decryption failed")
 
-	ErrKeystoreEncryption = errors.New("could not encrypt keystore")
-	ErrKeystoreDecryption = errors.New("could not decrypt keystore")
+	ErrKeystoreEncryption = errors.New("can not encrypt keystore")
+	ErrKeystoreDecryption = errors.New("can not decrypt keystore")
 )
 
 // KeyStore is the container of all useful dkg information.
@@ -318,7 +315,7 @@ func (ks *KeyStore) aggregateShare(selfPvss []byte, aggregatedCmt []byte, isPart
 	if isParticipant {
 		p, err := new(tpke.PVSS).Decode(selfPvss, ks.size, ks.threshold)
 		if err != nil {
-			return ErrInvalidDKGPVSS
+			return ErrInvalidPVSS
 		}
 		err = ks.sharing.confirmSecret(p)
 		if err != nil {
@@ -346,12 +343,12 @@ func (ks *KeyStore) ReceiveSecretShare(selfIndex int, fromIndex int, ess [][]byt
 	}
 	// Check if the secret share has a valid length
 	if len(ess) < ks.size {
-		return ErrDKGSecret
+		return ErrInvalidSecret
 	}
 	// Decode PVSS
 	p, err := new(tpke.PVSS).Decode(pvss, ks.size, ks.threshold)
 	if err != nil {
-		return ErrInvalidDKGPVSS
+		return ErrInvalidPVSS
 	}
 	// Decrypt and accept the sharing message
 	ss, err := ks.decryptShareMessage(ess[selfIndex-1])
@@ -374,12 +371,12 @@ func (ks *KeyStore) ReceiveSecretReshare(selfIndex int, fromIndex int, ers [][]b
 	}
 	// Check if the secret share has a valid length
 	if len(ers) < ks.size {
-		return ErrDKGSecret
+		return ErrInvalidSecret
 	}
 	// Decode PVSS
 	p, err := new(tpke.PVSS).Decode(pvss, ks.size, ks.threshold)
 	if err != nil {
-		return ErrInvalidDKGPVSS
+		return ErrInvalidPVSS
 	}
 	// Decrypt and accept the resharing message
 	ss, err := ks.decryptShareMessage(ers[selfIndex-1])
@@ -403,7 +400,7 @@ func (ks *KeyStore) ReceiveRecoverShare(selfIndex int, fromIndex int, ers []byte
 	// Decode PVSS
 	p, err := new(tpke.PVSS).Decode(pvss, ks.size, ks.threshold)
 	if err != nil {
-		return ErrInvalidDKGPVSS
+		return ErrInvalidPVSS
 	}
 	// Decrypt and accept the recovering message
 	ss, err := ks.decryptShareMessage(ers)

--- a/antimev/keystore_test.go
+++ b/antimev/keystore_test.go
@@ -106,7 +106,7 @@ func TestShare(t *testing.T) {
 	}
 	for i := 0; i < size; i++ {
 		// No reshare to handle
-		kss[i].OnSharePeriodStart()
+		kss[i].OnSharePeriodStart(false)
 		ss, pvss, err := kss[i].DKGShare()
 		require.NoError(t, err)
 		contract.shareMsgs[i], err = encryptShareMessages(pubs, ss)
@@ -117,9 +117,7 @@ func TestShare(t *testing.T) {
 	for i := 0; i < size; i++ {
 		for j := 0; j < size; j++ {
 			err := kss[i].ReceiveSecretShare(i+1, j+1, contract.shareMsgs[j], contract.sharePVSSes[j])
-			if err != nil {
-				t.Fatalf(err.Error())
-			}
+			require.NoError(t, err)
 		}
 	}
 	// Aggregate pvss manually
@@ -133,7 +131,7 @@ func TestShare(t *testing.T) {
 	}
 	for i := 0; i < size; i++ {
 		// Try finish DKG without resharing
-		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), true)
+		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), nil, true)
 		require.NoError(t, err)
 	}
 }
@@ -162,7 +160,7 @@ func TestReshare(t *testing.T) {
 	}
 	for i := 0; i < size; i++ {
 		// No reshare to handle
-		kss[i].OnSharePeriodStart()
+		kss[i].OnSharePeriodStart(false)
 		ss, pvss, err := kss[i].DKGShare()
 		require.NoError(t, err)
 		contract.shareMsgs[i], err = encryptShareMessages(pubs, ss)
@@ -173,9 +171,7 @@ func TestReshare(t *testing.T) {
 	for i := 0; i < size; i++ {
 		for j := 0; j < size; j++ {
 			err := kss[i].ReceiveSecretShare(i+1, j+1, contract.shareMsgs[j], contract.sharePVSSes[j])
-			if err != nil {
-				t.Fatalf(err.Error())
-			}
+			require.NoError(t, err)
 		}
 	}
 	// Aggregate pvss manually
@@ -189,12 +185,12 @@ func TestReshare(t *testing.T) {
 	}
 	// Finalize dkg
 	for i := 0; i < size; i++ {
-		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), true)
+		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), nil, true)
 		require.NoError(t, err)
 	}
 	// Execute resharing this time
 	for i := 0; i < size; i++ {
-		kss[i].OnSharePeriodStart()
+		kss[i].OnSharePeriodStart(false)
 		rss, rPvss, err := kss[i].DKGReshare()
 		require.NoError(t, err)
 		ss, sPvss, err := kss[i].DKGShare()
@@ -210,13 +206,9 @@ func TestReshare(t *testing.T) {
 	for i := 0; i < size; i++ {
 		for j := 0; j < size; j++ {
 			err := kss[i].ReceiveSecretReshare(i+1, j+1, contract.reshareMsgs[j], contract.resharePVSSes[j])
-			if err != nil {
-				t.Fatalf(err.Error())
-			}
+			require.NoError(t, err)
 			err = kss[i].ReceiveSecretShare(i+1, j+1, contract.shareMsgs[j], contract.sharePVSSes[j])
-			if err != nil {
-				t.Fatalf(err.Error())
-			}
+			require.NoError(t, err)
 		}
 	}
 	// Aggregate pvss manually
@@ -230,7 +222,7 @@ func TestReshare(t *testing.T) {
 	}
 	// Check sharing and resharing
 	for i := 0; i < size; i++ {
-		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), true)
+		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), nil, true)
 		require.NoError(t, err)
 	}
 }
@@ -259,7 +251,7 @@ func TestGroupChange(t *testing.T) {
 	}
 	for i := 0; i < len(addrs); i++ {
 		// No resharing to handle
-		kss[i].OnSharePeriodStart()
+		kss[i].OnSharePeriodStart(false)
 		// Sharing members, i ranges from 0 to 6
 		if i < size {
 			ss, pvss, err := kss[i].DKGShare()
@@ -288,14 +280,14 @@ func TestGroupChange(t *testing.T) {
 	}
 	// Finalize dkg
 	for i := 0; i < size; i++ {
-		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), true)
+		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), nil, true)
 		require.NoError(t, err)
 	}
-	err := kss[7].OnEpochChange(nil, encodePointG1(cmt), false)
+	err := kss[7].OnEpochChange(nil, encodePointG1(cmt), nil, false)
 	require.NoError(t, err)
 	// Execute resharing this time
 	for i := 0; i < len(addrs); i++ {
-		kss[i].OnSharePeriodStart()
+		kss[i].OnSharePeriodStart(false)
 		// Resharing members
 		if i < size {
 			rss, rPvss, err := kss[i].DKGReshare()
@@ -324,19 +316,19 @@ func TestGroupChange(t *testing.T) {
 		}
 	}
 	// Aggregate pvss manually
-	cmt = new(bls12381.G1Affine).ScalarMultiplicationBase(big.NewInt(0))
+	newCmt := new(bls12381.G1Affine).ScalarMultiplicationBase(big.NewInt(0))
 	for i := 0; i < size; i++ {
 		p, err := new(tpke.PVSS).Decode(contract.sharePVSSes[i], size, threshold)
 		require.NoError(t, err)
 		pg1, err := decodePointG1(p.GetCommitment().Encode()[:128])
 		require.NoError(t, err)
-		cmt = new(bls12381.G1Affine).Add(cmt, pg1)
+		newCmt = new(bls12381.G1Affine).Add(newCmt, pg1)
 	}
 	// Check sharing and resharing
-	err = kss[0].OnEpochChange(nil, encodePointG1(cmt), false)
+	err = kss[0].OnEpochChange(nil, encodePointG1(newCmt), encodePointG1(cmt), false)
 	require.NoError(t, err)
 	for i := 1; i <= size; i++ {
-		err := kss[i].OnEpochChange(contract.sharePVSSes[i-1], encodePointG1(cmt), i != 0)
+		err := kss[i].OnEpochChange(contract.sharePVSSes[i-1], encodePointG1(newCmt), encodePointG1(cmt), i != 0)
 		require.NoError(t, err)
 	}
 }
@@ -366,7 +358,7 @@ func TestRecover(t *testing.T) {
 	}
 	for i := 0; i < len(addrs); i++ {
 		// No resharing to handle
-		kss[i].OnSharePeriodStart()
+		kss[i].OnSharePeriodStart(false)
 		// Sharing members, i ranges from 0 to 6
 		if i < size {
 			ss, pvss, err := kss[i].DKGShare()
@@ -395,14 +387,14 @@ func TestRecover(t *testing.T) {
 	}
 	// Finalize dkg
 	for i := 0; i < size; i++ {
-		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), true)
+		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), nil, true)
 		require.NoError(t, err)
 	}
-	err := kss[7].OnEpochChange(nil, encodePointG1(cmt), false)
+	err := kss[7].OnEpochChange(nil, encodePointG1(cmt), nil, false)
 	require.NoError(t, err)
 	// Execute resharing this time
 	for i := 0; i < len(addrs); i++ {
-		kss[i].OnSharePeriodStart()
+		kss[i].OnSharePeriodStart(false)
 		// Resharing members
 		if i < size {
 			rss, rPvss, err := kss[i].DKGReshare()
@@ -448,7 +440,7 @@ func TestRecover(t *testing.T) {
 	}
 	// Only check resharing
 	for i := 0; i < len(addrs); i++ {
-		err := kss[i].aggregateReshare(i != 0)
+		err := kss[i].aggregateReshare(encodePointG1(cmt), i != 0)
 		require.NoError(t, err)
 	}
 }

--- a/antimev/signature_test.go
+++ b/antimev/signature_test.go
@@ -81,7 +81,7 @@ func TestThresholdSignature(t *testing.T) {
 	}
 	for i := 0; i < size; i++ {
 		// No reshare to handle
-		kss[i].OnSharePeriodStart()
+		kss[i].OnSharePeriodStart(false)
 		ss, pvss, err := kss[i].DKGShare()
 		require.NoError(t, err)
 		contract.shareMsgs[i], err = encryptShareMessages(pubs, ss)
@@ -92,9 +92,7 @@ func TestThresholdSignature(t *testing.T) {
 	for i := 0; i < size; i++ {
 		for j := 0; j < size; j++ {
 			err := kss[i].ReceiveSecretShare(i+1, j+1, contract.shareMsgs[j], contract.sharePVSSes[j])
-			if err != nil {
-				t.Fatalf(err.Error())
-			}
+			require.NoError(t, err)
 		}
 	}
 	// Aggregate pvss manually
@@ -107,7 +105,7 @@ func TestThresholdSignature(t *testing.T) {
 		cmt = new(bls12381.G1Affine).Add(cmt, pg1)
 	}
 	for i := 0; i < size; i++ {
-		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), true)
+		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), nil, true)
 		require.NoError(t, err)
 	}
 

--- a/antimev/tpke_test.go
+++ b/antimev/tpke_test.go
@@ -47,7 +47,7 @@ func TestTPKE(t *testing.T) {
 	}
 	for i := 0; i < size; i++ {
 		// No reshare to handle
-		kss[i].OnSharePeriodStart()
+		kss[i].OnSharePeriodStart(false)
 		ss, pvss, err := kss[i].DKGShare()
 		require.NoError(t, err)
 		contract.shareMsgs[i], err = encryptShareMessages(pubs, ss)
@@ -71,7 +71,7 @@ func TestTPKE(t *testing.T) {
 		cmt = new(bls12381.G1Affine).Add(cmt, pg1)
 	}
 	for i := 0; i < size; i++ {
-		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), true)
+		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), nil, true)
 		require.NoError(t, err)
 	}
 
@@ -281,7 +281,7 @@ func TestBenchmark(t *testing.T) {
 	}
 	for i := 0; i < size; i++ {
 		// No reshare to handle
-		kss[i].OnSharePeriodStart()
+		kss[i].OnSharePeriodStart(false)
 		ss, pvss, err := kss[i].DKGShare()
 		require.NoError(t, err)
 		contract.shareMsgs[i], err = encryptShareMessages(pubs, ss)
@@ -305,7 +305,7 @@ func TestBenchmark(t *testing.T) {
 		cmt = new(bls12381.G1Affine).Add(cmt, pg1)
 	}
 	for i := 0; i < size; i++ {
-		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), true)
+		err := kss[i].OnEpochChange(contract.sharePVSSes[i], encodePointG1(cmt), nil, true)
 		require.NoError(t, err)
 	}
 

--- a/cmd/geth/antimevcmd.go
+++ b/cmd/geth/antimevcmd.go
@@ -122,15 +122,16 @@ changing your password is only possible interactively.
 
 Reset the existing antimev keystore.
 
-The keystore is reset to the initial state, all DKG data are deleted to recover
-from a stuck epoch change.
+The keystore is reset to the initial state before any DKG round, but the message
+key, identity address and basic DKG parameters are reserved.
 
 For non-interactive use, password can be specified with --antimev.password flag:
 
     geth antimev reset [options]
 
-Note, this is meant to be used for emergency only, it is a bad idea to reset your
-keystore when everything runs correctly.
+Note, you can use this command to recycle your keystore for Privnet or other
+networks, but it is a bad idea to reset an in-use one when everything runs
+correctly.
 `,
 			},
 		},

--- a/consensus/dbft/dkg.go
+++ b/consensus/dbft/dkg.go
@@ -130,11 +130,7 @@ func (c *DBFT) handleDKG(snapshot *snapshot, keystore *antimev.KeyStore, h *type
 	// If there is an ongoing round and it's time to epoch change.
 	if snapshot.initDone && currentHeight >= snapshot.EpochStartHeight+epochDuration {
 		indexOfSharing := slices.Index(snapshot.PendingCNs, amevAddress) + 1
-		ready, err := isShareReady(c.backend, state, h)
-		if err != nil {
-			return fmt.Errorf("failed to check if sharing is ready: %v", err)
-		}
-		if ready && indexOfSharing > 0 {
+		if indexOfSharing > 0 {
 			if err := c.syncThisRoundSecrets(snapshot, keystore, indexOfSharing, state, h); err != nil {
 				return fmt.Errorf("failed to sync sharing DKG, err: %v", err)
 			}
@@ -289,18 +285,11 @@ func (c *DBFT) handleDKG(snapshot *snapshot, keystore *antimev.KeyStore, h *type
 			return fmt.Errorf("failed to check if sharing is ready: %v", err)
 		}
 		if ready {
-			// If share is ready, pending consensus nodes should ReceiveSecretShare.
-			indexOfSharing := slices.Index(snapshot.PendingCNs, amevAddress) + 1
-			if indexOfSharing > 0 {
-				if err := c.syncThisRoundSecrets(snapshot, keystore, indexOfSharing, state, h); err != nil {
-					return fmt.Errorf("failed to sync sharing DKG, err: %v", err)
-				}
-			}
 			snapshot.IndexNeedRecover, err = getIndexCurrentNeedRecovering(c.backend, state, h)
 			if err != nil {
 				return fmt.Errorf("failed to fetch index need recovering, err: %v", err)
 			}
-			// If the period finished, then skip sending a transaction.
+			// If no recover is required, then skip sending a transaction.
 			if len(snapshot.IndexNeedRecover) > 0 {
 				// Only indexesNeedRecover <= (consensusSize - threshold) can recover.
 				threshold := consensusSize - (consensusSize-1)/3
@@ -718,17 +707,20 @@ func (c *DBFT) syncThisRoundSecrets(snap *snapshot, keystore *antimev.KeyStore, 
 // downloadAndReceiveShare downloads DKG messages and related PVSS in sharing, and sends to keystore.
 func (c *DBFT) downloadAndReceiveShare(keystore *antimev.KeyStore, round uint64, fromIndex int, selfIndex int, state *state.StateDB, header *types.Header) error {
 	// Call ReceiveSecretShare
-	shareMsgs, err := getShareMsgs(c.backend, round, uint64(fromIndex), state, header)
-	if err != nil {
-		return err
-	}
 	spvss, err := getSharePVSS(c.backend, round, uint64(fromIndex), state, header)
 	if err != nil {
 		return err
 	}
-	err = keystore.ReceiveSecretShare(selfIndex, fromIndex, shareMsgs, spvss)
-	if err != nil {
-		return err
+	// Only receive share has value
+	if len(spvss) > 0 {
+		shareMsgs, err := getShareMsgs(c.backend, round, uint64(fromIndex), state, header)
+		if err != nil {
+			return err
+		}
+		err = keystore.ReceiveSecretShare(selfIndex, fromIndex, shareMsgs, spvss)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/consensus/dbft/dkg.go
+++ b/consensus/dbft/dkg.go
@@ -344,7 +344,7 @@ func (c *DBFT) handleDKG(snapshot *snapshot, keystore *antimev.KeyStore, h *type
 			if err != nil {
 				return fmt.Errorf("failed to fecth message keys, err: %v", err)
 			}
-			err = taskList.taskReshareRecover(keystore, receiverMessageKeys, currentHeight, zkVersion, targetHeight)
+			err = taskList.taskReshareRecover(keystore, receiverMessageKeys, zkVersion, currentHeight, targetHeight)
 			if err != nil {
 				return fmt.Errorf("failed to task DKG reshare recover, err: %v", err)
 			}

--- a/consensus/dbft/dkg.go
+++ b/consensus/dbft/dkg.go
@@ -149,7 +149,11 @@ func (c *DBFT) handleDKG(snapshot *snapshot, keystore *antimev.KeyStore, h *type
 		if err != nil {
 			return fmt.Errorf("failed to fetch aggregated commitment, err: %v", err)
 		}
-		err = keystore.OnEpochChange(selfPvss, aggregatedCommitment, indexOfSharing > 0)
+		lastCommitment, err := getAggregatedCommitment(c.backend, snapshot.Round-1, state, h)
+		if err != nil {
+			return fmt.Errorf("failed to fetch aggregated commitment, err: %v", err)
+		}
+		err = keystore.OnEpochChange(selfPvss, aggregatedCommitment, lastCommitment, indexOfSharing > 0)
 		if err != nil {
 			return fmt.Errorf("failed to change keystore epoch, err: %v", err)
 		}
@@ -202,7 +206,8 @@ func (c *DBFT) handleDKG(snapshot *snapshot, keystore *antimev.KeyStore, h *type
 		}
 		// If keystore is in a sharing state already, then regard it has a valid secret.
 		if !keystore.IsSharing() {
-			keystore.OnSharePeriodStart()
+			// Enforce to init an empty resharing when necessary.
+			keystore.OnSharePeriodStart(snapshot.Round > 2)
 		}
 		// If is a member of current consensus, then try sync secrets.
 		indexOfSharing := slices.Index(snapshot.CurrentCNs, amevAddress) + 1
@@ -225,7 +230,14 @@ func (c *DBFT) handleDKG(snapshot *snapshot, keystore *antimev.KeyStore, h *type
 		if err != nil {
 			return fmt.Errorf("failed to fetch aggregated commitment, err: %v", err)
 		}
-		if err := keystore.OnEpochChange(selfPvss, aggregatedCommitment, indexOfSharing > 0); err != nil {
+		var lastCommitment []byte
+		if snapshot.Round > 2 {
+			lastCommitment, err = getAggregatedCommitment(c.backend, snapshot.Round-2, state, h)
+			if err != nil {
+				return fmt.Errorf("failed to fetch aggregated commitment, err: %v", err)
+			}
+		}
+		if err := keystore.OnEpochChange(selfPvss, aggregatedCommitment, lastCommitment, indexOfSharing > 0); err != nil {
 			return fmt.Errorf("failed to sync shared DKG, err: %v", err)
 		}
 		if !suspended {
@@ -242,24 +254,24 @@ func (c *DBFT) handleDKG(snapshot *snapshot, keystore *antimev.KeyStore, h *type
 		}
 		// Prepare and start a DKG.
 		if !keystore.IsSharing() {
-			keystore.OnSharePeriodStart()
+			keystore.OnSharePeriodStart(false)
 		}
 		// If the period finished, then skip sending a transaction.
 		if !suspended && currentHeight < recoverStartHeight {
 			// If is a member of current consensus, try reshare but give up if error.
 			indexOfResharing := slices.Index(snapshot.CurrentCNs, amevAddress) + 1
 			receiverMessageKeys, err := getMessagePubkeys(c.backend, snapshot.PendingCNs, state, h)
+			if err != nil {
+				return fmt.Errorf("failed to get message keys, err: %v", err)
+			}
 			if indexOfResharing > 0 && snapshot.Round > 1 {
 				err = taskList.taskReshare(keystore, receiverMessageKeys, zkVersion, currentHeight, recoverStartHeight)
 				if err != nil {
-					return fmt.Errorf("failed to task DKG reshare, err: %v", err)
+					log.Error("Failed to task DKG reshare", "err", err)
 				}
 			}
 			// If is a member of pending consensus.
 			indexOfSharing := slices.Index(snapshot.PendingCNs, amevAddress) + 1
-			if err != nil {
-				return fmt.Errorf("failed to get message keys, err: %v", err)
-			}
 			if indexOfSharing > 0 {
 				err = taskList.taskShare(keystore, receiverMessageKeys, zkVersion, currentHeight, recoverStartHeight)
 				if err != nil {
@@ -681,7 +693,7 @@ func (c *DBFT) syncLastRoundSecrets(snap *snapshot, keystore *antimev.KeyStore, 
 		if err := c.downloadAndReceiveShare(keystore, snap.Round-1, i+1, selfIndex, state, header); err != nil {
 			return err
 		}
-		if snap.Round > 1 {
+		if snap.Round > 2 {
 			if err := c.downloadAndReceiveReshare(keystore, snap.Round-1, i+1, selfIndex, state, header); err != nil {
 				return err
 			}
@@ -692,12 +704,10 @@ func (c *DBFT) syncLastRoundSecrets(snap *snapshot, keystore *antimev.KeyStore, 
 
 // syncThisRoundSecrets synchronizes DKG data in this round to update the local anti-mev keystore for the first stage.
 func (c *DBFT) syncThisRoundSecrets(snap *snapshot, keystore *antimev.KeyStore, selfIndex int, state *state.StateDB, header *types.Header) error {
-	for i := range snap.PendingCNs {
+	for i := range snap.CurrentCNs {
 		if err := c.downloadAndReceiveShare(keystore, snap.Round, i+1, selfIndex, state, header); err != nil {
 			return err
 		}
-	}
-	for i := range snap.CurrentCNs {
 		if err := c.downloadAndReceiveReshare(keystore, snap.Round, i+1, selfIndex, state, header); err != nil {
 			return err
 		}


### PR DESCRIPTION
Close #479. Close #481. Close #482. Close #483. Including some other fixes and optimizations found in DKG.