### PR TITLE
*: revert customized behaviors about finalized block

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -118,11 +118,3 @@ type Engine interface {
 	// Close terminates any background threads maintained by the consensus engine.
 	Close() error
 }
-
-// PoS consensus engine.
-type PoS interface {
-	Engine
-
-	// GetFinalizedHeader retrieves the finalized header for a given header.
-	GetFinalizedHeader(chain ChainHeaderReader, header *types.Header) *types.Header
-}

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -2959,15 +2959,3 @@ func unpackContractExecutionResult(res interface{}, result *core.ExecutionResult
 	}
 	return contractAbi.UnpackIntoInterface(&res, method, result.Return())
 }
-
-// GetFinalizedHeader returns highest finalized block header.
-func (c *DBFT) GetFinalizedHeader(chain consensus.ChainHeaderReader, header *types.Header) *types.Header {
-	if chain == nil || header == nil {
-		return nil
-	}
-	if !chain.Config().IsNeoXDKG(header.Number) || header.Number.Uint64() < 1 {
-		return chain.GetHeaderByNumber(0)
-	}
-
-	return chain.GetHeaderByNumber(header.Number.Uint64() - 1)
-}

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -244,16 +244,15 @@ type BlockChain struct {
 	statedb       *state.CachingDB                 // State database to reuse between imports (contains state cache)
 	txIndexer     *txIndexer                       // Transaction indexer, might be nil if not enabled
 
-	hc                  *HeaderChain
-	rmLogsFeed          event.Feed
-	chainFeed           event.Feed
-	chainHeadFeed       event.Feed
-	logsFeed            event.Feed
-	blockProcFeed       event.Feed
-	finalizedHeaderFeed event.Feed
-	blockProcCounter    int32
-	scope               event.SubscriptionScope
-	genesisBlock        *types.Block
+	hc               *HeaderChain
+	rmLogsFeed       event.Feed
+	chainFeed        event.Feed
+	chainHeadFeed    event.Feed
+	logsFeed         event.Feed
+	blockProcFeed    event.Feed
+	blockProcCounter int32
+	scope            event.SubscriptionScope
+	genesisBlock     *types.Block
 
 	// This mutex synchronizes chain write operations.
 	// Readers don't need to take it, they can just read the database.
@@ -525,17 +524,6 @@ func (bc *BlockChain) empty() bool {
 	return true
 }
 
-// GetFinalizedNumber returns the highest finalized number before the specific block.
-func (bc *BlockChain) GetFinalizedNumber(header *types.Header) uint64 {
-	if p, ok := bc.engine.(consensus.PoS); ok {
-		if finalizedHeader := p.GetFinalizedHeader(bc, header); finalizedHeader != nil {
-			return finalizedHeader.Number.Uint64()
-		}
-	}
-
-	return 0
-}
-
 // loadLastState loads the last known chain state from the database. This method
 // assumes that the chain manager mutex is held.
 func (bc *BlockChain) loadLastState() error {
@@ -611,7 +599,8 @@ func (bc *BlockChain) loadLastState() error {
 
 	// Issue a status log for the user
 	var (
-		currentSnapBlock = bc.CurrentSnapBlock()
+		currentSnapBlock  = bc.CurrentSnapBlock()
+		currentFinalBlock = bc.CurrentFinalBlock()
 
 		headerTd = bc.GetTd(headHeader.Hash(), headHeader.Number.Uint64())
 		blockTd  = bc.GetTd(headBlock.Hash(), headBlock.NumberU64())
@@ -624,14 +613,9 @@ func (bc *BlockChain) loadLastState() error {
 		snapTd := bc.GetTd(currentSnapBlock.Hash(), currentSnapBlock.Number.Uint64())
 		log.Info("Loaded most recent local snap block", "number", currentSnapBlock.Number, "hash", currentSnapBlock.Hash(), "td", snapTd, "age", common.PrettyAge(time.Unix(int64(currentSnapBlock.Time), 0)))
 	}
-	if p, ok := bc.engine.(consensus.PoS); ok {
-		if currentFinalizedHeader := p.GetFinalizedHeader(bc, headHeader); currentFinalizedHeader != nil {
-			bc.currentFinalBlock.Store(currentFinalizedHeader)
-			if currentFinalizedBlock := bc.GetBlockByHash(currentFinalizedHeader.Hash()); currentFinalizedBlock != nil {
-				finalTd := bc.GetTd(currentFinalizedBlock.Hash(), currentFinalizedBlock.NumberU64())
-				log.Info("Loaded most recent local finalized block", "number", currentFinalizedBlock.Number(), "hash", currentFinalizedBlock.Hash(), "root", currentFinalizedBlock.Root(), "td", finalTd, "age", common.PrettyAge(time.Unix(int64(currentFinalizedBlock.Time()), 0)))
-			}
-		}
+	if currentFinalBlock != nil {
+		finalTd := bc.GetTd(currentFinalBlock.Hash(), currentFinalBlock.Number.Uint64())
+		log.Info("Loaded most recent local finalized block", "number", currentFinalBlock.Number, "hash", currentFinalBlock.Hash(), "td", finalTd, "age", common.PrettyAge(time.Unix(int64(currentFinalBlock.Time), 0)))
 	}
 	if pivot := rawdb.ReadLastPivotNumber(bc.db); pivot != nil {
 		log.Info("Loaded last snap-sync pivot marker", "number", *pivot)
@@ -1716,14 +1700,6 @@ func (bc *BlockChain) writeBlockAndSetHead(block *types.Block, receipts []*types
 		if len(logs) > 0 {
 			bc.logsFeed.Send(logs)
 		}
-
-		var finalizedHeader *types.Header
-		if p, ok := bc.Engine().(consensus.PoS); ok {
-			if finalizedHeader = p.GetFinalizedHeader(bc, block.Header()); finalizedHeader != nil {
-				bc.SetFinalized(finalizedHeader)
-			}
-		}
-
 		// In theory, we should fire a ChainHeadEvent when we inject
 		// a canonical block, but sometimes we can insert a batch of
 		// canonical blocks. Avoid firing too many ChainHeadEvents,
@@ -1731,9 +1707,6 @@ func (bc *BlockChain) writeBlockAndSetHead(block *types.Block, receipts []*types
 		// event here.
 		if emitHeadEvent {
 			bc.chainHeadFeed.Send(ChainHeadEvent{Header: block.Header()})
-			if finalizedHeader != nil {
-				bc.finalizedHeaderFeed.Send(FinalizedHeaderEvent{finalizedHeader})
-			}
 		}
 	}
 	return status, nil
@@ -1827,11 +1800,6 @@ func (bc *BlockChain) insertChain(chain types.Blocks, setHead bool, makeWitness 
 	defer func() {
 		if lastCanon != nil && bc.CurrentBlock().Hash() == lastCanon.Hash() {
 			bc.chainHeadFeed.Send(ChainHeadEvent{Header: lastCanon.Header()})
-			if p, ok := bc.Engine().(consensus.PoS); ok {
-				if finalizedHeader := p.GetFinalizedHeader(bc, lastCanon.Header()); finalizedHeader != nil {
-					bc.finalizedHeaderFeed.Send(FinalizedHeaderEvent{finalizedHeader})
-				}
-			}
 		}
 	}()
 	// Start the parallel header verifier

--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -54,29 +54,13 @@ func (bc *BlockChain) CurrentSnapBlock() *types.Header {
 // CurrentFinalBlock retrieves the current finalized block of the canonical
 // chain. The block is retrieved from the blockchain's internal cache.
 func (bc *BlockChain) CurrentFinalBlock() *types.Header {
-	if p, ok := bc.engine.(consensus.PoS); ok {
-		currentHeader := bc.CurrentHeader()
-		if currentHeader == nil {
-			return nil
-		}
-		return p.GetFinalizedHeader(bc, currentHeader)
-	}
-
-	return nil
+	return bc.currentFinalBlock.Load()
 }
 
 // CurrentSafeBlock retrieves the current safe block of the canonical
 // chain. The block is retrieved from the blockchain's internal cache.
 func (bc *BlockChain) CurrentSafeBlock() *types.Header {
-	if p, ok := bc.engine.(consensus.PoS); ok {
-		currentHeader := bc.CurrentHeader()
-		if currentHeader == nil {
-			return nil
-		}
-		return p.GetFinalizedHeader(bc, currentHeader)
-	}
-
-	return nil
+	return bc.currentSafeBlock.Load()
 }
 
 // HasHeader checks if a block header is present in the database or not, caching
@@ -476,9 +460,4 @@ func (bc *BlockChain) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscript
 // block processing has started while false means it has stopped.
 func (bc *BlockChain) SubscribeBlockProcessingEvent(ch chan<- bool) event.Subscription {
 	return bc.scope.Track(bc.blockProcFeed.Subscribe(ch))
-}
-
-// SubscribeFinalizedHeaderEvent registers a subscription of FinalizedHeaderEvent.
-func (bc *BlockChain) SubscribeFinalizedHeaderEvent(ch chan<- FinalizedHeaderEvent) event.Subscription {
-	return bc.scope.Track(bc.finalizedHeaderFeed.Subscribe(ch))
 }

--- a/core/events.go
+++ b/core/events.go
@@ -32,9 +32,6 @@ type NewMinedBlockEvent struct{ Block *types.Block }
 // RemovedLogsEvent is posted when a reorg happens
 type RemovedLogsEvent struct{ Logs []*types.Log }
 
-// FinalizedHeaderEvent is posted when a finalized header is reached.
-type FinalizedHeaderEvent struct{ Header *types.Header }
-
 type ChainEvent struct {
 	Header *types.Header
 }

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -99,17 +99,6 @@ func NewHeaderChain(chainDb ethdb.Database, config *params.ChainConfig, engine c
 	return hc, nil
 }
 
-// GetFinalizedNumber returns the highest finalized number before the specific block.
-func (hc *HeaderChain) GetFinalizedNumber(header *types.Header) uint64 {
-	if p, ok := hc.engine.(consensus.PoS); ok {
-		if finalizedHeader := p.GetFinalizedHeader(hc, header); finalizedHeader != nil {
-			return finalizedHeader.Number.Uint64()
-		}
-	}
-
-	return 0
-}
-
 // GetBlockNumber retrieves the block number belonging to the given hash
 // from the cache or database
 func (hc *HeaderChain) GetBlockNumber(hash common.Hash) *uint64 {

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -840,7 +840,9 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	}
 	// Flush out any blobs from limbo that are older than the latest finality
 	if p.chain.Config().IsCancun(p.head.Number, p.head.Time) {
-		p.limbo.finalize(p.chain.CurrentFinalBlock())
+		if h := p.chain.CurrentFinalBlock(); h != nil {
+			p.limbo.finalize(h)
+		}
 	}
 	// Reset the price heap for the new set of basefee/blobfee pairs
 	var (

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -312,10 +312,6 @@ func (b *EthAPIBackend) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) e
 	return b.eth.BlockChain().SubscribeChainHeadEvent(ch)
 }
 
-func (b *EthAPIBackend) SubscribeFinalizedHeaderEvent(ch chan<- core.FinalizedHeaderEvent) event.Subscription {
-	return b.eth.BlockChain().SubscribeFinalizedHeaderEvent(ch)
-}
-
 func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription {
 	return b.eth.BlockChain().SubscribeLogsEvent(ch)
 }

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -197,6 +197,7 @@ type Config struct {
 // Clique is allowed for now to live standalone, but ethash is forbidden and can
 // only exist on already merged networks.
 func CreateConsensusEngine(config *params.ChainConfig, db ethdb.Database, statisticsCfg dbft.StatisticsConfig) (consensus.Engine, error) {
+	// TODO: config TTD correctly and move this check back after Clique
 	if config.DBFT != nil {
 		bft, err := dbft.New(config, db, statisticsCfg)
 		if err != nil {

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -273,65 +273,6 @@ func (api *FilterAPI) NewHeads(ctx context.Context) (*rpc.Subscription, error) {
 	return rpcSub, nil
 }
 
-// NewFinalizedHeaderFilter creates a filter that fetches finalized headers that are reached.
-func (api *FilterAPI) NewFinalizedHeaderFilter() rpc.ID {
-	var (
-		headers   = make(chan *types.Header)
-		headerSub = api.events.SubscribeNewFinalizedHeaders(headers)
-	)
-
-	api.filtersMu.Lock()
-	api.filters[headerSub.ID] = &filter{typ: FinalizedHeadersSubscription, deadline: time.NewTimer(api.timeout), hashes: make([]common.Hash, 0), s: headerSub}
-	api.filtersMu.Unlock()
-
-	go func() {
-		for {
-			select {
-			case h := <-headers:
-				api.filtersMu.Lock()
-				if f, found := api.filters[headerSub.ID]; found {
-					f.hashes = append(f.hashes, h.Hash())
-				}
-				api.filtersMu.Unlock()
-			case <-headerSub.Err():
-				api.filtersMu.Lock()
-				delete(api.filters, headerSub.ID)
-				api.filtersMu.Unlock()
-				return
-			}
-		}
-	}()
-
-	return headerSub.ID
-}
-
-// NewFinalizedHeaders send a notification each time a new finalized header is reached.
-func (api *FilterAPI) NewFinalizedHeaders(ctx context.Context) (*rpc.Subscription, error) {
-	notifier, supported := rpc.NotifierFromContext(ctx)
-	if !supported {
-		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
-	}
-
-	rpcSub := notifier.CreateSubscription()
-
-	go func() {
-		headers := make(chan *types.Header)
-		headersSub := api.events.SubscribeNewFinalizedHeaders(headers)
-		defer headersSub.Unsubscribe()
-
-		for {
-			select {
-			case h := <-headers:
-				notifier.Notify(rpcSub.ID, h)
-			case <-rpcSub.Err():
-				return
-			}
-		}
-	}()
-
-	return rpcSub, nil
-}
-
 // Logs creates a subscription that fires for all new log that match the given filter criteria.
 func (api *FilterAPI) Logs(ctx context.Context, crit FilterCriteria) (*rpc.Subscription, error) {
 	notifier, supported := rpc.NotifierFromContext(ctx)

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -67,7 +67,6 @@ type Backend interface {
 	ChainConfig() *params.ChainConfig
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
 	SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription
-	SubscribeFinalizedHeaderEvent(ch chan<- core.FinalizedHeaderEvent) event.Subscription
 	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription
 	SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription
 
@@ -160,8 +159,6 @@ const (
 	BlocksSubscription
 	// LastIndexSubscription keeps track of the last index
 	LastIndexSubscription
-	// FinalizedHeadersSubscription queries hashes for finalized headers that are reached
-	FinalizedHeadersSubscription
 )
 
 const (
@@ -174,8 +171,6 @@ const (
 	logsChanSize = 10
 	// chainEvChanSize is the size of channel listening to ChainEvent.
 	chainEvChanSize = 10
-	// finalizedHeaderEvChanSize is the size of channel listening to FinalizedHeaderEvent.
-	finalizedHeaderEvChanSize = 10
 )
 
 type subscription struct {
@@ -197,20 +192,18 @@ type EventSystem struct {
 	sys     *FilterSystem
 
 	// Subscriptions
-	txsSub             event.Subscription // Subscription for new transaction event
-	logsSub            event.Subscription // Subscription for new log event
-	rmLogsSub          event.Subscription // Subscription for removed log event
-	chainSub           event.Subscription // Subscription for new chain event
-	finalizedHeaderSub event.Subscription // Subscription for new finalized header
+	txsSub    event.Subscription // Subscription for new transaction event
+	logsSub   event.Subscription // Subscription for new log event
+	rmLogsSub event.Subscription // Subscription for removed log event
+	chainSub  event.Subscription // Subscription for new chain event
 
 	// Channels
-	install           chan *subscription             // install filter for event notification
-	uninstall         chan *subscription             // remove filter for event notification
-	txsCh             chan core.NewTxsEvent          // Channel to receive new transactions event
-	logsCh            chan []*types.Log              // Channel to receive new log event
-	rmLogsCh          chan core.RemovedLogsEvent     // Channel to receive removed log event
-	chainCh           chan core.ChainEvent           // Channel to receive new chain event
-	finalizedHeaderCh chan core.FinalizedHeaderEvent // Channel to receive new finalized header event
+	install   chan *subscription         // install filter for event notification
+	uninstall chan *subscription         // remove filter for event notification
+	txsCh     chan core.NewTxsEvent      // Channel to receive new transactions event
+	logsCh    chan []*types.Log          // Channel to receive new log event
+	rmLogsCh  chan core.RemovedLogsEvent // Channel to receive removed log event
+	chainCh   chan core.ChainEvent       // Channel to receive new chain event
 }
 
 // NewEventSystem creates a new manager that listens for event on the given mux,
@@ -221,15 +214,14 @@ type EventSystem struct {
 // or by stopping the given mux.
 func NewEventSystem(sys *FilterSystem) *EventSystem {
 	m := &EventSystem{
-		sys:               sys,
-		backend:           sys.backend,
-		install:           make(chan *subscription),
-		uninstall:         make(chan *subscription),
-		txsCh:             make(chan core.NewTxsEvent, txChanSize),
-		logsCh:            make(chan []*types.Log, logsChanSize),
-		rmLogsCh:          make(chan core.RemovedLogsEvent, rmLogsChanSize),
-		chainCh:           make(chan core.ChainEvent, chainEvChanSize),
-		finalizedHeaderCh: make(chan core.FinalizedHeaderEvent, finalizedHeaderEvChanSize),
+		sys:       sys,
+		backend:   sys.backend,
+		install:   make(chan *subscription),
+		uninstall: make(chan *subscription),
+		txsCh:     make(chan core.NewTxsEvent, txChanSize),
+		logsCh:    make(chan []*types.Log, logsChanSize),
+		rmLogsCh:  make(chan core.RemovedLogsEvent, rmLogsChanSize),
+		chainCh:   make(chan core.ChainEvent, chainEvChanSize),
 	}
 
 	// Subscribe events
@@ -237,14 +229,10 @@ func NewEventSystem(sys *FilterSystem) *EventSystem {
 	m.logsSub = m.backend.SubscribeLogsEvent(m.logsCh)
 	m.rmLogsSub = m.backend.SubscribeRemovedLogsEvent(m.rmLogsCh)
 	m.chainSub = m.backend.SubscribeChainEvent(m.chainCh)
-	m.finalizedHeaderSub = m.backend.SubscribeFinalizedHeaderEvent(m.finalizedHeaderCh)
 
 	// Make sure none of the subscriptions are empty
 	if m.txsSub == nil || m.logsSub == nil || m.rmLogsSub == nil || m.chainSub == nil {
 		log.Crit("Subscribe for event system failed")
-	}
-	if m.finalizedHeaderSub == nil {
-		log.Warn("Subscribe for finalized header event failed")
 	}
 
 	go m.eventLoop()
@@ -368,22 +356,6 @@ func (es *EventSystem) SubscribeNewHeads(headers chan *types.Header) *Subscripti
 	return es.subscribe(sub)
 }
 
-// SubscribeNewFinalizedHeaders creates a subscription that writes the finalized header of a block that is
-// reached recently.
-func (es *EventSystem) SubscribeNewFinalizedHeaders(headers chan *types.Header) *Subscription {
-	sub := &subscription{
-		id:        rpc.NewID(),
-		typ:       FinalizedHeadersSubscription,
-		created:   time.Now(),
-		logs:      make(chan []*types.Log),
-		txs:       make(chan []*types.Transaction),
-		headers:   headers,
-		installed: make(chan struct{}),
-		err:       make(chan error),
-	}
-	return es.subscribe(sub)
-}
-
 // SubscribePendingTxs creates a subscription that writes transactions for
 // transactions that enter the transaction pool.
 func (es *EventSystem) SubscribePendingTxs(txs chan []*types.Transaction) *Subscription {
@@ -425,11 +397,6 @@ func (es *EventSystem) handleChainEvent(filters filterIndex, ev core.ChainEvent)
 		f.headers <- ev.Header
 	}
 }
-func (es *EventSystem) handleFinalizedHeaderEvent(filters filterIndex, ev core.FinalizedHeaderEvent) {
-	for _, f := range filters[FinalizedHeadersSubscription] {
-		f.headers <- ev.Header
-	}
-}
 
 // eventLoop (un)installs filters and processes mux events.
 func (es *EventSystem) eventLoop() {
@@ -439,7 +406,6 @@ func (es *EventSystem) eventLoop() {
 		es.logsSub.Unsubscribe()
 		es.rmLogsSub.Unsubscribe()
 		es.chainSub.Unsubscribe()
-		es.finalizedHeaderSub.Unsubscribe()
 	}()
 
 	index := make(filterIndex)
@@ -457,8 +423,6 @@ func (es *EventSystem) eventLoop() {
 			es.handleLogs(index, ev.Logs)
 		case ev := <-es.chainCh:
 			es.handleChainEvent(index, ev)
-		case ev := <-es.finalizedHeaderCh:
-			es.handleFinalizedHeaderEvent(index, ev)
 
 		case f := <-es.install:
 			index[f.typ][f.id] = f
@@ -476,8 +440,6 @@ func (es *EventSystem) eventLoop() {
 		case <-es.rmLogsSub.Err():
 			return
 		case <-es.chainSub.Err():
-			return
-		case <-es.finalizedHeaderSub.Err():
 			return
 		}
 	}

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -40,15 +40,14 @@ import (
 )
 
 type testBackend struct {
-	db                  ethdb.Database
-	fm                  *filtermaps.FilterMaps
-	txFeed              event.Feed
-	logsFeed            event.Feed
-	rmLogsFeed          event.Feed
-	chainFeed           event.Feed
-	finalizedHeaderFeed event.Feed
-	pendingBlock        *types.Block
-	pendingReceipts     types.Receipts
+	db              ethdb.Database
+	fm              *filtermaps.FilterMaps
+	txFeed          event.Feed
+	logsFeed        event.Feed
+	rmLogsFeed      event.Feed
+	chainFeed       event.Feed
+	pendingBlock    *types.Block
+	pendingReceipts types.Receipts
 }
 
 func (b *testBackend) ChainConfig() *params.ChainConfig {
@@ -161,10 +160,6 @@ func (b *testBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscript
 
 func (b *testBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription {
 	return b.chainFeed.Subscribe(ch)
-}
-
-func (b *testBackend) SubscribeFinalizedHeaderEvent(ch chan<- core.FinalizedHeaderEvent) event.Subscription {
-	return b.finalizedHeaderFeed.Subscribe(ch)
 }
 
 func (b *testBackend) CurrentView() *filtermaps.ChainView {

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/beacon"
 	"github.com/ethereum/go-ethereum/consensus/dbft"
 	"github.com/ethereum/go-ethereum/core"
@@ -209,11 +208,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 			log.Warn("Chain pre-merge, sync via PoW (ensure beacon client is ready)")
 		}
 	} else {
-		if _, ok := h.chain.Engine().(consensus.PoS); ok {
-			log.Info("Chain configured with PoS engine but no TTD.")
-		} else {
-			log.Error("Chain configured without TTD. Are you debugging sync?")
-		}
+		log.Error("Chain configured without TTD")
 	}
 	// Construct the fetcher (short sync)
 	validator := func(header *types.Header) error {

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -600,9 +600,6 @@ func (b testBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscr
 func (b testBackend) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription {
 	panic("implement me")
 }
-func (b testBackend) SubscribeFinalizedHeaderEvent(ch chan<- core.FinalizedHeaderEvent) event.Subscription {
-	panic("implement me")
-}
 func (b testBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {
 	panic("implement me")
 }

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -97,7 +97,6 @@ type Backend interface {
 	GetLogs(ctx context.Context, blockHash common.Hash, number uint64) ([][]*types.Log, error)
 	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription
 	SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription
-	SubscribeFinalizedHeaderEvent(ch chan<- core.FinalizedHeaderEvent) event.Subscription
 
 	CurrentView() *filtermaps.ChainView
 	NewMatcherBackend() filtermaps.MatcherBackend

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -386,9 +386,6 @@ func (b *backendMock) SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subsc
 func (b *backendMock) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) event.Subscription {
 	return nil
 }
-func (b *backendMock) SubscribeFinalizedHeaderEvent(ch chan<- core.FinalizedHeaderEvent) event.Subscription {
-	return nil
-}
 func (b *backendMock) SendTx(ctx context.Context, signedTx *types.Transaction) error { return nil }
 func (b *backendMock) GetTransaction(txHash common.Hash) (bool, *types.Transaction, common.Hash, uint64, uint64) {
 	return false, nil, [32]byte{}, 0, 0


### PR DESCRIPTION
Related to #507 and #517.

#487 introduced a consensus engine change to publish finalized blocks locally to allow the blob finalization and avoid the usage of `terminalTotalDifficulty`. This enabled the chain freezer before the merge block and the TTD.

Considering the influence to future work on #507, and the possibility of enabling other post-merge behaviours unexpectedly, we've discussed and decided to move the refactor to later upgrades, e.g. a scheduled TTD with #507, or for further discussion.

@qianhh Let's first focus on the code merge from upstream.