### PR TITLE
privnet: update Makefile and README of the zk privnet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ define run_bootnode
 endef
 
 define run_miner_node_with_zk_dkg
-	$(call run_node,$(1),$(2),$(3),$(4),$(5),$(6),--mine --miner.etherbase="0x$$(cat $(1)/$(7)/node_address.txt)" --antimev.password=$(1)/$(7)/password.txt --dkg.one-msg-r1cs=$(1)/r1cs/R1CS_1 --dkg.two-msg-r1cs=$(1)/r1cs/R1CS_2 --dkg.seven-msg-r1cs=$(1)/r1cs/R1CS_7 --dkg.one-msg-pk=$(1)/provingkey/PK_1 --dkg.two-msg-pk=$(1)/provingkey/PK_2 --dkg.seven-msg-pk=$(1)/provingkey/PK_7)
+	$(call run_node,$(1),$(2),$(3),$(4),$(5),$(6),--mine --miner.etherbase="0x$$(cat $(1)/$(7)/node_address.txt)" --antimev.password=$(1)/$(7)/password.txt --dkg.one-msg-r1cs=$(1)/r1cs/one_message.ccs --dkg.two-msg-r1cs=$(1)/r1cs/two_message.ccs --dkg.seven-msg-r1cs=$(1)/r1cs/seven_message.ccs --dkg.one-msg-pk=$(1)/provingkey/one_message.pk --dkg.two-msg-pk=$(1)/provingkey/two_message.pk --dkg.seven-msg-pk=$(1)/provingkey/seven_message.pk)
 endef
 
 define run_miner_node

--- a/privnet/zk/provingkey/README.md
+++ b/privnet/zk/provingkey/README.md
@@ -2,9 +2,12 @@
 
 We use [Consensys/gnark](https://github.com/Consensys/gnark) for ZK proving, and the circuit implementation can be found at [bane-labs/zk-dkg](https://github.com/bane-labs/zk-dkg).
 
-Currently this privnet is using an experimental MPC ceremony as setup. You can download its output from the following links.
-- https://neochain1.blob.core.windows.net/fileshare/mengyu20250408.zip (R1CS_1 and PK_1)
-- https://neochain1.blob.core.windows.net/fileshare/mengyu20250409.zip (R1CS_2 and PK_2)
-- https://neochain1.blob.core.windows.net/fileshare/mengyu20250401.zip (R1CS_7 and PK_7)
+Now this privnet uses the same MPC ceremony as in production. You can download the required files from the following links.
 
-Please extract and rename the proving key files in this folder, as defined in the Makefile.
+- https://zkstorage.blob.core.windows.net/zk-blob/one_message.pk
+- https://zkstorage.blob.core.windows.net/zk-blob/two_message.pk
+- https://zkstorage.blob.core.windows.net/zk-blob/seven_message.pk
+
+Or, if you're familiar with NeoFS, you can also download them as described in [bane-labs/mpc](https://github.com/bane-labs/mpc).
+
+Please put the proving key files in this folder, as defined in the Makefile.

--- a/privnet/zk/r1cs/README.md
+++ b/privnet/zk/r1cs/README.md
@@ -2,9 +2,12 @@
 
 We use [Consensys/gnark](https://github.com/Consensys/gnark) for ZK proving, and the circuit implementation can be found at [bane-labs/zk-dkg](https://github.com/bane-labs/zk-dkg).
 
-Currently this privnet is using an experimental MPC ceremony as setup. You can download its output from the following links.
-- https://neochain1.blob.core.windows.net/fileshare/mengyu20250408.zip (R1CS_1 and PK_1)
-- https://neochain1.blob.core.windows.net/fileshare/mengyu20250409.zip (R1CS_2 and PK_2)
-- https://neochain1.blob.core.windows.net/fileshare/mengyu20250401.zip (R1CS_7 and PK_7)
+Now this privnet uses the same MPC ceremony as in production. You can download the required files from the following links.
 
-Please extract and rename the R1CS files in this folder, as defined in the Makefile.
+- https://zkstorage.blob.core.windows.net/zk-blob/one_message.ccs
+- https://zkstorage.blob.core.windows.net/zk-blob/two_message.ccs
+- https://zkstorage.blob.core.windows.net/zk-blob/seven_message.ccs
+
+Or, if you're familiar with NeoFS, you can also download them as described in [bane-labs/mpc](https://github.com/bane-labs/mpc).
+
+Please put the R1CS files in this folder, as defined in the Makefile.


### PR DESCRIPTION
Related #489.

That PR updated the ZK verifier codes in the privnet genesis, but the introduction and Makefile remain the old.