### PR TITLE
*: lower the minimum RAM requirement of consensus nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Recommended:
 Minimum:
 
 * Fast CPU with 2+ cores
-* 24GB RAM
+* 16GB RAM
 * 200GB free storage space to sync the Testnet
 * 8 MBit/sec download Internet service
 


### PR DESCRIPTION
We tried some weaker hardware on my Testnet CN, and the result shows 2 cores with 16 GB memory is a practical choice, and virtual RAM is useful to avoid OOM.

<img width="1910" height="716" alt="image" src="https://github.com/user-attachments/assets/df909855-8407-490e-9e48-bc8dd03cf036" />

The idea was proposed by our IT support, he wants to use virtual RAM to reduce the running cost of our Testnet, because 32 GB seems a waste for most of the running time. The following comparisons are based on our past Privnet test on above.

We start with 16 GB physical RAM + 16 GB virtual RAM. Here is the result, memory usage didn't hit the limit of physical RAM or cause any swap. GC made more effect, so that more memory used for the first proving (about 4~5 GB, almost all) was released before the second started, and no OOM happened.

<img width="2532" height="458" alt="b2fad7424b6cd55c4ddc7c110b937c6a" src="https://github.com/user-attachments/assets/340b19f8-8d0f-42a2-b3af-31addd29f600" />

And we stepped further, tried 8 GB physical RAM + 16 GB virtual RAM. This time the physical RAM was used up and there were memory swaps between the virtual RAM, and still, no OOM happened.

As we observed the block processing, the difference of performance was quite insignificant (still 5s block time), but the node spent more time on DKG proof generation.

<img width="2526" height="384" alt="71253e0db1d7cb32e2113201ef8fee01" src="https://github.com/user-attachments/assets/3dbf138e-ad19-47f2-9fba-714da6e62524" />

As a conclusion, 2 cores with 16 GB RAM is a practical minimum hardware requirement. Since the traffic of Testnet is light so that we only counted DKG in this result. In production, we recommend a combined usage of virtual RAM on SSD, to avoid possible OOM breakdown.
