### PR TITLE
consensus: eth: refactor PreBlock handling and support Envelope event subscription

### DIFF
--- a/antimev/envelope.go
+++ b/antimev/envelope.go
@@ -85,3 +85,9 @@ func GetEncryptedGas(envelopeData []byte) uint32 {
 	gasOffset := EncryptedDataPrefixLen + EncryptedDataRoundLen
 	return binary.BigEndian.Uint32(envelopeData[gasOffset : gasOffset+EncryptedDataGasLen])
 }
+
+type EnvelopeInfo struct {
+	Envelope  *types.Transaction // Original Envelope transaction
+	Decrypted *types.Transaction // Decrypted inner transaction
+	Err       error              // Decryption error, if any
+}

--- a/antimev/envelope.go
+++ b/antimev/envelope.go
@@ -86,8 +86,9 @@ func GetEncryptedGas(envelopeData []byte) uint32 {
 	return binary.BigEndian.Uint32(envelopeData[gasOffset : gasOffset+EncryptedDataGasLen])
 }
 
+// EnvelopeInfo is a wrapped packet of an Envelope and its handling result.
 type EnvelopeInfo struct {
-	Envelope  *types.Transaction // Original Envelope transaction
-	Decrypted *types.Transaction // Decrypted inner transaction
-	Err       error              // Decryption error, if any
+	Envelope  *types.Transaction `json:"envelope"`  // Original Envelope transaction
+	Decrypted *types.Transaction `json:"decrypted"` // Decrypted inner transaction
+	Err       error              `json:"err"`       // Decryption error, if any
 }

--- a/antimev/tpke_test.go
+++ b/antimev/tpke_test.go
@@ -237,7 +237,7 @@ func buildEnvelopeFromPriv0(t *testing.T, ks *keystore.KeyStore, acc coreaccount
 		to       = systemcontracts.GovernanceRewardProxyHash // transfer to Governance Reward as required by Envelope verification rules
 		nonce    = uint64(0)                                 // same nonce as for Inner transaction
 		gasPrice = big.NewInt(400_0000_0000)                 // based on (*ethclient.Client).SuggestGasPrice
-		gasLimit = uint64(3_1000)                            // higher than required by inner transaciton
+		gasLimit = uint64(3_5000)                            // higher than required by inner transaciton
 		value    = big.NewInt(1)                             // 1 wei
 	)
 

