### PR TITLE
config: reschedule NeoXAMEV, NeoXEthSig forks

### DIFF
--- a/config/genesis_mainnet.json
+++ b/config/genesis_mainnet.json
@@ -16,8 +16,8 @@
     "grayGlacierBlock": 0,
     "shanghaiTime": 0,
     "neoXDKGBlock": 3623040,
-    "neoXEthSigBlock": 3689280,
-    "neoXAMEVBlock": 3689280,
+    "neoXEthSigBlock": 3749760,
+    "neoXAMEVBlock": 3749760,
     "dbft": {
       "period": 5,
       "standbyValidators": [


### PR DESCRIPTION
This is an already-applied change on Mainnet.

We failed the first round DKG, but the second was successful. To enable the AMEV feature and threshold block signature smoothly, without enforcing ECDSA signatures in the new schema, we decided to delay NeoXAMEV and NeoXEthSig another epoch to height `3749760`.
