### PR TITLE
antimev: dbft: fix envelope event error serialization

### DIFF
--- a/antimev/envelope.go
+++ b/antimev/envelope.go
@@ -90,5 +90,5 @@ func GetEncryptedGas(envelopeData []byte) uint32 {
 type EnvelopeInfo struct {
 	Envelope  *types.Transaction `json:"envelope"`  // Original Envelope transaction
 	Decrypted *types.Transaction `json:"decrypted"` // Decrypted inner transaction
-	Err       error              `json:"err"`       // Decryption error, if any
+	Err       *string            `json:"err"`       // Decryption error, if any
 }

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1215,10 +1215,14 @@ func (c *DBFT) processPreBlockCb(b dbft.PreBlock[common.Hash]) error {
 			fallbackToPreBlockTx = func(i int, isEnvelope bool, sender common.Address, decrypted *types.Transaction, err error) {
 				// Log the fallback event.
 				if isEnvelope {
+					if err == nil {
+						panic("bug: no error is given to fallback an Envelope")
+					}
+					errStr := err.Error()
 					envelopes[j] = &antimev.EnvelopeInfo{
 						Envelope:  pre.transactions[i],
 						Decrypted: decrypted,
-						Err:       err,
+						Err:       &errStr,
 					}
 					j++
 				}


### PR DESCRIPTION
This issue is imported by #528.

The type `Error` can't be serialized correctly through RPC API, so the user will always receive an empty struct `{}`  instead of the correct error message.

The solution is to carry the message inside a string directly.