### PR TITLE
antimev: make local DKG secret recoverable independently without threshold

### DIFF
--- a/antimev/keygroup.go
+++ b/antimev/keygroup.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/crypto/ecies"
 	"github.com/ethereum/go-ethereum/crypto/tpke"
 )
 
@@ -118,13 +119,11 @@ func (tkg *thresholdKeyGroup) recover(secretIndexs []int) ([]*big.Int, error) {
 	return ss, nil
 }
 
-// share generates local secrets and returns sharing messages.
-func (tkg *thresholdKeyGroup) share(size int, threshold int) ([]*big.Int, *tpke.PVSS, error) {
+// share generates local secrets and returns sharing messages. Network id,
+// keystore key and round number is required for predictable randomness.
+func (tkg *thresholdKeyGroup) share(networkId *big.Int, ethPrvKey *ecies.PrivateKey, size int, threshold int, round int) ([]*big.Int, *tpke.PVSS, error) {
 	// Generate local secret
-	secret, err := tpke.RandomSecret(threshold)
-	if err != nil {
-		return nil, nil, err
-	}
+	secret := tpke.RandomSecret(threshold, ethPrvKey, networkId.Bytes(), round)
 	tkg.pendingSecrets = append(tkg.pendingSecrets, secret)
 	// Generate and encrypt messages to share the secret
 	return generateShares(secret, size)

--- a/antimev/keystore.go
+++ b/antimev/keystore.go
@@ -235,13 +235,16 @@ func (ks *KeyStore) DKGReshare() ([]*big.Int, []byte, error) {
 	return rss, rPvss.Encode(), nil
 }
 
-// DKGShare generates and returns sharing secrets and pvss.
-func (ks *KeyStore) DKGShare() ([]*big.Int, []byte, error) {
+// DKGShare generates and returns sharing secrets and pvss. Different from
+// DKGReshare, the secret generation here is predictable based on message
+// decryption key, network id and DKG round number. Network id is used for
+// replay protection.
+func (ks *KeyStore) DKGShare(networkId *big.Int) ([]*big.Int, []byte, error) {
 	if ks.sharing == nil {
 		return nil, nil, ErrKeyGroupNotExists
 	}
 	// Generate sharing secrets and pvss
-	ss, sPvss, err := ks.sharing.share(ks.size, ks.threshold)
+	ss, sPvss, err := ks.sharing.share(networkId, ks.ethPrvKey, ks.size, ks.threshold, ks.round+1)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/antimev/keystore_test.go
+++ b/antimev/keystore_test.go
@@ -107,7 +107,7 @@ func TestShare(t *testing.T) {
 	for i := 0; i < size; i++ {
 		// No reshare to handle
 		kss[i].OnSharePeriodStart(false)
-		ss, pvss, err := kss[i].DKGShare()
+		ss, pvss, err := kss[i].DKGShare(big.NewInt(1))
 		require.NoError(t, err)
 		contract.shareMsgs[i], err = encryptShareMessages(pubs, ss)
 		require.NoError(t, err)
@@ -161,7 +161,7 @@ func TestReshare(t *testing.T) {
 	for i := 0; i < size; i++ {
 		// No reshare to handle
 		kss[i].OnSharePeriodStart(false)
-		ss, pvss, err := kss[i].DKGShare()
+		ss, pvss, err := kss[i].DKGShare(big.NewInt(1))
 		require.NoError(t, err)
 		contract.shareMsgs[i], err = encryptShareMessages(pubs, ss)
 		require.NoError(t, err)
@@ -193,7 +193,7 @@ func TestReshare(t *testing.T) {
 		kss[i].OnSharePeriodStart(false)
 		rss, rPvss, err := kss[i].DKGReshare()
 		require.NoError(t, err)
-		ss, sPvss, err := kss[i].DKGShare()
+		ss, sPvss, err := kss[i].DKGShare(big.NewInt(1))
 		require.NoError(t, err)
 		contract.shareMsgs[i], err = encryptShareMessages(pubs, ss)
 		require.NoError(t, err)
@@ -254,7 +254,7 @@ func TestGroupChange(t *testing.T) {
 		kss[i].OnSharePeriodStart(false)
 		// Sharing members, i ranges from 0 to 6
 		if i < size {
-			ss, pvss, err := kss[i].DKGShare()
+			ss, pvss, err := kss[i].DKGShare(big.NewInt(1))
 			require.NoError(t, err)
 			contract.shareMsgs[i], err = encryptShareMessages(pubs[:size], ss)
 			require.NoError(t, err)
@@ -297,7 +297,7 @@ func TestGroupChange(t *testing.T) {
 			contract.resharePVSSes[i] = rPvss
 		}
 		if i > 0 {
-			ss, sPvss, err := kss[i].DKGShare()
+			ss, sPvss, err := kss[i].DKGShare(big.NewInt(1))
 			require.NoError(t, err)
 			contract.shareMsgs[i-1], err = encryptShareMessages(pubs[1:], ss)
 			require.NoError(t, err)
@@ -361,7 +361,7 @@ func TestRecover(t *testing.T) {
 		kss[i].OnSharePeriodStart(false)
 		// Sharing members, i ranges from 0 to 6
 		if i < size {
-			ss, pvss, err := kss[i].DKGShare()
+			ss, pvss, err := kss[i].DKGShare(big.NewInt(1))
 			require.NoError(t, err)
 			contract.shareMsgs[i], err = encryptShareMessages(pubs[:size], ss)
 			require.NoError(t, err)

--- a/antimev/signature_test.go
+++ b/antimev/signature_test.go
@@ -83,7 +83,7 @@ func TestThresholdSignature(t *testing.T) {
 	for i := 0; i < size; i++ {
 		// No reshare to handle
 		kss[i].OnSharePeriodStart(false)
-		ss, pvss, err := kss[i].DKGShare()
+		ss, pvss, err := kss[i].DKGShare(big.NewInt(1))
 		require.NoError(t, err)
 		contract.shareMsgs[i], err = encryptShareMessages(pubs, ss)
 		require.NoError(t, err)

--- a/antimev/tpke_test.go
+++ b/antimev/tpke_test.go
@@ -48,7 +48,7 @@ func TestTPKE(t *testing.T) {
 	for i := 0; i < size; i++ {
 		// No reshare to handle
 		kss[i].OnSharePeriodStart(false)
-		ss, pvss, err := kss[i].DKGShare()
+		ss, pvss, err := kss[i].DKGShare(big.NewInt(1))
 		require.NoError(t, err)
 		contract.shareMsgs[i], err = encryptShareMessages(pubs, ss)
 		require.NoError(t, err)
@@ -282,7 +282,7 @@ func TestBenchmark(t *testing.T) {
 	for i := 0; i < size; i++ {
 		// No reshare to handle
 		kss[i].OnSharePeriodStart(false)
-		ss, pvss, err := kss[i].DKGShare()
+		ss, pvss, err := kss[i].DKGShare(big.NewInt(1))
 		require.NoError(t, err)
 		contract.shareMsgs[i], err = encryptShareMessages(pubs, ss)
 		require.NoError(t, err)

--- a/consensus/dbft/dkg.go
+++ b/consensus/dbft/dkg.go
@@ -210,10 +210,19 @@ func (c *DBFT) handleDKG(snapshot *snapshot, keystore *antimev.KeyStore, h *type
 		if indexOfSharing > 0 {
 			// Only a warning here, since it doesn't destroy dBFT and anti-mev,
 			// a new DKG can perform and the next reshare is recoverable.
-			// But it is dangerous if more than 1/3 CNs reinit their keystores
-			// or change their message key.
+			// But it is dangerous if more than 1/3 CNs change their message key.
 			if err := c.syncLastRoundSecrets(snapshot, keystore, indexOfSharing, state, h); err != nil {
 				log.Warn("failed to sync shared DKG", "err", err)
+			} else {
+				// If the message synchronization succeeds, then the message key remains the same.
+				// It means the local secret is also recoverable. Here we just do share with the
+				// same network id and round number, then we should get the same result.
+				// The result will be checked in epoch change, log an error message if no secret
+				// can not be confirmed in committed PVSS.
+				_, _, err := keystore.DKGShare((*c.backend).ChainConfig().ChainID)
+				if err != nil {
+					return fmt.Errorf("failed to replay sharing, err: %v", err)
+				}
 			}
 		}
 		// If indexOfSharing is 0, then selfPvss should be nil.

--- a/consensus/dbft/dkg.go
+++ b/consensus/dbft/dkg.go
@@ -262,7 +262,7 @@ func (c *DBFT) handleDKG(snapshot *snapshot, keystore *antimev.KeyStore, h *type
 			keystore.OnSharePeriodStart(false)
 		}
 		// If the period finished, then skip sending a transaction.
-		if !suspended && currentHeight < recoverStartHeight {
+		if !suspended {
 			// If is a member of current consensus, try reshare but give up if error.
 			indexOfResharing := slices.Index(snapshot.CurrentCNs, amevAddress) + 1
 			receiverMessageKeys, err := getMessagePubkeys(c.backend, snapshot.PendingCNs, state, h)
@@ -306,7 +306,7 @@ func (c *DBFT) handleDKG(snapshot *snapshot, keystore *antimev.KeyStore, h *type
 					if !keystore.IsRecovering() {
 						keystore.OnRecoverPeriodStart()
 					}
-					if !suspended && currentHeight < recoverCheckHeight {
+					if !suspended {
 						// Send recover tx from current consensus node.
 						indexOfResharing := slices.Index(snapshot.CurrentCNs, amevAddress) + 1
 						if indexOfResharing > 0 {
@@ -334,7 +334,7 @@ func (c *DBFT) handleDKG(snapshot *snapshot, keystore *antimev.KeyStore, h *type
 		// Send reshareRecovered at height recoverStartHeigh+c.shareDuration/2.
 		// Only index in indexsNeedRecover and pending consensus node need to call reshareRecovered.
 		indexOfSharing := slices.Index(snapshot.PendingCNs, amevAddress) + 1
-		if !suspended && indexOfSharing > 0 && currentHeight < targetHeight && slices.Contains(snapshot.IndexNeedRecover, uint64(indexOfSharing)) {
+		if !suspended && indexOfSharing > 0 && slices.Contains(snapshot.IndexNeedRecover, uint64(indexOfSharing)) {
 			if err := c.syncRecoveredSecrets(snapshot, keystore, indexOfSharing, state, h); err != nil {
 				return fmt.Errorf("failed to sync recovering DKG, err: %v", err)
 			}
@@ -778,9 +778,14 @@ func (c *DBFT) syncRecoveredSecrets(snap *snapshot, keystore *antimev.KeyStore, 
 
 // taskShare tries to prepare necessary inputs for a contract calling for DKG share.
 func (t *taskList) taskShare(keystore *antimev.KeyStore, networkId *big.Int, receiverMessageKeys []*ecies.PublicKey, zkVersion uint64, start uint64, end uint64) error {
+	// Generate or regenerate the local secrets.
 	secrets, sPvss, err := keystore.DKGShare(networkId)
 	if err != nil {
 		return err
+	}
+	// Call keystore to share before skip, in case there is a synchronization.
+	if start >= end {
+		return nil
 	}
 	// Set up a new task with keystore outputs.
 	*t = append(*t, &task{SendHeight: start, EndHeight: end, Method: "share", ZKVersion: zkVersion, Params: []interface{}{secrets, sPvss, receiverMessageKeys}})
@@ -789,6 +794,10 @@ func (t *taskList) taskShare(keystore *antimev.KeyStore, networkId *big.Int, rec
 
 // taskReshare tries to prepare necessary inputs for a contract calling for DKG reshare.
 func (t *taskList) taskReshare(keystore *antimev.KeyStore, receiverMessageKeys []*ecies.PublicKey, zkVersion uint64, start uint64, end uint64) error {
+	// If is later than the period deadline, skip.
+	if start >= end {
+		return nil
+	}
 	secrets, rPvss, err := keystore.DKGReshare()
 	if err != nil {
 		return err
@@ -800,6 +809,10 @@ func (t *taskList) taskReshare(keystore *antimev.KeyStore, receiverMessageKeys [
 
 // taskRecover tries to prepare necessary inputs for a contract calling for DKG recover.
 func (t *taskList) taskRecover(keystore *antimev.KeyStore, indexesNeedRecover []uint64, receiverMessageKeys []*ecies.PublicKey, zkVersion uint64, start uint64, end uint64) error {
+	// If is later than the target deadline, skip.
+	if start >= end {
+		return nil
+	}
 	var idxsInt []int
 	for _, idx := range indexesNeedRecover {
 		idxsInt = append(idxsInt, int(idx))
@@ -815,6 +828,10 @@ func (t *taskList) taskRecover(keystore *antimev.KeyStore, indexesNeedRecover []
 
 // taskReshareRecover tries to prepare necessary inputs for a contract calling for DKG reshare after recover.
 func (t *taskList) taskReshareRecover(keystore *antimev.KeyStore, receiverMessageKeys []*ecies.PublicKey, zkVersion uint64, start uint64, end uint64) error {
+	// If is later than the period deadline, skip.
+	if start >= end {
+		return nil
+	}
 	// Recover the lost resharing messages.
 	secrets, pvss, err := keystore.TryRecoverReshare()
 	if err != nil {

--- a/consensus/dbft/dkg.go
+++ b/consensus/dbft/dkg.go
@@ -269,7 +269,7 @@ func (c *DBFT) handleDKG(snapshot *snapshot, keystore *antimev.KeyStore, h *type
 			// If is a member of pending consensus.
 			indexOfSharing := slices.Index(snapshot.PendingCNs, amevAddress) + 1
 			if indexOfSharing > 0 {
-				err = taskList.taskShare(keystore, receiverMessageKeys, zkVersion, currentHeight, recoverStartHeight)
+				err = taskList.taskShare(keystore, (*c.backend).ChainConfig().ChainID, receiverMessageKeys, zkVersion, currentHeight, recoverStartHeight)
 				if err != nil {
 					return fmt.Errorf("failed to task DKG share, err: %v", err)
 				}
@@ -768,8 +768,8 @@ func (c *DBFT) syncRecoveredSecrets(snap *snapshot, keystore *antimev.KeyStore, 
 }
 
 // taskShare tries to prepare necessary inputs for a contract calling for DKG share.
-func (t *taskList) taskShare(keystore *antimev.KeyStore, receiverMessageKeys []*ecies.PublicKey, zkVersion uint64, start uint64, end uint64) error {
-	secrets, sPvss, err := keystore.DKGShare()
+func (t *taskList) taskShare(keystore *antimev.KeyStore, networkId *big.Int, receiverMessageKeys []*ecies.PublicKey, zkVersion uint64, start uint64, end uint64) error {
+	secrets, sPvss, err := keystore.DKGShare(networkId)
 	if err != nil {
 		return err
 	}

--- a/crypto/tpke/poly.go
+++ b/crypto/tpke/poly.go
@@ -25,6 +25,16 @@ func randomPoly(degree int) (*Poly, error) {
 	}, nil
 }
 
+func predictablePoly(degree int, secret []byte, public []byte, round int) *Poly {
+	coeff := make([]*big.Int, degree)
+	for i := range coeff {
+		coeff[i] = predictableRandScalar(secret, public, byte(round), byte(i))
+	}
+	return &Poly{
+		coeff: coeff,
+	}
+}
+
 func (p *Poly) evaluate(x *big.Int) *big.Int {
 	i := len(p.coeff) - 1
 	result := new(big.Int).Set(p.coeff[i])

--- a/crypto/tpke/secrect.go
+++ b/crypto/tpke/secrect.go
@@ -2,6 +2,8 @@ package tpke
 
 import (
 	"math/big"
+
+	"github.com/ethereum/go-ethereum/crypto/ecies"
 )
 
 type Secret struct {
@@ -9,14 +11,10 @@ type Secret struct {
 }
 
 // RandomSecret returns a random polynomial with zero δ
-func RandomSecret(threshold int) (*Secret, error) {
-	p, err := randomPoly(threshold)
-	if err != nil {
-		return nil, err
-	}
+func RandomSecret(threshold int, secret *ecies.PrivateKey, public []byte, round int) *Secret {
 	return &Secret{
-		poly: p,
-	}, nil
+		poly: predictablePoly(threshold, secret.D.Bytes(), public, round),
+	}
 }
 
 // RecoverSecret tries to recover a polynomial with (x,fx) array

--- a/crypto/tpke/util.go
+++ b/crypto/tpke/util.go
@@ -3,6 +3,7 @@ package tpke
 import (
 	"bytes"
 	"crypto/rand"
+	"crypto/sha256"
 	"errors"
 	"math/big"
 
@@ -17,6 +18,40 @@ var (
 	ErrTPKEFieldElementDecoding = errors.New("crypto/tpke: invalid fe decoding")
 	ErrTPKEScalarDecoding       = errors.New("crypto/tpke: invalid scalar decoding")
 )
+
+// predictableRandScalar generates predictable random number based on a secret source
+// for privacy and a public source for replay protection. At least 1 seed is required
+// for randomness.
+func predictableRandScalar(secret []byte, public []byte, seeds ...byte) *big.Int {
+	if len(secret) < 1 {
+		panic("invalid privacy source")
+	}
+	if len(public) < 1 {
+		panic("invalid replay protection")
+	}
+	if len(seeds) < 1 {
+		panic("invalid randomness")
+	}
+	source := append(secret, public...)
+	source = append(source, seeds...)
+
+	max := ecc.BLS12_381.ScalarField() // The byte length of max is 32
+	var k *big.Int
+	for {
+		seed := sha256.Sum256(source) // The length of seed is 32 as well
+		k = new(big.Int).SetBytes(seed[:])
+		if k.Cmp(max) > 0 {
+			k = new(big.Int).Mod(k, max)
+		}
+		// It's almost impossible to get a zero hash and fill it into the result
+		// But if it happens, then append a zero byte to source and compute again
+		if k.Sign() > 0 {
+			break
+		}
+		source = append(source, byte(0))
+	}
+	return k
+}
 
 // randScalar returns a random big int
 func randScalar() (*big.Int, error) {

--- a/crypto/tpke/util_test.go
+++ b/crypto/tpke/util_test.go
@@ -7,6 +7,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestPredictableRandScalar(t *testing.T) {
+	r := predictableRandScalar([]byte{0}, []byte{0}, byte(0))
+	if r.Cmp(predictableRandScalar([]byte{0}, []byte{0}, byte(0))) != 0 {
+		t.Fatalf("random number not predictable")
+	}
+	if r.Cmp(predictableRandScalar([]byte{0}, []byte{0}, byte(1))) == 0 {
+		t.Fatalf("random number not random")
+	}
+}
+
 func TestRecover(t *testing.T) {
 	s, err := randomPoly(5)
 	require.NoError(t, err)


### PR DESCRIPTION
Close #486. The local secret in DKG becomes not fully random, but can be reproduced in the same network, the same DKG round with the same antimev keystore secret key.

@songb2 In this implementation, you will not come up with the following error messages when reinit the keystore and restart a CN.

```
ERROR[07-11|16:05:10.007] Failed to confirm secret share           error="secret not found"
```

```
ERROR[07-11|16:06:49.507] Failed to task DKG reshare               err="secret not found"
```