### PR TITLE
eth/gasprice: initializing member variables is used to handle abnormal situations and prevent panics

### DIFF
--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -148,6 +148,9 @@ func NewOracle(backend OracleBackend, params Config, startPrice *big.Int) *Oracl
 	return &Oracle{
 		backend:          backend,
 		lastPrice:        startPrice,
+		lastBaseFee:      new(big.Int),
+		lastMinGasTipCap: new(big.Int),
+		lastEnvelopeFee:  new(big.Int),
 		maxPrice:         maxPrice,
 		ignorePrice:      ignorePrice,
 		checkBlocks:      blocks,


### PR DESCRIPTION
Close #533.