### PR TITLE
crypto/tpke: antimev: enforce none-zero random scalar

### DIFF
--- a/antimev/keygroup.go
+++ b/antimev/keygroup.go
@@ -119,9 +119,12 @@ func (tkg *thresholdKeyGroup) recover(secretIndexs []int) ([]*big.Int, error) {
 }
 
 // share generates local secrets and returns sharing messages.
-func (tkg *thresholdKeyGroup) share(size int, threshold int) ([]*big.Int, *tpke.PVSS) {
+func (tkg *thresholdKeyGroup) share(size int, threshold int) ([]*big.Int, *tpke.PVSS, error) {
 	// Generate local secret
-	secret := tpke.RandomSecret(threshold)
+	secret, err := tpke.RandomSecret(threshold)
+	if err != nil {
+		return nil, nil, err
+	}
 	tkg.pendingSecrets = append(tkg.pendingSecrets, secret)
 	// Generate and encrypt messages to share the secret
 	return generateShares(secret, size)
@@ -134,9 +137,12 @@ func (tkg *thresholdKeyGroup) reshare(size int) ([]*big.Int, *tpke.PVSS, error) 
 	if tkg.localSecret == nil {
 		return nil, nil, ErrSecretNotFound
 	}
+	secret, err := tkg.localSecret.Renovate()
+	if err != nil {
+		return nil, nil, err
+	}
 	// Generate and encrypt messages to share the secret
-	ss, pvss := generateShares(tkg.localSecret.Renovate(), size)
-	return ss, pvss, nil
+	return generateShares(secret, size)
 }
 
 // reshareRecovered tries to recover a dkg secret, and returns an error if
@@ -161,12 +167,14 @@ func (tkg *thresholdKeyGroup) reshareRecovered(size int, threshold int) ([]*big.
 
 // generateShares generates shares from a secret.
 // Secret shares can be decrypted by specific receivers, but pvss is public.
-func generateShares(secret *tpke.Secret, size int) ([]*big.Int, *tpke.PVSS) {
+func generateShares(secret *tpke.Secret, size int) ([]*big.Int, *tpke.PVSS, error) {
 	// Random value for pvss generation
-	randR := randScalar()
+	randR, err := randScalar()
+	if err != nil {
+		return nil, nil, err
+	}
 	pvss, ss := tpke.GenerateSecretShares(randR, size, secret)
-
-	return ss, pvss
+	return ss, pvss, nil
 }
 
 // receiveShareMessage verifies received sharing/resharing messages. It verifies

--- a/antimev/keystore.go
+++ b/antimev/keystore.go
@@ -241,7 +241,10 @@ func (ks *KeyStore) DKGShare() ([]*big.Int, []byte, error) {
 		return nil, nil, ErrKeyGroupNotExists
 	}
 	// Generate sharing secrets and pvss
-	ss, sPvss := ks.sharing.share(ks.size, ks.threshold)
+	ss, sPvss, err := ks.sharing.share(ks.size, ks.threshold)
+	if err != nil {
+		return nil, nil, err
+	}
 	return ss, sPvss.Encode(), nil
 }
 

--- a/antimev/signature_test.go
+++ b/antimev/signature_test.go
@@ -17,7 +17,8 @@ import (
 )
 
 func TestSingleSignature(t *testing.T) {
-	sk := tpke.RandomPrivateKey()
+	sk, err := tpke.RandomPrivateKey()
+	require.NoError(t, err)
 	pk := sk.GetPublicKey()
 
 	msg := []byte("pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza")

--- a/antimev/tpke.go
+++ b/antimev/tpke.go
@@ -24,7 +24,10 @@ func (ks *KeyStore) Encrypt(msg []byte) (*tpke.CipherText, []byte, error) {
 		return nil, nil, ErrNoPubKey
 	}
 	// Random AES key
-	aesKey := randPG1()
+	aesKey, err := randPG1()
+	if err != nil {
+		return nil, nil, err
+	}
 	// Encrypt the key
 	encryptedKey, err := ks.shared.encrypt(aesKey)
 	if err != nil {
@@ -125,7 +128,7 @@ func (tkg *thresholdKeyGroup) encrypt(msg *bls12381.G1Affine) (*tpke.CipherText,
 	if tkg.globalPubKey == nil {
 		return nil, ErrNoPubKey
 	}
-	return tkg.globalPubKey.Encrypt(msg), nil
+	return tkg.globalPubKey.Encrypt(msg)
 }
 
 // decryptShare generates decryption shares for an array of encrypted aes keys.

--- a/antimev/util.go
+++ b/antimev/util.go
@@ -13,15 +13,28 @@ import (
 )
 
 // randPG1 returns a random bls12381 g1 point
-func randPG1() *bls12381.G1Affine {
-	r := randScalar()
-	return new(bls12381.G1Affine).ScalarMultiplicationBase(r)
+func randPG1() (*bls12381.G1Affine, error) {
+	r, err := randScalar()
+	if err != nil {
+		return nil, err
+	}
+	return new(bls12381.G1Affine).ScalarMultiplicationBase(r), nil
 }
 
 // randScalar returns a random big int
-func randScalar() *big.Int {
-	a, _ := rand.Int(rand.Reader, ecc.BLS12_381.ScalarField())
-	return a
+func randScalar() (*big.Int, error) {
+	var k *big.Int
+	var err error
+	for {
+		k, err = rand.Int(rand.Reader, ecc.BLS12_381.ScalarField())
+		if err != nil {
+			return nil, err
+		}
+		if k.Sign() > 0 {
+			break
+		}
+	}
+	return k, nil
 }
 
 // getScaler returns a scaler factor for public key, works under size 7,

--- a/crypto/tpke/aes_test.go
+++ b/crypto/tpke/aes_test.go
@@ -2,24 +2,23 @@ package tpke
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestAES(t *testing.T) {
 	msg := []byte("pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza pizza")
-	g1 := randPG1()
+	g1, err := randPG1()
+	require.NoError(t, err)
 	t.Logf("origin msg : %v", string(msg))
 
 	// Encrypt
 	encrypted, err := AESEncrypt(g1, msg)
-	if err != nil {
-		t.Fatalf("encryption failed.")
-	}
+	require.NoError(t, err)
 	t.Logf("encrypted msg : %v", encrypted)
 
 	// Decrypt
 	decrypted, err := AESDecrypt(g1, encrypted)
-	if err != nil {
-		t.Fatalf("decryption failed.")
-	}
+	require.NoError(t, err)
 	t.Logf("decrypted msg : %v", string(decrypted))
 }

--- a/crypto/tpke/encryption_test.go
+++ b/crypto/tpke/encryption_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCipherTextEncoding(t *testing.T) {
@@ -16,9 +17,7 @@ func TestCipherTextEncoding(t *testing.T) {
 	}
 	b := ct.ToBytes()
 	result, err := new(CipherText).FromBytes(b)
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
+	require.NoError(t, err)
 	if !ct.cMsg.Equal(result.cMsg) {
 		t.Fatalf("cMsg mismatch.")
 	}

--- a/crypto/tpke/poly.go
+++ b/crypto/tpke/poly.go
@@ -10,16 +10,19 @@ type Poly struct {
 	coeff []*big.Int
 }
 
-func randomPoly(degree int) *Poly {
+func randomPoly(degree int) (*Poly, error) {
 	coeff := make([]*big.Int, degree)
 
 	for i := range coeff {
-		fr := randScalar()
+		fr, err := randScalar()
+		if err != nil {
+			return nil, err
+		}
 		coeff[i] = fr
 	}
 	return &Poly{
 		coeff: coeff,
-	}
+	}, nil
 }
 
 func (p *Poly) evaluate(x *big.Int) *big.Int {

--- a/crypto/tpke/private_key.go
+++ b/crypto/tpke/private_key.go
@@ -11,11 +11,14 @@ type PrivateKey struct {
 	fr *big.Int // A secret number aggregated from DKG sharing
 }
 
-func RandomPrivateKey() *PrivateKey {
-	fr := randScalar()
+func RandomPrivateKey() (*PrivateKey, error) {
+	fr, err := randScalar()
+	if err != nil {
+		return nil, err
+	}
 	return &PrivateKey{
 		fr: fr,
-	}
+	}, nil
 }
 
 // NewPrivateKey returns a tpke private key for threshold decryption

--- a/crypto/tpke/public_key.go
+++ b/crypto/tpke/public_key.go
@@ -91,8 +91,11 @@ func (pk *PublicKey) Equal(opk *PublicKey) bool {
 }
 
 // Encrypt returns an encrypted point with encryption commitment.
-func (pk *PublicKey) Encrypt(msg *bls12381.G1Affine) *CipherText {
-	r := randScalar()
+func (pk *PublicKey) Encrypt(msg *bls12381.G1Affine) (*CipherText, error) {
+	r, err := randScalar()
+	if err != nil {
+		return nil, err
+	}
 
 	// C=M+rpk, R1=rG1, R2=-rG2
 	_, _, _, g2 := bls12381.Generators()
@@ -107,7 +110,7 @@ func (pk *PublicKey) Encrypt(msg *bls12381.G1Affine) *CipherText {
 		cMsg:       cMsg,
 		bigR:       bigR1,
 		commitment: bigR2,
-	}
+	}, nil
 }
 
 // VerifySigShare verifies a signature in form of a single signature.

--- a/crypto/tpke/pvss_test.go
+++ b/crypto/tpke/pvss_test.go
@@ -5,11 +5,13 @@ import (
 	"testing"
 
 	bls12381 "github.com/consensys/gnark-crypto/ecc/bls12-381"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPVSSEncoding(t *testing.T) {
 	_, _, g1, g2 := bls12381.Generators()
-	poly := randomPoly(2)
+	poly, err := randomPoly(2)
+	require.NoError(t, err)
 	comm := poly.commitment()
 	bigf := make([]*bls12381.G1Affine, 3)
 	bigf[0] = comm.evaluate(big.NewInt(1))
@@ -23,9 +25,7 @@ func TestPVSSEncoding(t *testing.T) {
 	}
 	b := pvss.Encode()
 	result, err := new(PVSS).Decode(b, 3, 2)
-	if err != nil {
-		t.Fatalf(err.Error())
-	}
+	require.NoError(t, err)
 	for i, pg1 := range pvss.commitment.coeff {
 		if !pg1.Equal(result.commitment.coeff[i]) {
 			t.Fatalf("commitment mismatch.")

--- a/crypto/tpke/secrect.go
+++ b/crypto/tpke/secrect.go
@@ -9,10 +9,14 @@ type Secret struct {
 }
 
 // RandomSecret returns a random polynomial with zero δ
-func RandomSecret(threshold int) *Secret {
-	return &Secret{
-		poly: randomPoly(threshold),
+func RandomSecret(threshold int) (*Secret, error) {
+	p, err := randomPoly(threshold)
+	if err != nil {
+		return nil, err
 	}
+	return &Secret{
+		poly: p,
+	}, nil
 }
 
 // RecoverSecret tries to recover a polynomial with (x,fx) array
@@ -41,12 +45,15 @@ func (s *Secret) FromBigIntArray(arr []*big.Int) {
 }
 
 // Renovate returns a new secret random a1..an-1 expect a0
-func (s *Secret) Renovate() *Secret {
-	poly := randomPoly(len(s.poly.coeff))
+func (s *Secret) Renovate() (*Secret, error) {
+	poly, err := randomPoly(len(s.poly.coeff))
+	if err != nil {
+		return nil, err
+	}
 	poly.coeff[0].Set(s.poly.coeff[0])
 	return &Secret{
 		poly: poly,
-	}
+	}, nil
 }
 
 func (s *Secret) Commitment() *Commitment {

--- a/crypto/tpke/util.go
+++ b/crypto/tpke/util.go
@@ -18,14 +18,29 @@ var (
 	ErrTPKEScalarDecoding       = errors.New("crypto/tpke: invalid scalar decoding")
 )
 
-func randScalar() *big.Int {
-	a, _ := rand.Int(rand.Reader, ecc.BLS12_381.ScalarField())
-	return a
+// randScalar returns a random big int
+func randScalar() (*big.Int, error) {
+	var k *big.Int
+	var err error
+	for {
+		k, err = rand.Int(rand.Reader, ecc.BLS12_381.ScalarField())
+		if err != nil {
+			return nil, err
+		}
+		if k.Sign() > 0 {
+			break
+		}
+	}
+	return k, nil
 }
 
-func randPG1() *bls12381.G1Affine {
-	r := randScalar()
-	return new(bls12381.G1Affine).ScalarMultiplicationBase(r)
+// randPG1 returns a random bls12381 g1 point
+func randPG1() (*bls12381.G1Affine, error) {
+	r, err := randScalar()
+	if err != nil {
+		return nil, err
+	}
+	return new(bls12381.G1Affine).ScalarMultiplicationBase(r), nil
 }
 
 func decodePointG1(in []byte) (*bls12381.G1Affine, error) {

--- a/crypto/tpke/util_test.go
+++ b/crypto/tpke/util_test.go
@@ -3,10 +3,13 @@ package tpke
 import (
 	"math/big"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestRecover(t *testing.T) {
-	s := randomPoly(5)
+	s, err := randomPoly(5)
+	require.NoError(t, err)
 	p := polyRecover([]int{1, 2, 3, 4, 5}, []*big.Int{s.evaluate(big.NewInt(1)), s.evaluate(big.NewInt(2)), s.evaluate(big.NewInt(3)), s.evaluate(big.NewInt(4)), s.evaluate(big.NewInt(5))})
 	if p[0].Cmp(s.coeff[0]) != 0 || p[1].Cmp(s.coeff[1]) != 0 || p[2].Cmp(s.coeff[2]) != 0 || p[3].Cmp(s.coeff[3]) != 0 || p[4].Cmp(s.coeff[4]) != 0 {
 		t.Fatalf("recover failed.")


### PR DESCRIPTION
In the current crypto scheme, we use `rand.Int()` to generate random numbers for DKG local secret generation, crypto commitment and encryption.

Even though the possibility is very low, but this function may output `0`, which weakens the security of our protocol in several perspectives.

This PR prevents zero values from appearing in `crypto/tpke` and `antimev`.