### PR TITLE
contracts: remove unused initializers after Mainnet upgrade

### DIFF
--- a/contracts/solidity/Governance.sol
+++ b/contracts/solidity/Governance.sol
@@ -96,11 +96,6 @@ contract Governance is IGovernance, ReentrancyGuard, GovProxyUpgradeable {
         }
     }
 
-    // Only for Governance upgrading for the new KeyManagement contract
-    function setInitialSharePeriodDuration(uint _sharePeriodDuration) external onlyAdmin {
-        sharePeriodDuration = _sharePeriodDuration;
-    }
-
     receive() external payable nonReentrant {
         if (msg.sender != GOV_REWARD) revert Errors.SideCallNotAllowed();
         address[] memory validators = currentConsensus;

--- a/contracts/solidity/Policy.sol
+++ b/contracts/solidity/Policy.sol
@@ -41,15 +41,6 @@ contract Policy is IPolicy, GovernanceVote, GovProxyUpgradeable {
         }
     }
 
-    // Only for Policy upgrading for the new Envelope transactions
-    function setInitialEnvelopeLimits(
-        uint256 _maxEnvelopesPerBlock,
-        uint256 _maxEnvelopeGasLimit
-    ) external onlyAdmin {
-        maxEnvelopesPerBlock = _maxEnvelopesPerBlock;
-        maxEnvelopeGasLimit = _maxEnvelopeGasLimit;
-    }
-
     function addBlackList(
         address _addr
     )


### PR DESCRIPTION
Close #505. Hardhat tests are not affected.