--- a/consensus/beacon/consensus.go
+++ b/consensus/beacon/consensus.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/antimev"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
@@ -29,6 +30,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
@@ -458,6 +460,11 @@ func (beacon *Beacon) APIs(chain consensus.ChainHeaderReader) []rpc.API {
 // Close shutdowns the consensus engine
 func (beacon *Beacon) Close() error {
 	return beacon.ethone.Close()
+}
+
+// SubscribeEnvelopeEvent creates a subscription that fires for all new envelopes that enter the consensus engine.
+func (beacon *Beacon) SubscribeEnvelopeEvent(ch chan<- []*antimev.EnvelopeInfo) event.Subscription {
+	return beacon.ethone.SubscribeEnvelopeEvent(ch)
 }
 
 // IsPoSHeader reports the header belongs to the PoS-stage with some special fields.

--- a/consensus/clique/clique.go
+++ b/consensus/clique/clique.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/antimev"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/common/lru"
@@ -39,6 +40,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
@@ -183,6 +185,9 @@ type Clique struct {
 	signer common.Address // Ethereum address of the signing key
 	signFn SignerFn       // Signer function to authorize hashes with
 	lock   sync.RWMutex   // Protects the signer and proposals fields
+
+	envelopeFeed event.Feed              // Event feed for new Envelopes
+	scope        event.SubscriptionScope // Subscription scope for clique events
 
 	// The fields below are for testing only
 	fakeDiff bool // Skip difficulty verifications
@@ -711,6 +716,11 @@ func (c *Clique) SealHash(header *types.Header) common.Hash {
 // Close implements consensus.Engine. It's a noop for clique as there are no background threads.
 func (c *Clique) Close() error {
 	return nil
+}
+
+// SubscribeEnvelopeEvent creates a subscription that fires for all new envelopes that enter the consensus engine.
+func (c *Clique) SubscribeEnvelopeEvent(ch chan<- []*antimev.EnvelopeInfo) event.Subscription {
+	return c.scope.Track(c.envelopeFeed.Subscribe(ch))
 }
 
 // APIs implements consensus.Engine, returning the user facing RPC API to allow

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -20,10 +20,12 @@ package consensus
 import (
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/antimev"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -117,4 +119,7 @@ type Engine interface {
 
 	// Close terminates any background threads maintained by the consensus engine.
 	Close() error
+
+	// SubscribeEnvelopeEvent creates a subscription that fires for all new envelopes that enter the consensus engine.
+	SubscribeEnvelopeEvent(ch chan<- []*antimev.EnvelopeInfo) event.Subscription
 }

--- a/consensus/dbft/chainreader.go
+++ b/consensus/dbft/chainreader.go
@@ -20,6 +20,9 @@ type ChainHeaderReader interface {
 	StateAt(root common.Hash) (*state.StateDB, error)
 	VerifyBlock(block *types.Block, checkState bool) (*state.StateDB, types.Receipts, uint64, error)
 	ProcessState(block *types.Block, statedb *state.StateDB) (*state.StateDB, *core.ProcessResult, error)
+
+	// Only for EVM context construction
+	Engine() consensus.Engine
 }
 
 // ChainHeaderWriter is a Blockchain API abstraction needed for proper blockQueue

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -137,6 +137,46 @@ var (
 	errUnauthorizedSigner = errors.New("unauthorized signer")
 )
 
+// Various error messages to mark Envelopes invalid. These are not relevant to
+// block validity, but rather to Envelope processing.
+var (
+	// errEnvelopeDecryption is returned if an Envelope's data decryption fails.
+	errEnvelopeDecryption = errors.New("envelope data decryption failed")
+
+	// errDecryptedDecoding is returned if an Envelope's decrypted data decoding fails.
+	errDecryptedDecoding = errors.New("decrypted transaction decoding failed")
+
+	// errDecryptedTypeUnsupported is returned if a decrypted transaction type is unsupported.
+	errDecryptedTypeUnsupported = errors.New("decrypted transaction type unsupported")
+
+	// errDecryptedNonceMismatch is returned if a decrypted transaction nonce is different
+	// from the nonce of Envelope.
+	errDecryptedNonceMismatch = errors.New("decrypted transaction nonce mismatch")
+
+	// errDecryptedUnderpriced is returned if a decrypted transaction gas price is lower
+	// than the Envelope.
+	errDecryptedUnderpriced = errors.New("decrypted transaction underpriced")
+
+	// errDecryptedSenderMismatch is returned if a decrypted transaction sender is different
+	// from the Envelope sender.
+	errDecryptedSenderMismatch = errors.New("decrypted transaction sender mismatch")
+
+	// errDecryptedHashMismatch is returned if a decrypted transaction hash is different
+	// from the declared hash in Envelope.
+	errDecryptedHashMismatch = errors.New("decrypted transaction hash mismatch")
+
+	// errDecryptedGasMismatch is returned if a decrypted transaction gas limit is different
+	// from the declared gas limit in Envelope.
+	errDecryptedGasMismatch = errors.New("decrypted transaction gas limit mismatch")
+
+	// errDecryptedGasNotAllocated is returned if a decrypted transaction gas limit is
+	// higher than the gas allocated in Envelope.
+	errDecryptedGasNotAllocated = errors.New("decrypted transaction gas limit not allocated")
+
+	// errPreBlockReverted is returned if PreBlock state processing fails.
+	errPreBlockReverted = errors.New("pre-block processing reverted")
+)
+
 // errShutdown represents an error caused by engine shutdown initiated by user.
 var errShutdown = errors.New("shutdown detected")
 
@@ -175,6 +215,9 @@ type DBFT struct {
 	signFn       SignerFn          // Signer function to authorize hashes with
 	amevKeystore *antimev.KeyStore // anti-MEV keystore responsible for DKG and encrypted transactions decryption
 	lock         sync.RWMutex      // Protects signer, signFn and amevKeystore fields
+
+	envelopeFeed event.Feed              // Event feed for new Envelopes
+	scope        event.SubscriptionScope // Subscription scope for dBFT events
 
 	dbft             *dbft.DBFT[common.Hash]
 	dbftStarted      atomic.Bool
@@ -1142,13 +1185,18 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 		var (
 			j                  int
 			txx                = make([]*types.Transaction, len(pre.transactions))
+			envelopes          = make([]*antimev.EnvelopeInfo, len(pre.envelopesData))
 			parent             = c.chain.GetHeader(pre.header.ParentHash, pre.header.Number.Uint64()-1)
-			fallbackToEnvelope = func(i int, incrementJ bool, reason string) bool {
-				if len(reason) != 0 {
+			fallbackToEnvelope = func(i int, incrementJ bool, err error) bool {
+				if err != nil {
 					log.Info("Falling back to envelope",
 						"envelope hash", pre.transactions[i].Hash(),
 						"envelope index", i,
-						"reason", reason)
+						"err", err)
+					envelopes[j] = &antimev.EnvelopeInfo{
+						Envelope: pre.transactions[i],
+						Err:      err,
+					}
 				}
 				if pre.transactions[i].Type() != types.BlobTxType {
 					errs := c.staticPool.Add([]*types.Transaction{pre.transactions[i]}, false)
@@ -1158,6 +1206,12 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 							"envelope index", i,
 							"reason", fmt.Sprintf("envelope has pool conflicts: %s", errs[0]))
 						txx = pre.transactions
+						for i := range envelopes {
+							envelopes[i] = &antimev.EnvelopeInfo{
+								Envelope: pre.transactions[pre.envelopesData[i].index],
+								Err:      errPreBlockReverted,
+							}
+						}
 						hasDecryptedTxs = false
 						return false
 					}
@@ -1186,11 +1240,11 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 			var isEnvelope = j < len(pre.envelopesData) && pre.envelopesData[j].index == i
 			if !isEnvelope || // pre.transactions[i] is not an envelope, use it as-is.
 				decryptedTxsBytes[j] == nil { // pre.transactions[i] is Envelope, but its content failed to be decrypted, use Envelope as-is.
-				var reason string
+				var err error
 				if isEnvelope {
-					reason = "envelope data decryption failed"
+					err = errEnvelopeDecryption
 				}
-				if fallbackToEnvelope(i, isEnvelope, reason) {
+				if fallbackToEnvelope(i, isEnvelope, err) {
 					continue
 				} else {
 					break
@@ -1203,7 +1257,7 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 			var decryptedTx = new(types.Transaction)
 			err := decryptedTx.UnmarshalBinary(decryptedTxsBytes[j])
 			if err != nil {
-				if fallbackToEnvelope(i, true, fmt.Sprintf("decrypted transaction decoding failed: %s", err)) {
+				if fallbackToEnvelope(i, true, errDecryptedDecoding) {
 					continue
 				} else {
 					break
@@ -1211,7 +1265,7 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 			}
 			err = c.validateDecryptedTx(parent, decryptedTx, pre.transactions[i], receipts[i])
 			if err != nil {
-				if fallbackToEnvelope(i, true, fmt.Sprintf("decrypted transaction verification failed: %s", err)) {
+				if fallbackToEnvelope(i, true, err) {
 					continue
 				} else {
 					break
@@ -1219,17 +1273,22 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 			}
 			errs := c.staticPool.Add([]*types.Transaction{decryptedTx}, false)
 			if errs[0] != nil {
-				if fallbackToEnvelope(i, true, fmt.Sprintf("decrypted transaction has pool conflicts: %s", errs[0].Error())) {
+				if fallbackToEnvelope(i, true, err) {
 					continue
 				} else {
 					break
 				}
 			}
 			txx[i] = decryptedTx
+			envelopes[j] = &antimev.EnvelopeInfo{
+				Envelope:  pre.transactions[i],
+				Decrypted: decryptedTx,
+			}
 			j++
 			hasDecryptedTxs = true
 		}
 		pre.finalTransactions = txx
+		c.envelopeFeed.Send(envelopes)
 		c.staticPool.ResetStatic()
 	}
 
@@ -1305,46 +1364,46 @@ func (c *DBFT) initStaticPool(parent *types.Header, state *state.StateDB) error 
 func (c *DBFT) validateDecryptedTx(head *types.Header, decryptedTx *types.Transaction, envelope *types.Transaction, envelopeReceipt *types.Receipt) error {
 	// Make sure the transaction type is supported by legacy tx pool
 	if decryptedTx.Type() == types.BlobTxType {
-		return fmt.Errorf("decryptedTx has unsupported type: %v", decryptedTx.Type())
+		return errDecryptedTypeUnsupported
 	}
 
 	// Make sure the transaction is signed properly and has the same sender and nonce with envelope
 	if decryptedTx.Nonce() != envelope.Nonce() {
-		return fmt.Errorf("decryptedTx nonce mismatch: decryptedNonce %v, envelopeNonce %v", decryptedTx.Nonce(), envelope.Nonce())
+		return errDecryptedNonceMismatch
 	}
 
 	// Ensure the gasprice is high enough to replace the envelope transaction
 	baseFee := head.BaseFee
 	if decryptedTx.EffectiveGasTipCmp(envelope, baseFee) < 0 {
-		return fmt.Errorf("decryptedTx underpriced: EffectiveGasTip needed %v, EffectiveGasTip permitted %v", envelope.EffectiveGasTipValue(baseFee), decryptedTx.EffectiveGasTipValue(baseFee))
+		return errDecryptedUnderpriced
 	}
 
 	// Ensure envelope sender matches decrypted sender.
 	envelopeFrom, err := types.Sender(c.signerConfig, envelope)
 	if err != nil {
-		return fmt.Errorf("%w: failed to retrieve envelope sender: %w", txpool.ErrInvalidSender, err)
+		return txpool.ErrInvalidSender
 	}
 	decryptedFrom, err := types.Sender(c.signerConfig, decryptedTx)
 	if err != nil {
-		return fmt.Errorf("%w: failed to retrieve decrypted transaction sender: %w", txpool.ErrInvalidSender, err)
+		return txpool.ErrInvalidSender
 	}
 	if envelopeFrom != decryptedFrom {
-		return fmt.Errorf("decryptedTx from mismatch: decryptedFrom %v, envelopeFrom %v", decryptedFrom, envelopeFrom)
+		return errDecryptedSenderMismatch
 	}
 
 	// Ensure decrypted hash matches the one specified in an unencrypted part of Envelope data.
 	expectedH := antimev.GetEncryptedHash(envelope)
 	if decryptedTx.Hash().Cmp(expectedH) != 0 {
-		return fmt.Errorf("decryptedTx hash mismatch: expected %s, got %s", expectedH, decryptedTx.Hash())
+		return errDecryptedHashMismatch
 	}
 	// Ensure decrypted gas limit is the same as the envelope declared
 	expectedG := antimev.GetEncryptedGas(envelope.Data())
 	if decryptedTx.Gas() != uint64(expectedG) {
-		return fmt.Errorf("decryptedTx gas limit mismatch: expected %v, got %v", expectedG, decryptedTx.Gas())
+		return errDecryptedGasMismatch
 	}
 	// Ensure decrypted gas limit has been allocated by Envelope
 	if decryptedTx.Gas() > envelopeReceipt.GasUsed {
-		return fmt.Errorf("decryptedTx gas limit not allocated: needed %v, got %v", decryptedTx.Gas(), envelopeReceipt.GasUsed)
+		return errDecryptedGasNotAllocated
 	}
 
 	return nil
@@ -2795,6 +2854,11 @@ func (c *DBFT) APIs(chain consensus.ChainHeaderReader) []rpc.API {
 		Namespace: "dbft",
 		Service:   &API{chain: chain, bft: c, config: c.config.statisticsConfig},
 	}}
+}
+
+// SubscribeEnvelopeEvent creates a subscription that fires for all new envelopes that enter the consensus engine.
+func (c *DBFT) SubscribeEnvelopeEvent(ch chan<- []*antimev.EnvelopeInfo) event.Subscription {
+	return c.scope.Track(c.envelopeFeed.Subscribe(ch))
 }
 
 // getValidatorsSorted returns validators chosen in the result of the latest

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -173,8 +173,11 @@ var (
 	// higher than the gas allocated in Envelope.
 	errDecryptedGasNotAllocated = errors.New("decrypted transaction gas limit not allocated")
 
-	// errPreBlockReverted is returned if PreBlock state processing fails.
-	errPreBlockReverted = errors.New("pre-block processing reverted")
+	// errDecryptedRejectedByPool is returned if a decrypted transaction is rejected by mempool.
+	errDecryptedRejectedByPool = errors.New("decrypted transaction rejected by mempool")
+
+	// errDecryptedRejectedByEVM is returned if a decrypted transaction is rejected by EVM.
+	errDecryptedRejectedByEVM = errors.New("decrypted transaction rejected by EVM")
 )
 
 // errShutdown represents an error caused by engine shutdown initiated by user.
@@ -1087,9 +1090,8 @@ func (c *DBFT) newPreBlockFromContextCb(ctx *dbft.Context[common.Hash]) dbft.Pre
 // processPreBlockCb is a dbft library setting callback.
 func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 	var (
-		ctx             = c.dbft.Context
-		pre             = b.(*PreBlock)
-		hasDecryptedTxs bool
+		ctx = c.dbft.Context
+		pre = b.(*PreBlock)
 	)
 	// A short path: there's no envelopes at all, use proposed transactions as-is.
 	if len(pre.envelopesData) == 0 {
@@ -1182,156 +1184,167 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 			}
 		}
 
+		// Now validate decrypted transactions and construct final list of transactions for the block.
+		parent := c.chain.GetHeader(pre.header.ParentHash, pre.header.Number.Uint64()-1)
+		state, err := c.chain.StateAt(parent.Root)
+		if err != nil {
+			return fmt.Errorf("failed to get parent state: %w", err)
+		}
+		// Initialize EVM context for transaction validation and reconstruct the block like a miner.
 		var (
-			j                  int
-			txx                = make([]*types.Transaction, len(pre.transactions))
-			envelopes          = make([]*antimev.EnvelopeInfo, len(pre.envelopesData))
-			parent             = c.chain.GetHeader(pre.header.ParentHash, pre.header.Number.Uint64()-1)
-			fallbackToEnvelope = func(i int, incrementJ bool, err error) bool {
-				if err != nil {
-					log.Info("Falling back to envelope",
-						"envelope hash", pre.transactions[i].Hash(),
-						"envelope index", i,
-						"err", err)
+			receipts []*types.Receipt
+			allLogs  []*types.Log
+			evm      = vm.NewEVM(core.NewEVMBlockContext(pre.header, c.chain, &pre.header.Coinbase), state, c.chain.Config(), vm.Config{})
+			gasPool  = new(core.GasPool).AddGas(pre.header.GasLimit)
+			gasUsed  = uint64(0)
+		)
+		if pre.header.ParentBeaconRoot != nil {
+			core.ProcessBeaconBlockRoot(*pre.header.ParentBeaconRoot, evm)
+		}
+		if c.chain.Config().IsPrague(pre.header.Number, pre.header.Time) {
+			core.ProcessParentBlockHash(pre.header.ParentHash, evm)
+		}
+		core.ProcessOnPersist(evm)
+
+		var (
+			j                    int
+			txx                  = make([]*types.Transaction, 0)
+			envelopes            = make([]*antimev.EnvelopeInfo, len(pre.envelopesData))
+			signer               = types.MakeSigner(c.chain.Config(), pre.header.Number, pre.header.Time)
+			skipAccounts         = make(map[common.Address]bool) // Record accounts have failed transactions in reconstruction.
+			fallbackToPreBlockTx = func(i int, isEnvelope bool, sender common.Address, decrypted *types.Transaction, err error) {
+				// Log the fallback event.
+				if isEnvelope {
 					envelopes[j] = &antimev.EnvelopeInfo{
-						Envelope: pre.transactions[i],
-						Err:      err,
+						Envelope:  pre.transactions[i],
+						Decrypted: decrypted,
+						Err:       err,
 					}
-				}
-				if pre.transactions[i].Type() != types.BlobTxType {
-					errs := c.staticPool.Add([]*types.Transaction{pre.transactions[i]}, false)
-					if errs[0] != nil {
-						log.Info("Falling back to original set of transactions",
-							"envelope hash", pre.transactions[i].Hash(),
-							"envelope index", i,
-							"reason", fmt.Sprintf("envelope has pool conflicts: %s", errs[0]))
-						txx = pre.transactions
-						for i := range envelopes {
-							envelopes[i] = &antimev.EnvelopeInfo{
-								Envelope: pre.transactions[pre.envelopesData[i].index],
-								Err:      errPreBlockReverted,
-							}
-						}
-						hasDecryptedTxs = false
-						return false
-					}
-				}
-				txx[i] = pre.transactions[i]
-				if incrementJ {
 					j++
 				}
-				return true
+				// Use original Envelope transaction as-is.
+				if errs := c.staticPool.Add([]*types.Transaction{pre.transactions[i]}, false); errs[0] == nil {
+					var (
+						snap = state.Snapshot()
+						gp   = gasPool.Gas()
+					)
+					state.SetTxContext(pre.transactions[i].Hash(), i)
+					receipt, err := core.ApplyTransaction(evm, gasPool, state, pre.header, pre.transactions[i], &gasUsed)
+					if err != nil {
+						state.RevertToSnapshot(snap)
+						gasPool.SetGas(gp)
+						// Drop following transactions from this account.
+						skipAccounts[sender] = true
+					} else {
+						txx = append(txx, pre.transactions[i])
+						receipts = append(receipts, receipt)
+						allLogs = append(allLogs, receipt.Logs...)
+					}
+				} else {
+					// Drop following transactions from this account.
+					skipAccounts[sender] = true
+				}
 			}
 		)
 
 		// If we're backup, then pre.finalReceipts are filled in during PreBlock verification;
 		// if we're primary, then reuse receipts got after PrepareRequest construction since
 		// PreBlock verification code is not executed by block proposer.
-		var receipts = pre.finalReceipts
+		preReceipts := pre.finalReceipts
 		if ctx.IsPrimary() && pre.finalState == nil {
-			receipts = c.sealingReceipts
+			preReceipts = c.sealingReceipts
 		}
-		if len(receipts) != len(pre.transactions) {
-			return fmt.Errorf("number of receipts mismatch: expected %d, actual %d", len(pre.transactions), len(receipts))
+		if len(preReceipts) != len(pre.transactions) {
+			return fmt.Errorf("number of receipts mismatch: expected %d, actual %d", len(pre.transactions), len(preReceipts))
 		}
 		// No need to reinitialize static pool since it was already initialized in verifyPreBlockCb.
 		// Reset the static pool after processing all transactions.
 		for i := range pre.transactions {
-			var isEnvelope = j < len(pre.envelopesData) && pre.envelopesData[j].index == i
+			sender, err := types.Sender(signer, pre.transactions[i])
+			if err != nil || skipAccounts[sender] {
+				continue
+			}
+			isEnvelope := j < len(pre.envelopesData) && pre.envelopesData[j].index == i
 			if !isEnvelope || // pre.transactions[i] is not an envelope, use it as-is.
 				decryptedTxsBytes[j] == nil { // pre.transactions[i] is Envelope, but its content failed to be decrypted, use Envelope as-is.
-				var err error
 				if isEnvelope {
-					err = errEnvelopeDecryption
-				}
-				if fallbackToEnvelope(i, isEnvelope, err) {
-					continue
+					fallbackToPreBlockTx(i, true, sender, nil, errEnvelopeDecryption)
 				} else {
-					break
+					fallbackToPreBlockTx(i, false, sender, nil, nil)
 				}
+				continue
 			}
 			log.Info("Envelope data decrypted",
 				"envelope hash", pre.transactions[i].Hash(),
 				"envelope index", i,
 				"data", hex.EncodeToString(decryptedTxsBytes[j]))
 			var decryptedTx = new(types.Transaction)
-			err := decryptedTx.UnmarshalBinary(decryptedTxsBytes[j])
+			if err := decryptedTx.UnmarshalBinary(decryptedTxsBytes[j]); err != nil {
+				fallbackToPreBlockTx(i, true, sender, nil, errDecryptedDecoding)
+				continue
+			}
+			if err = c.validateDecryptedTx(parent, decryptedTx, pre.transactions[i], preReceipts[i]); err != nil {
+				fallbackToPreBlockTx(i, true, sender, decryptedTx, err)
+				continue
+			}
+			if errs := c.staticPool.Add([]*types.Transaction{decryptedTx}, false); errs[0] != nil {
+				fallbackToPreBlockTx(i, true, sender, decryptedTx, errDecryptedRejectedByPool)
+				continue
+			}
+			var (
+				snap = state.Snapshot()
+				gp   = gasPool.Gas()
+			)
+			state.SetTxContext(decryptedTx.Hash(), i)
+			receipt, err := core.ApplyTransaction(evm, gasPool, state, pre.header, decryptedTx, &gasUsed)
 			if err != nil {
-				if fallbackToEnvelope(i, true, errDecryptedDecoding) {
-					continue
-				} else {
-					break
+				state.RevertToSnapshot(snap)
+				gasPool.SetGas(gp)
+				fallbackToPreBlockTx(i, true, sender, decryptedTx, errDecryptedRejectedByEVM)
+				continue
+			} else {
+				envelopes[j] = &antimev.EnvelopeInfo{
+					Envelope:  pre.transactions[i],
+					Decrypted: decryptedTx,
+					Err:       nil,
 				}
+				txx = append(txx, decryptedTx)
+				receipts = append(receipts, receipt)
+				allLogs = append(allLogs, receipt.Logs...)
+				j++
 			}
-			err = c.validateDecryptedTx(parent, decryptedTx, pre.transactions[i], receipts[i])
-			if err != nil {
-				if fallbackToEnvelope(i, true, err) {
-					continue
-				} else {
-					break
-				}
-			}
-			errs := c.staticPool.Add([]*types.Transaction{decryptedTx}, false)
-			if errs[0] != nil {
-				if fallbackToEnvelope(i, true, err) {
-					continue
-				} else {
-					break
-				}
-			}
-			txx[i] = decryptedTx
-			envelopes[j] = &antimev.EnvelopeInfo{
-				Envelope:  pre.transactions[i],
-				Decrypted: decryptedTx,
-			}
-			j++
-			hasDecryptedTxs = true
 		}
+		// Read requests if Prague is enabled.
+		var requests [][]byte
+		if c.chain.Config().IsPrague(pre.header.Number, pre.header.Time) {
+			requests = [][]byte{}
+			// EIP-6110
+			if err := core.ParseDepositLogs(&requests, allLogs, c.chain.Config()); err != nil {
+				return err
+			}
+			// EIP-7002
+			if err := core.ProcessWithdrawalQueue(&requests, evm); err != nil {
+				return err
+			}
+			// EIP-7251
+			if err := core.ProcessConsolidationQueue(&requests, evm); err != nil {
+				return err
+			}
+		}
+		if requests != nil {
+			reqHash := types.CalcRequestsHash(requests)
+			pre.header.RequestsHash = &reqHash
+		}
+		// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
+		c.Finalize(c.chain, pre.header, state, &types.Body{Transactions: txx, Withdrawals: pre.withdrawals})
+
 		pre.finalTransactions = txx
+		pre.finalState = state
+		pre.finalReceipts = receipts
+		pre.finalGASUsed = gasUsed
 		c.envelopeFeed.Send(envelopes)
 		c.staticPool.ResetStatic()
 	}
-
-	// Use cached processing results if no new transactions were included into
-	// the block compared to the original proposal.
-	if !hasDecryptedTxs {
-		return nil
-	}
-
-	// Process state with constructed list of transactions to fill state-dependent
-	// block fields.
-	finalBlock := &PreBlock{
-		header:                 pre.header,
-		transactions:           pre.finalTransactions,
-		withdrawals:            pre.withdrawals,
-		dkgRound:               pre.dkgRound,
-		enforceECDSASignatures: pre.enforceECDSASignatures,
-	}
-	ethBlock := finalBlock.ToEthBlock()
-	state, res, err := c.chain.ProcessState(ethBlock, nil)
-	if err != nil {
-		// Something went wrong, fallback to the original set of transactions and cached
-		// processing results.
-		log.Error("failed to process PreBlock, falling back to the original proposal",
-			"err", err,
-			"number", ethBlock.NumberU64(),
-			"seal hash", c.SealHash(ethBlock.Header()),
-			"parent hash", ethBlock.ParentHash().String(),
-			"intermediate merkle root", ethBlock.Root(),
-			"coinbase", ethBlock.Coinbase().String(),
-			"gas limit", ethBlock.GasLimit(),
-			"gas used", ethBlock.GasUsed(),
-			"difficulty", ethBlock.Difficulty().String(),
-			"mix digest", ethBlock.MixDigest().String(),
-			"nonce", ethBlock.Nonce(),
-			"time", ethBlock.Time(),
-			"uncle hash", ethBlock.UncleHash().String(),
-			"txs", len(ethBlock.Transactions()))
-		pre.finalTransactions = pre.transactions
-		return nil
-	}
-
-	pre.finalState, pre.finalReceipts, pre.finalGASUsed = state, res.Receipts, res.GasUsed
 	return nil
 }
 

--- a/consensus/ethash/ethash.go
+++ b/consensus/ethash/ethash.go
@@ -20,8 +20,10 @@ package ethash
 import (
 	"time"
 
+	"github.com/ethereum/go-ethereum/antimev"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
@@ -31,6 +33,9 @@ type Ethash struct {
 	fakeFail  *uint64        // Block number which fails PoW check even in fake mode
 	fakeDelay *time.Duration // Time delay to sleep for before returning from verify
 	fakeFull  bool           // Accepts everything as valid
+
+	envelopeFeed event.Feed              // Event feed for new Envelopes
+	scope        event.SubscriptionScope // Subscription scope for ethash events
 }
 
 // NewFaker creates an ethash consensus engine with a fake PoW scheme that accepts
@@ -75,6 +80,11 @@ func (ethash *Ethash) Close() error {
 // shell in the post-merge world.
 func (ethash *Ethash) APIs(chain consensus.ChainHeaderReader) []rpc.API {
 	return []rpc.API{}
+}
+
+// SubscribeEnvelopeEvent creates a subscription that fires for all new envelopes that enter the consensus engine.
+func (ethash *Ethash) SubscribeEnvelopeEvent(ch chan<- []*antimev.EnvelopeInfo) event.Subscription {
+	return ethash.scope.Track(ethash.envelopeFeed.Subscribe(ch))
 }
 
 // Seal generates a new sealing request for the given input block and pushes

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/antimev"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
@@ -314,6 +315,10 @@ func (b *EthAPIBackend) SubscribeChainHeadEvent(ch chan<- core.ChainHeadEvent) e
 
 func (b *EthAPIBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription {
 	return b.eth.BlockChain().SubscribeLogsEvent(ch)
+}
+
+func (b *EthAPIBackend) SubscribeEnvelopeEvent(ch chan<- []*antimev.EnvelopeInfo) event.Subscription {
+	return b.eth.engine.SubscribeEnvelopeEvent(ch)
 }
 
 func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction) error {

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/antimev"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip1559"
@@ -300,6 +301,35 @@ func (api *FilterAPI) Logs(ctx context.Context, crit FilterCriteria) (*rpc.Subsc
 					notifier.Notify(rpcSub.ID, &log)
 				}
 			case <-rpcSub.Err(): // client send an unsubscribe request
+				return
+			}
+		}
+	}()
+
+	return rpcSub, nil
+}
+
+// Envelopes creates a subscription that fires for all new envelopes that enter the consensus engine.
+func (api *FilterAPI) Envelopes(ctx context.Context) (*rpc.Subscription, error) {
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
+	}
+
+	rpcSub := notifier.CreateSubscription()
+
+	go func() {
+		envelopes := make(chan []*antimev.EnvelopeInfo)
+		envelopeSub := api.events.SubscribeEnvelopes(envelopes)
+		defer envelopeSub.Unsubscribe()
+
+		for {
+			select {
+			case envs := <-envelopes:
+				for _, env := range envs {
+					notifier.Notify(rpcSub.ID, env)
+				}
+			case <-rpcSub.Err():
 				return
 			}
 		}

--- a/eth/filters/filter_system.go
+++ b/eth/filters/filter_system.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/antimev"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
 	"github.com/ethereum/go-ethereum/core"
@@ -71,6 +72,7 @@ type Backend interface {
 	SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription
 	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription
 	SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription
+	SubscribeEnvelopeEvent(ch chan<- []*antimev.EnvelopeInfo) event.Subscription
 
 	CurrentView() *filtermaps.ChainView
 	NewMatcherBackend() filtermaps.MatcherBackend
@@ -159,6 +161,8 @@ const (
 	PendingTransactionsSubscription
 	// BlocksSubscription queries hashes for blocks that are imported
 	BlocksSubscription
+	// EnvelopeSubscription queries for dBFT envelope transactions handling
+	EnvelopeSubscription
 	// LastIndexSubscription keeps track of the last index
 	LastIndexSubscription
 )
@@ -173,6 +177,9 @@ const (
 	logsChanSize = 10
 	// chainEvChanSize is the size of channel listening to ChainEvent.
 	chainEvChanSize = 10
+	// envelopeChanSize is the size of channel listening to EnvelopeEvent.
+	// The number is referenced from the size of tx pool.
+	envelopeChanSize = 4096
 )
 
 type subscription struct {
@@ -183,6 +190,7 @@ type subscription struct {
 	logs      chan []*types.Log
 	txs       chan []*types.Transaction
 	headers   chan *types.Header
+	envelopes chan []*antimev.EnvelopeInfo
 	installed chan struct{} // closed when the filter is installed
 	err       chan error    // closed when the filter is uninstalled
 }
@@ -194,18 +202,20 @@ type EventSystem struct {
 	sys     *FilterSystem
 
 	// Subscriptions
-	txsSub    event.Subscription // Subscription for new transaction event
-	logsSub   event.Subscription // Subscription for new log event
-	rmLogsSub event.Subscription // Subscription for removed log event
-	chainSub  event.Subscription // Subscription for new chain event
+	txsSub      event.Subscription // Subscription for new transaction event
+	logsSub     event.Subscription // Subscription for new log event
+	rmLogsSub   event.Subscription // Subscription for removed log event
+	chainSub    event.Subscription // Subscription for new chain event
+	envelopeSub event.Subscription // Subscription for new envelope event
 
 	// Channels
-	install   chan *subscription         // install filter for event notification
-	uninstall chan *subscription         // remove filter for event notification
-	txsCh     chan core.NewTxsEvent      // Channel to receive new transactions event
-	logsCh    chan []*types.Log          // Channel to receive new log event
-	rmLogsCh  chan core.RemovedLogsEvent // Channel to receive removed log event
-	chainCh   chan core.ChainEvent       // Channel to receive new chain event
+	install    chan *subscription           // install filter for event notification
+	uninstall  chan *subscription           // remove filter for event notification
+	txsCh      chan core.NewTxsEvent        // Channel to receive new transactions event
+	logsCh     chan []*types.Log            // Channel to receive new log event
+	rmLogsCh   chan core.RemovedLogsEvent   // Channel to receive removed log event
+	chainCh    chan core.ChainEvent         // Channel to receive new chain event
+	envelopeCh chan []*antimev.EnvelopeInfo // Channel to receive new envelope event
 }
 
 // NewEventSystem creates a new manager that listens for event on the given mux,
@@ -216,14 +226,15 @@ type EventSystem struct {
 // or by stopping the given mux.
 func NewEventSystem(sys *FilterSystem) *EventSystem {
 	m := &EventSystem{
-		sys:       sys,
-		backend:   sys.backend,
-		install:   make(chan *subscription),
-		uninstall: make(chan *subscription),
-		txsCh:     make(chan core.NewTxsEvent, txChanSize),
-		logsCh:    make(chan []*types.Log, logsChanSize),
-		rmLogsCh:  make(chan core.RemovedLogsEvent, rmLogsChanSize),
-		chainCh:   make(chan core.ChainEvent, chainEvChanSize),
+		sys:        sys,
+		backend:    sys.backend,
+		install:    make(chan *subscription),
+		uninstall:  make(chan *subscription),
+		txsCh:      make(chan core.NewTxsEvent, txChanSize),
+		logsCh:     make(chan []*types.Log, logsChanSize),
+		rmLogsCh:   make(chan core.RemovedLogsEvent, rmLogsChanSize),
+		chainCh:    make(chan core.ChainEvent, chainEvChanSize),
+		envelopeCh: make(chan []*antimev.EnvelopeInfo, envelopeChanSize),
 	}
 
 	// Subscribe events
@@ -231,9 +242,10 @@ func NewEventSystem(sys *FilterSystem) *EventSystem {
 	m.logsSub = m.backend.SubscribeLogsEvent(m.logsCh)
 	m.rmLogsSub = m.backend.SubscribeRemovedLogsEvent(m.rmLogsCh)
 	m.chainSub = m.backend.SubscribeChainEvent(m.chainCh)
+	m.envelopeSub = m.backend.SubscribeEnvelopeEvent(m.envelopeCh)
 
 	// Make sure none of the subscriptions are empty
-	if m.txsSub == nil || m.logsSub == nil || m.rmLogsSub == nil || m.chainSub == nil {
+	if m.txsSub == nil || m.logsSub == nil || m.rmLogsSub == nil || m.chainSub == nil || m.envelopeSub == nil {
 		log.Crit("Subscribe for event system failed")
 	}
 
@@ -269,6 +281,7 @@ func (sub *Subscription) Unsubscribe() {
 			case <-sub.f.logs:
 			case <-sub.f.txs:
 			case <-sub.f.headers:
+			case <-sub.f.envelopes:
 			}
 		}
 
@@ -344,6 +357,7 @@ func (es *EventSystem) subscribeLogs(crit ethereum.FilterQuery, logs chan []*typ
 		logs:      logs,
 		txs:       make(chan []*types.Transaction),
 		headers:   make(chan *types.Header),
+		envelopes: make(chan []*antimev.EnvelopeInfo),
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
@@ -360,6 +374,7 @@ func (es *EventSystem) SubscribeNewHeads(headers chan *types.Header) *Subscripti
 		logs:      make(chan []*types.Log),
 		txs:       make(chan []*types.Transaction),
 		headers:   headers,
+		envelopes: make(chan []*antimev.EnvelopeInfo),
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
@@ -376,6 +391,24 @@ func (es *EventSystem) SubscribePendingTxs(txs chan []*types.Transaction) *Subsc
 		logs:      make(chan []*types.Log),
 		txs:       txs,
 		headers:   make(chan *types.Header),
+		envelopes: make(chan []*antimev.EnvelopeInfo),
+		installed: make(chan struct{}),
+		err:       make(chan error),
+	}
+	return es.subscribe(sub)
+}
+
+// SubscribeEnvelopes creates a subscription that writes information for
+// envelopes that enter the consensus engine.
+func (es *EventSystem) SubscribeEnvelopes(envelopes chan []*antimev.EnvelopeInfo) *Subscription {
+	sub := &subscription{
+		id:        rpc.NewID(),
+		typ:       EnvelopeSubscription,
+		created:   time.Now(),
+		logs:      make(chan []*types.Log),
+		txs:       make(chan []*types.Transaction),
+		headers:   make(chan *types.Header),
+		envelopes: envelopes,
 		installed: make(chan struct{}),
 		err:       make(chan error),
 	}
@@ -408,6 +441,12 @@ func (es *EventSystem) handleChainEvent(filters filterIndex, ev core.ChainEvent)
 	}
 }
 
+func (es *EventSystem) handleEnvelopeEvent(filters filterIndex, ev []*antimev.EnvelopeInfo) {
+	for _, f := range filters[EnvelopeSubscription] {
+		f.envelopes <- ev
+	}
+}
+
 // eventLoop (un)installs filters and processes mux events.
 func (es *EventSystem) eventLoop() {
 	// Ensure all subscriptions get cleaned up
@@ -416,6 +455,7 @@ func (es *EventSystem) eventLoop() {
 		es.logsSub.Unsubscribe()
 		es.rmLogsSub.Unsubscribe()
 		es.chainSub.Unsubscribe()
+		es.envelopeSub.Unsubscribe()
 	}()
 
 	index := make(filterIndex)
@@ -433,6 +473,8 @@ func (es *EventSystem) eventLoop() {
 			es.handleLogs(index, ev.Logs)
 		case ev := <-es.chainCh:
 			es.handleChainEvent(index, ev)
+		case ev := <-es.envelopeCh:
+			es.handleEnvelopeEvent(index, ev)
 
 		case f := <-es.install:
 			index[f.typ][f.id] = f
@@ -450,6 +492,8 @@ func (es *EventSystem) eventLoop() {
 		case <-es.rmLogsSub.Err():
 			return
 		case <-es.chainSub.Err():
+			return
+		case <-es.envelopeSub.Err():
 			return
 		}
 	}

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/antimev"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
 	"github.com/ethereum/go-ethereum/core"
@@ -46,6 +47,7 @@ type testBackend struct {
 	logsFeed        event.Feed
 	rmLogsFeed      event.Feed
 	chainFeed       event.Feed
+	envelopeFeed    event.Feed
 	pendingBlock    *types.Block
 	pendingReceipts types.Receipts
 }
@@ -160,6 +162,10 @@ func (b *testBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscript
 
 func (b *testBackend) SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription {
 	return b.chainFeed.Subscribe(ch)
+}
+
+func (b *testBackend) SubscribeEnvelopeEvent(ch chan<- []*antimev.EnvelopeInfo) event.Subscription {
+	return b.envelopeFeed.Subscribe(ch)
 }
 
 func (b *testBackend) CurrentView() *filtermaps.ChainView {

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/antimev"
 	"github.com/ethereum/go-ethereum/internal/ethapi/override"
 
 	"github.com/ethereum/go-ethereum"
@@ -637,6 +638,9 @@ func (b testBackend) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) 
 	panic("implement me")
 }
 func (b testBackend) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription {
+	panic("implement me")
+}
+func (b testBackend) SubscribeEnvelopeEvent(ch chan<- []*antimev.EnvelopeInfo) event.Subscription {
 	panic("implement me")
 }
 func (b testBackend) CurrentView() *filtermaps.ChainView {

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/antimev"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core"
@@ -98,6 +99,7 @@ type Backend interface {
 	GetLogs(ctx context.Context, blockHash common.Hash, number uint64) ([][]*types.Log, error)
 	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription
 	SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription
+	SubscribeEnvelopeEvent(ch chan<- []*antimev.EnvelopeInfo) event.Subscription
 
 	CurrentView() *filtermaps.ChainView
 	NewMatcherBackend() filtermaps.MatcherBackend

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/antimev"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -409,6 +410,9 @@ func (b *backendMock) TxPoolContentFrom(addr common.Address) ([]*types.Transacti
 func (b *backendMock) SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription { return nil }
 func (b *backendMock) SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription    { return nil }
 func (b *backendMock) SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription {
+	return nil
+}
+func (b *backendMock) SubscribeEnvelopeEvent(ch chan<- []*antimev.EnvelopeInfo) event.Subscription {
 	return nil
 }
 


### PR DESCRIPTION
Close #524. Close #527.

- [x] Add real-time event subscription for Envelope handling;
- [x] Eliminate the result influence between succeeded Envelopes and failed Envelopes.

@songb2 The new Envelope event can be subscribed through socket with the following request:

```json
{"id":1,"jsonrpc":"2.0","method":"eth_subscribe","params":["envelopes"]}
```