### PR TITLE
beacon: consensus/dbft: eth: split eth protocol, and move consensus and block broadcast fully on top of beacon

### DIFF
--- a/beacon/engine/gen_ed.go
+++ b/beacon/engine/gen_ed.go
@@ -28,6 +28,7 @@ func (e ExecutableData) MarshalJSON() ([]byte, error) {
 		GasLimit         hexutil.Uint64          `json:"gasLimit"      gencodec:"required"`
 		GasUsed          hexutil.Uint64          `json:"gasUsed"       gencodec:"required"`
 		Timestamp        hexutil.Uint64          `json:"timestamp"     gencodec:"required"`
+		Nonce            hexutil.Uint64          `json:"nonce"         gencodec:"required"`
 		ExtraData        hexutil.Bytes           `json:"extraData"     gencodec:"required"`
 		BaseFeePerGas    *hexutil.Big            `json:"baseFeePerGas" gencodec:"required"`
 		BlockHash        common.Hash             `json:"blockHash"     gencodec:"required"`
@@ -49,6 +50,7 @@ func (e ExecutableData) MarshalJSON() ([]byte, error) {
 	enc.GasLimit = hexutil.Uint64(e.GasLimit)
 	enc.GasUsed = hexutil.Uint64(e.GasUsed)
 	enc.Timestamp = hexutil.Uint64(e.Timestamp)
+	enc.Nonce = hexutil.Uint64(e.Nonce)
 	enc.ExtraData = e.ExtraData
 	enc.BaseFeePerGas = (*hexutil.Big)(e.BaseFeePerGas)
 	enc.BlockHash = e.BlockHash
@@ -79,6 +81,7 @@ func (e *ExecutableData) UnmarshalJSON(input []byte) error {
 		GasLimit         *hexutil.Uint64         `json:"gasLimit"      gencodec:"required"`
 		GasUsed          *hexutil.Uint64         `json:"gasUsed"       gencodec:"required"`
 		Timestamp        *hexutil.Uint64         `json:"timestamp"     gencodec:"required"`
+		Nonce            *hexutil.Uint64         `json:"nonce"         gencodec:"required"`
 		ExtraData        *hexutil.Bytes          `json:"extraData"     gencodec:"required"`
 		BaseFeePerGas    *hexutil.Big            `json:"baseFeePerGas" gencodec:"required"`
 		BlockHash        *common.Hash            `json:"blockHash"     gencodec:"required"`
@@ -138,6 +141,10 @@ func (e *ExecutableData) UnmarshalJSON(input []byte) error {
 	e.Timestamp = uint64(*dec.Timestamp)
 	if dec.ExtraData == nil {
 		return errors.New("missing required field 'extraData' for ExecutableData")
+	}
+	e.Nonce = uint64(*dec.Nonce)
+	if dec.Nonce == nil {
+		return errors.New("missing required field 'nonce' for ExecutableData")
 	}
 	e.ExtraData = *dec.ExtraData
 	if dec.BaseFeePerGas == nil {

--- a/beacon/engine/types.go
+++ b/beacon/engine/types.go
@@ -17,6 +17,7 @@
 package engine
 
 import (
+	"encoding/binary"
 	"fmt"
 	"math/big"
 	"slices"
@@ -24,7 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/trie"
 )
 
@@ -70,6 +70,7 @@ type ExecutableData struct {
 	GasLimit         uint64                  `json:"gasLimit"      gencodec:"required"`
 	GasUsed          uint64                  `json:"gasUsed"       gencodec:"required"`
 	Timestamp        uint64                  `json:"timestamp"     gencodec:"required"`
+	Nonce            uint64                  `json:"nonce"         gencodec:"required"`
 	ExtraData        []byte                  `json:"extraData"     gencodec:"required"`
 	BaseFeePerGas    *big.Int                `json:"baseFeePerGas" gencodec:"required"`
 	BlockHash        common.Hash             `json:"blockHash"     gencodec:"required"`
@@ -233,9 +234,9 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 	if err != nil {
 		return nil, err
 	}
-	if len(data.ExtraData) > int(params.MaximumExtraDataSize) {
-		return nil, fmt.Errorf("invalid extradata length: %v", len(data.ExtraData))
-	}
+	// if len(data.ExtraData) > int(params.MaximumExtraDataSize) {
+	// 	return nil, fmt.Errorf("invalid extradata length: %v", len(data.ExtraData))
+	// }
 	if len(data.LogsBloom) != 256 {
 		return nil, fmt.Errorf("invalid logsBloom length: %v", len(data.LogsBloom))
 	}
@@ -247,14 +248,15 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 	for _, tx := range txs {
 		blobHashes = append(blobHashes, tx.BlobHashes()...)
 	}
-	if len(blobHashes) != len(versionedHashes) {
-		return nil, fmt.Errorf("invalid number of versionedHashes: %v blobHashes: %v", versionedHashes, blobHashes)
-	}
-	for i := 0; i < len(blobHashes); i++ {
-		if blobHashes[i] != versionedHashes[i] {
-			return nil, fmt.Errorf("invalid versionedHash at %v: %v blobHashes: %v", i, versionedHashes, blobHashes)
-		}
-	}
+	// TODO: add this check back when we have versioned hashes in the payload feedback.
+	// if len(blobHashes) != len(versionedHashes) {
+	// 	return nil, fmt.Errorf("invalid number of versionedHashes: %v blobHashes: %v", versionedHashes, blobHashes)
+	// }
+	// for i := 0; i < len(blobHashes); i++ {
+	// 	if blobHashes[i] != versionedHashes[i] {
+	// 		return nil, fmt.Errorf("invalid versionedHash at %v: %v blobHashes: %v", i, versionedHashes, blobHashes)
+	// 	}
+	// }
 	// Only set withdrawalsRoot if it is non-nil. This allows CLs to use
 	// ExecutableData before withdrawals are enabled by marshaling
 	// Withdrawals as the json null value.
@@ -292,6 +294,7 @@ func ExecutableDataToBlockNoHash(data ExecutableData, versionedHashes []common.H
 		ParentBeaconRoot: beaconRoot,
 		RequestsHash:     requestsHash,
 	}
+	binary.BigEndian.PutUint64(header.Nonce[:], data.Nonce)
 	return types.NewBlockWithHeader(header).
 			WithBody(types.Body{Transactions: txs, Uncles: nil, Withdrawals: data.Withdrawals}).
 			WithWitness(data.ExecutionWitness),
@@ -316,6 +319,7 @@ func BlockToExecutableData(block *types.Block, fees *big.Int, sidecars []*types.
 		LogsBloom:        block.Bloom().Bytes(),
 		Transactions:     encodeTransactions(block.Transactions()),
 		Random:           block.MixDigest(),
+		Nonce:            block.Nonce(),
 		ExtraData:        block.Extra(),
 		Withdrawals:      block.Withdrawals(),
 		BlobGasUsed:      block.BlobGasUsed(),

--- a/beacon/impl/beacon.go
+++ b/beacon/impl/beacon.go
@@ -1,136 +1,82 @@
-// Package beacon implements minimized Ethereum beacon client.
 package impl
 
 import (
-	"sync"
+	"time"
 
+	"github.com/ethereum/go-ethereum/beacon/impl/fetcher"
+	"github.com/ethereum/go-ethereum/beacon/impl/miner"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
-// Backend wraps all methods required for mining. Only full node is capable
-// to offer all the functions here.
-type Backend interface {
-	BlockChain() *core.BlockChain
-	Engine() consensus.Engine
-}
-
-// Beacon is the main object which takes care of submitting new work to consensus
-// engine and gathering the sealing result.
 type Beacon struct {
-	mux     *event.TypeMux
-	engine  consensus.Engine
-	exitCh  chan struct{}
-	startCh chan struct{}
-	stopCh  chan struct{}
-	worker  *worker
-	rpc     *rpc.Client
-
-	wg sync.WaitGroup
+	chain        *core.BlockChain
+	miner        *miner.Miner
+	blockFetcher *fetcher.BlockFetcher
 }
 
-func New(eth Backend, rpc *rpc.Client, mux *event.TypeMux, coinbase common.Address) *Beacon {
-	beacon := &Beacon{
-		mux:     mux,
-		engine:  eth.Engine(),
-		exitCh:  make(chan struct{}),
-		startCh: make(chan struct{}),
-		stopCh:  make(chan struct{}),
-		worker:  newWorker(eth, rpc, mux, coinbase),
-		rpc:     rpc,
-	}
-	beacon.wg.Add(1)
-	go beacon.update()
-	return beacon
-}
-
-// update keeps track of the downloader events. Please be aware that this is a one shot type of update loop.
-// It's entered once and as soon as `Done` or `Failed` has been broadcasted the events are unregistered and
-// the loop is exited. This to prevent a major security vuln where external parties can DOS you with blocks
-// and halt your mining operation for as long as the DOS continues.
-func (beacon *Beacon) update() {
-	defer beacon.wg.Done()
-
-	events := beacon.mux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{})
-	defer func() {
-		if !events.Closed() {
-			events.Unsubscribe()
-		}
-	}()
-
-	shouldStart := false
-	canStart := true
-	dlEventCh := events.Chan()
-	for {
-		select {
-		case ev := <-dlEventCh:
-			if ev == nil {
-				// Unsubscription done, stop listening
-				dlEventCh = nil
-				continue
-			}
-			switch ev.Data.(type) {
-			case downloader.StartEvent:
-				wasMining := beacon.Mining()
-				beacon.worker.stopMining()
-				canStart = false
-				if wasMining {
-					// Resume mining after sync was finished
-					shouldStart = true
-					log.Info("Mining aborted due to sync")
-				}
-				beacon.worker.syncing.Store(true)
-
-			case downloader.FailedEvent:
-				canStart = true
-				if shouldStart {
-					beacon.worker.startMining()
-				}
-				beacon.worker.syncing.Store(false)
-
-			case downloader.DoneEvent:
-				canStart = true
-				if shouldStart {
-					beacon.worker.startMining()
-				}
-				beacon.worker.syncing.Store(false)
-
-				// Stop reacting to downloader events
-				events.Unsubscribe()
-			}
-		case <-beacon.startCh:
-			if canStart {
-				beacon.worker.startMining()
-			}
-			shouldStart = true
-		case <-beacon.stopCh:
-			shouldStart = false
-			beacon.worker.stopMining()
-		case <-beacon.exitCh:
-			beacon.worker.close()
-			return
-		}
+// New creates a mock beacon client with basic mining functionality.
+func New(eth miner.Backend, rpc *rpc.Client, mux *event.TypeMux, coinbase common.Address) *Beacon {
+	return &Beacon{
+		chain: eth.BlockChain(),
+		miner: miner.New(eth, rpc, mux, coinbase),
 	}
 }
 
-func (beacon *Beacon) Start() {
-	beacon.startCh <- struct{}{}
+// StartBlockFetcher enables the block fetching functionality of the beacon client.
+func (b *Beacon) StartBlockFetcher(broadcastBlock fetcher.BlockBroadcasterFn, insertChain fetcher.ChainInsertFn,
+	dropPeer fetcher.PeerDropFn, fetchHeader fetcher.HeaderRequesterFn, fetchBodies fetcher.BodyRequesterFn) {
+
+	validator := func(header *types.Header) error {
+		return b.chain.Engine().VerifyHeader(b.chain, header)
+	}
+	heighter := func() uint64 {
+		return b.chain.CurrentBlock().Number.Uint64()
+	}
+	finalizeHeighter := func() uint64 {
+		fblock := b.chain.CurrentFinalBlock()
+		if fblock == nil {
+			return 0
+		}
+		return fblock.Number.Uint64()
+	}
+
+	b.blockFetcher = fetcher.NewBlockFetcher(b.chain.GetBlockByHash, validator,
+		broadcastBlock, heighter, finalizeHeighter, insertChain, dropPeer,
+		fetchHeader, fetchBodies)
+	b.blockFetcher.Start()
 }
 
-func (beacon *Beacon) Stop() {
-	beacon.stopCh <- struct{}{}
+// EnqueueBlock sends a received block to beacon for further injection.
+func (b *Beacon) EnqueueBlock(peer string, block *types.Block) {
+	b.blockFetcher.Enqueue(peer, block)
 }
 
-func (beacon *Beacon) Close() {
-	close(beacon.exitCh)
-	beacon.wg.Wait()
+// NotifyBlockAnnon sends a received block announcement to beacon for further download.
+func (b *Beacon) NotifyBlockAnnon(peer string, hash common.Hash, number uint64, time time.Time) {
+	b.blockFetcher.Notify(peer, hash, number, time)
 }
 
-func (beacon *Beacon) Mining() bool {
-	return beacon.worker.isMining()
+// Mining returns whether the beacon client is mining.
+func (b *Beacon) Mining() bool {
+	return b.miner.Mining()
+}
+
+// StartMining starts beacon mining.
+func (b *Beacon) StartMining() {
+	b.miner.Start()
+}
+
+// StopMining stops beacon mining.
+func (b *Beacon) StopMining() {
+	b.miner.Stop()
+}
+
+// Close closes the beacon client service.
+func (b *Beacon) Close() {
+	b.miner.Close()
+	b.blockFetcher.Stop()
 }

--- a/beacon/impl/beacon.go
+++ b/beacon/impl/beacon.go
@@ -22,20 +22,18 @@ type Beacon struct {
 	chain          *core.BlockChain
 	miner          *miner.Miner
 	blockCh        chan *types.Block
-	blockSub       event.Subscription
 	blockFetcher   *fetcher.BlockFetcher
 	broadcastBlock fetcher.BlockBroadcasterFn
 	wg             sync.WaitGroup
 }
 
 // New creates a mock beacon client with basic mining functionality.
-func New(eth miner.Backend, rpc *rpc.Client, bft DBFT, mux *event.TypeMux, coinbase common.Address) *Beacon {
+func New(eth miner.Backend, rpc *rpc.Client, mux *event.TypeMux, coinbase common.Address, shouldPreserve func(header *types.Header) bool) *Beacon {
 	b := &Beacon{
 		chain:   eth.BlockChain(),
-		miner:   miner.New(eth, rpc, mux, coinbase),
+		miner:   miner.New(eth, rpc, mux, coinbase, shouldPreserve),
 		blockCh: make(chan *types.Block),
 	}
-	b.blockSub = bft.SubscribeNewBlockEvent(b.blockCh)
 
 	b.wg.Add(1)
 	go b.minedBroadcastLoop()
@@ -44,8 +42,8 @@ func New(eth miner.Backend, rpc *rpc.Client, bft DBFT, mux *event.TypeMux, coinb
 
 // StartBlockFetcher enables the block fetching functionality of the beacon client.
 // This is also a part of initialization, to connect to the protocol layer.
-func (b *Beacon) StartBlockFetcher(broadcastBlock fetcher.BlockBroadcasterFn, insertChain fetcher.ChainInsertFn,
-	dropPeer fetcher.PeerDropFn, fetchHeader fetcher.HeaderRequesterFn, fetchBodies fetcher.BodyRequesterFn) {
+func (b *Beacon) StartBlockFetcher(broadcastBlock fetcher.BlockBroadcasterFn, dropPeer fetcher.PeerDropFn,
+	fetchHeader fetcher.HeaderRequesterFn, fetchBodies fetcher.BodyRequesterFn) {
 
 	validator := func(header *types.Header) error {
 		return b.chain.Engine().VerifyHeader(b.chain, header)
@@ -63,7 +61,7 @@ func (b *Beacon) StartBlockFetcher(broadcastBlock fetcher.BlockBroadcasterFn, in
 
 	b.broadcastBlock = broadcastBlock
 	b.blockFetcher = fetcher.NewBlockFetcher(b.chain.GetBlockByHash, validator,
-		broadcastBlock, heighter, finalizeHeighter, insertChain, dropPeer,
+		broadcastBlock, heighter, finalizeHeighter, b.InsertBlock, dropPeer,
 		fetchHeader, fetchBodies)
 	b.blockFetcher.Start()
 }
@@ -76,6 +74,11 @@ func (b *Beacon) EnqueueBlock(peer string, block *types.Block) {
 // NotifyBlockAnnon sends a received block announcement to beacon for further download.
 func (b *Beacon) NotifyBlockAnnon(peer string, hash common.Hash, number uint64, time time.Time) {
 	b.blockFetcher.Notify(peer, hash, number, time)
+}
+
+// InsertBlock is a universal block insert function to feed block back to EL.
+func (b *Beacon) InsertBlock(block *types.Block) error {
+	return b.miner.DispatchBlock(block)
 }
 
 // Mining returns whether the beacon client is mining.
@@ -97,12 +100,16 @@ func (b *Beacon) StopMining() {
 func (b *Beacon) Close() error {
 	b.miner.Close()
 	b.blockFetcher.Stop()
-	b.blockSub.Unsubscribe()
 	close(b.blockCh)
 	b.wg.Wait()
 
 	log.Info("Beacon stopped")
 	return nil
+}
+
+// BlockBroadcaster returns the channel for block broadcasting.
+func (b *Beacon) BlockBroadcaster() chan<- *types.Block {
+	return b.blockCh
 }
 
 // minedBroadcastLoop sends mined blocks to connected peers.

--- a/beacon/impl/beacon.go
+++ b/beacon/impl/beacon.go
@@ -1,6 +1,7 @@
 package impl
 
 import (
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/beacon/impl/fetcher"
@@ -9,24 +10,40 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
+type DBFT interface {
+	SubscribeNewBlockEvent(ch chan<- *types.Block) event.Subscription
+}
+
 type Beacon struct {
-	chain        *core.BlockChain
-	miner        *miner.Miner
-	blockFetcher *fetcher.BlockFetcher
+	chain          *core.BlockChain
+	miner          *miner.Miner
+	blockCh        chan *types.Block
+	blockSub       event.Subscription
+	blockFetcher   *fetcher.BlockFetcher
+	broadcastBlock fetcher.BlockBroadcasterFn
+	wg             sync.WaitGroup
 }
 
 // New creates a mock beacon client with basic mining functionality.
-func New(eth miner.Backend, rpc *rpc.Client, mux *event.TypeMux, coinbase common.Address) *Beacon {
-	return &Beacon{
-		chain: eth.BlockChain(),
-		miner: miner.New(eth, rpc, mux, coinbase),
+func New(eth miner.Backend, rpc *rpc.Client, bft DBFT, mux *event.TypeMux, coinbase common.Address) *Beacon {
+	b := &Beacon{
+		chain:   eth.BlockChain(),
+		miner:   miner.New(eth, rpc, mux, coinbase),
+		blockCh: make(chan *types.Block),
 	}
+	b.blockSub = bft.SubscribeNewBlockEvent(b.blockCh)
+
+	b.wg.Add(1)
+	go b.minedBroadcastLoop()
+	return b
 }
 
 // StartBlockFetcher enables the block fetching functionality of the beacon client.
+// This is also a part of initialization, to connect to the protocol layer.
 func (b *Beacon) StartBlockFetcher(broadcastBlock fetcher.BlockBroadcasterFn, insertChain fetcher.ChainInsertFn,
 	dropPeer fetcher.PeerDropFn, fetchHeader fetcher.HeaderRequesterFn, fetchBodies fetcher.BodyRequesterFn) {
 
@@ -44,6 +61,7 @@ func (b *Beacon) StartBlockFetcher(broadcastBlock fetcher.BlockBroadcasterFn, in
 		return fblock.Number.Uint64()
 	}
 
+	b.broadcastBlock = broadcastBlock
 	b.blockFetcher = fetcher.NewBlockFetcher(b.chain.GetBlockByHash, validator,
 		broadcastBlock, heighter, finalizeHeighter, insertChain, dropPeer,
 		fetchHeader, fetchBodies)
@@ -76,7 +94,23 @@ func (b *Beacon) StopMining() {
 }
 
 // Close closes the beacon client service.
-func (b *Beacon) Close() {
+func (b *Beacon) Close() error {
 	b.miner.Close()
 	b.blockFetcher.Stop()
+	b.blockSub.Unsubscribe()
+	close(b.blockCh)
+	b.wg.Wait()
+
+	log.Info("Beacon stopped")
+	return nil
+}
+
+// minedBroadcastLoop sends mined blocks to connected peers.
+func (b *Beacon) minedBroadcastLoop() {
+	defer b.wg.Done()
+
+	for block := range b.blockCh {
+		b.broadcastBlock(block, true)  // First propagate block to peers
+		b.broadcastBlock(block, false) // Only then announce to the rest
+	}
 }

--- a/beacon/impl/fetcher/block_fetcher.go
+++ b/beacon/impl/fetcher/block_fetcher.go
@@ -1,23 +1,7 @@
-// Copyright 2015 The go-ethereum Authors
-// This file is part of the go-ethereum library.
-//
-// The go-ethereum library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The go-ethereum library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
-
-// Package fetcher contains the announcement based header, blocks or transaction synchronisation.
 package fetcher
 
 import (
+	"errors"
 	"math/rand"
 	"time"
 
@@ -49,43 +33,45 @@ const (
 )
 
 var (
-	blockAnnounceInMeter   = metrics.NewRegisteredMeter("eth/fetcher/block/announces/in", nil)
-	blockAnnounceOutTimer  = metrics.NewRegisteredTimer("eth/fetcher/block/announces/out", nil)
-	blockAnnounceDropMeter = metrics.NewRegisteredMeter("eth/fetcher/block/announces/drop", nil)
-	blockAnnounceDOSMeter  = metrics.NewRegisteredMeter("eth/fetcher/block/announces/dos", nil)
+	blockAnnounceInMeter   = metrics.NewRegisteredMeter("beacon/fetcher/block/announces/in", nil)
+	blockAnnounceOutTimer  = metrics.NewRegisteredTimer("beacon/fetcher/block/announces/out", nil)
+	blockAnnounceDropMeter = metrics.NewRegisteredMeter("beacon/fetcher/block/announces/drop", nil)
+	blockAnnounceDOSMeter  = metrics.NewRegisteredMeter("beacon/fetcher/block/announces/dos", nil)
 
-	blockBroadcastInMeter   = metrics.NewRegisteredMeter("eth/fetcher/block/broadcasts/in", nil)
-	blockBroadcastOutTimer  = metrics.NewRegisteredTimer("eth/fetcher/block/broadcasts/out", nil)
-	blockBroadcastDropMeter = metrics.NewRegisteredMeter("eth/fetcher/block/broadcasts/drop", nil)
-	blockBroadcastDOSMeter  = metrics.NewRegisteredMeter("eth/fetcher/block/broadcasts/dos", nil)
+	blockBroadcastInMeter   = metrics.NewRegisteredMeter("beacon/fetcher/block/broadcasts/in", nil)
+	blockBroadcastOutTimer  = metrics.NewRegisteredTimer("beacon/fetcher/block/broadcasts/out", nil)
+	blockBroadcastDropMeter = metrics.NewRegisteredMeter("beacon/fetcher/block/broadcasts/drop", nil)
+	blockBroadcastDOSMeter  = metrics.NewRegisteredMeter("beacon/fetcher/block/broadcasts/dos", nil)
 
-	headerFetchMeter = metrics.NewRegisteredMeter("eth/fetcher/block/headers", nil)
-	bodyFetchMeter   = metrics.NewRegisteredMeter("eth/fetcher/block/bodies", nil)
+	headerFetchMeter = metrics.NewRegisteredMeter("beacon/fetcher/block/headers", nil)
+	bodyFetchMeter   = metrics.NewRegisteredMeter("beacon/fetcher/block/bodies", nil)
 
-	headerFilterInMeter  = metrics.NewRegisteredMeter("eth/fetcher/block/filter/headers/in", nil)
-	headerFilterOutMeter = metrics.NewRegisteredMeter("eth/fetcher/block/filter/headers/out", nil)
-	bodyFilterInMeter    = metrics.NewRegisteredMeter("eth/fetcher/block/filter/bodies/in", nil)
-	bodyFilterOutMeter   = metrics.NewRegisteredMeter("eth/fetcher/block/filter/bodies/out", nil)
+	headerFilterInMeter  = metrics.NewRegisteredMeter("beacon/fetcher/block/filter/headers/in", nil)
+	headerFilterOutMeter = metrics.NewRegisteredMeter("beacon/fetcher/block/filter/headers/out", nil)
+	bodyFilterInMeter    = metrics.NewRegisteredMeter("beacon/fetcher/block/filter/bodies/in", nil)
+	bodyFilterOutMeter   = metrics.NewRegisteredMeter("beacon/fetcher/block/filter/bodies/out", nil)
 
 	blockInsertFailRecords      = mapset.NewSet[common.Hash]()
 	blockInsertFailRecordslimit = 1000
 	blockInsertFailGauge        = metrics.NewRegisteredGauge("chain/insert/failed", nil)
 )
 
+var errTerminated = errors.New("terminated")
+
 // blockRetrievalFn is a callback type for retrieving a block from the local chain.
 type blockRetrievalFn func(common.Hash) *types.Block
 
-// headerRequesterFn is a callback type for sending a header retrieval request.
-type headerRequesterFn func(string, common.Hash, chan *eth.Response) (*eth.Request, error)
+// HeaderRequesterFn is a callback type for sending a header retrieval request.
+type HeaderRequesterFn func(string, common.Hash, chan *eth.Response) (*eth.Request, error)
 
-// bodyRequesterFn is a callback type for sending a body retrieval request.
-type bodyRequesterFn func(string, []common.Hash, chan *eth.Response) (*eth.Request, error)
+// BodyRequesterFn is a callback type for sending a body retrieval request.
+type BodyRequesterFn func(string, []common.Hash, chan *eth.Response) (*eth.Request, error)
 
 // headerVerifierFn is a callback type to verify a block's header for fast propagation.
 type headerVerifierFn func(header *types.Header) error
 
-// blockBroadcasterFn is a callback type for broadcasting a block to connected peers.
-type blockBroadcasterFn func(block *types.Block, propagate bool)
+// BlockBroadcasterFn is a callback type for broadcasting a block to connected peers.
+type BlockBroadcasterFn func(block *types.Block, propagate bool)
 
 // chainHeightFn is a callback type to retrieve the current chain height.
 type chainHeightFn func() uint64
@@ -93,11 +79,11 @@ type chainHeightFn func() uint64
 // chainFinalizedHeightFn is a callback type to retrieve the current chain finalized height.
 type chainFinalizedHeightFn func() uint64
 
-// chainInsertFn is a callback type to insert a batch of blocks into the local chain.
-type chainInsertFn func(types.Blocks) (int, error)
+// ChainInsertFn is a callback type to insert a batch of blocks into the local chain.
+type ChainInsertFn func(types.Blocks) (int, error)
 
-// peerDropFn is a callback type for dropping a peer detected as malicious.
-type peerDropFn func(id string)
+// PeerDropFn is a callback type for dropping a peer detected as malicious.
+type PeerDropFn func(id string)
 
 // blockAnnounce is the hash notification of the availability of a new block in the
 // network.
@@ -180,14 +166,14 @@ type BlockFetcher struct {
 	// Callbacks
 	getBlock             blockRetrievalFn       // Retrieves a block from the local chain
 	verifyHeader         headerVerifierFn       // Checks if a block's headers have a valid proof of work
-	broadcastBlock       blockBroadcasterFn     // Broadcasts a block to connected peers
+	broadcastBlock       BlockBroadcasterFn     // Broadcasts a block to connected peers
 	chainHeight          chainHeightFn          // Retrieves the current chain's height
 	chainFinalizedHeight chainFinalizedHeightFn // Retrieves the current chain's finalized height
-	insertChain          chainInsertFn          // Injects a batch of blocks into the chain
-	dropPeer             peerDropFn             // Drops a peer for misbehaving
+	insertChain          ChainInsertFn          // Injects a batch of blocks into the chain
+	dropPeer             PeerDropFn             // Drops a peer for misbehaving
 
-	fetchHeader headerRequesterFn // Fetcher function to retrieve the header of an announced block
-	fetchBodies bodyRequesterFn   // Fetcher function to retrieve the body of an announced block
+	fetchHeader HeaderRequesterFn // Fetcher function to retrieve the header of an announced block
+	fetchBodies BodyRequesterFn   // Fetcher function to retrieve the body of an announced block
 
 	// Testing hooks
 	announceChangeHook func(common.Hash, bool)           // Method to call upon adding or deleting a hash from the blockAnnounce list
@@ -198,9 +184,9 @@ type BlockFetcher struct {
 }
 
 // NewBlockFetcher creates a block fetcher to retrieve blocks based on hash announcements.
-func NewBlockFetcher(getBlock blockRetrievalFn, verifyHeader headerVerifierFn, broadcastBlock blockBroadcasterFn,
-	chainHeight chainHeightFn, chainFinalizedHeight chainFinalizedHeightFn, insertChain chainInsertFn, dropPeer peerDropFn,
-	fetchHeader headerRequesterFn, fetchBodies bodyRequesterFn) *BlockFetcher {
+func NewBlockFetcher(getBlock blockRetrievalFn, verifyHeader headerVerifierFn, broadcastBlock BlockBroadcasterFn,
+	chainHeight chainHeightFn, chainFinalizedHeight chainFinalizedHeightFn, insertChain ChainInsertFn, dropPeer PeerDropFn,
+	fetchHeader HeaderRequesterFn, fetchBodies BodyRequesterFn) *BlockFetcher {
 	return &BlockFetcher{
 		notify:               make(chan *blockAnnounce),
 		inject:               make(chan *blockOrHeaderInject),

--- a/beacon/impl/fetcher/block_fetcher.go
+++ b/beacon/impl/fetcher/block_fetcher.go
@@ -79,8 +79,8 @@ type chainHeightFn func() uint64
 // chainFinalizedHeightFn is a callback type to retrieve the current chain finalized height.
 type chainFinalizedHeightFn func() uint64
 
-// ChainInsertFn is a callback type to insert a batch of blocks into the local chain.
-type ChainInsertFn func(types.Blocks) (int, error)
+// chainInsertFn is a callback type to insert a block into the local chain.
+type chainInsertFn func(*types.Block) error
 
 // PeerDropFn is a callback type for dropping a peer detected as malicious.
 type PeerDropFn func(id string)
@@ -169,7 +169,7 @@ type BlockFetcher struct {
 	broadcastBlock       BlockBroadcasterFn     // Broadcasts a block to connected peers
 	chainHeight          chainHeightFn          // Retrieves the current chain's height
 	chainFinalizedHeight chainFinalizedHeightFn // Retrieves the current chain's finalized height
-	insertChain          ChainInsertFn          // Injects a batch of blocks into the chain
+	insertChain          chainInsertFn          // Injects a block into the chain
 	dropPeer             PeerDropFn             // Drops a peer for misbehaving
 
 	fetchHeader HeaderRequesterFn // Fetcher function to retrieve the header of an announced block
@@ -185,7 +185,7 @@ type BlockFetcher struct {
 
 // NewBlockFetcher creates a block fetcher to retrieve blocks based on hash announcements.
 func NewBlockFetcher(getBlock blockRetrievalFn, verifyHeader headerVerifierFn, broadcastBlock BlockBroadcasterFn,
-	chainHeight chainHeightFn, chainFinalizedHeight chainFinalizedHeightFn, insertChain ChainInsertFn, dropPeer PeerDropFn,
+	chainHeight chainHeightFn, chainFinalizedHeight chainFinalizedHeightFn, insertChain chainInsertFn, dropPeer PeerDropFn,
 	fetchHeader HeaderRequesterFn, fetchBodies BodyRequesterFn) *BlockFetcher {
 	return &BlockFetcher{
 		notify:               make(chan *blockAnnounce),
@@ -840,7 +840,7 @@ func (f *BlockFetcher) importBlocks(op *blockOrHeaderInject) {
 			return
 		}
 		// Run the actual import and log any issues
-		if _, err := f.insertChain(types.Blocks{block}); err != nil {
+		if err := f.insertChain(block); err != nil {
 			if blockInsertFailRecords.Cardinality() < blockInsertFailRecordslimit {
 				blockInsertFailRecords.Add(block.Hash())
 				blockInsertFailGauge.Update(int64(blockInsertFailRecords.Cardinality()))

--- a/beacon/impl/fetcher/block_fetcher_test.go
+++ b/beacon/impl/fetcher/block_fetcher_test.go
@@ -1,19 +1,3 @@
-// Copyright 2015 The go-ethereum Authors
-// This file is part of the go-ethereum library.
-//
-// The go-ethereum library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The go-ethereum library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
-
 package fetcher
 
 import (
@@ -174,7 +158,7 @@ func (f *fetcherTester) dropPeer(peer string) {
 }
 
 // makeHeaderFetcher retrieves a block header fetcher associated with a simulated peer.
-func (f *fetcherTester) makeHeaderFetcher(blocks map[common.Hash]*types.Block, drift time.Duration) headerRequesterFn {
+func (f *fetcherTester) makeHeaderFetcher(blocks map[common.Hash]*types.Block, drift time.Duration) HeaderRequesterFn {
 	closure := make(map[common.Hash]*types.Block)
 	for hash, block := range blocks {
 		closure[hash] = block
@@ -204,7 +188,7 @@ func (f *fetcherTester) makeHeaderFetcher(blocks map[common.Hash]*types.Block, d
 }
 
 // makeBodyFetcher retrieves a block body fetcher associated with a simulated peer.
-func (f *fetcherTester) makeBodyFetcher(blocks map[common.Hash]*types.Block, drift time.Duration) bodyRequesterFn {
+func (f *fetcherTester) makeBodyFetcher(blocks map[common.Hash]*types.Block, drift time.Duration) BodyRequesterFn {
 	closure := make(map[common.Hash]*types.Block)
 	for hash, block := range blocks {
 		closure[hash] = block

--- a/beacon/impl/fetcher/block_fetcher_test.go
+++ b/beacon/impl/fetcher/block_fetcher_test.go
@@ -127,25 +127,24 @@ func (f *fetcherTester) chainFinalizedHeight() uint64 {
 	return f.blocks[f.hashes[len(f.hashes)-3]].NumberU64()
 }
 
-// insertChain injects a new blocks into the simulated chain.
-func (f *fetcherTester) insertChain(blocks types.Blocks) (int, error) {
+// insertChain injects a new block into the simulated chain.
+func (f *fetcherTester) insertChain(block *types.Block) error {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
-	for i, block := range blocks {
-		// Make sure the parent in known
-		if _, ok := f.blocks[block.ParentHash()]; !ok {
-			return i, errors.New("unknown parent")
-		}
-		// Discard any new blocks if the same height already exists
-		if block.NumberU64() <= f.blocks[f.hashes[len(f.hashes)-1]].NumberU64() {
-			return i, nil
-		}
-		// Otherwise build our current chain
-		f.hashes = append(f.hashes, block.Hash())
-		f.blocks[block.Hash()] = block
+	// Make sure the parent in known
+	if _, ok := f.blocks[block.ParentHash()]; !ok {
+		return errors.New("unknown parent")
 	}
-	return 0, nil
+	// Discard any new blocks if the same height already exists
+	if block.NumberU64() <= f.blocks[f.hashes[len(f.hashes)-1]].NumberU64() {
+		return nil
+	}
+	// Otherwise build our current chain
+	f.hashes = append(f.hashes, block.Hash())
+	f.blocks[block.Hash()] = block
+
+	return nil
 }
 
 // dropPeer is an emulator for the peer removal, simply accumulating the various
@@ -556,9 +555,9 @@ func TestImportDeduplication(t *testing.T) {
 	tester.fetcher.fetchBodies = tester.makeBodyFetcher(blocks, 0)
 
 	var counter atomic.Uint32
-	tester.fetcher.insertChain = func(blocks types.Blocks) (int, error) {
-		counter.Add(uint32(len(blocks)))
-		return tester.insertChain(blocks)
+	tester.fetcher.insertChain = func(block *types.Block) error {
+		counter.Add(1)
+		return tester.insertChain(block)
 	}
 	// Instrument the fetching and imported events
 	fetching := make(chan []common.Hash)

--- a/beacon/impl/miner/miner.go
+++ b/beacon/impl/miner/miner.go
@@ -1,0 +1,136 @@
+package miner
+
+import (
+	"sync"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/consensus"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+// Backend wraps all methods required for mining. Only full node is capable
+// to offer all the functions here.
+type Backend interface {
+	BlockChain() *core.BlockChain
+	Engine() consensus.Engine
+}
+
+// Miner is the main object which takes care of submitting new work to consensus
+// engine and gathering the sealing result.
+type Miner struct {
+	mux     *event.TypeMux
+	engine  consensus.Engine
+	exitCh  chan struct{}
+	startCh chan struct{}
+	stopCh  chan struct{}
+
+	worker *worker
+	rpc    *rpc.Client
+
+	wg sync.WaitGroup
+}
+
+func New(eth Backend, rpc *rpc.Client, mux *event.TypeMux, coinbase common.Address) *Miner {
+	miner := &Miner{
+		mux:     mux,
+		engine:  eth.Engine(),
+		exitCh:  make(chan struct{}),
+		startCh: make(chan struct{}),
+		stopCh:  make(chan struct{}),
+		worker:  newWorker(eth, rpc, mux, coinbase),
+		rpc:     rpc,
+	}
+	miner.wg.Add(1)
+	go miner.update()
+	return miner
+}
+
+// update keeps track of the downloader events. Please be aware that this is a one shot type of update loop.
+// It's entered once and as soon as `Done` or `Failed` has been broadcasted the events are unregistered and
+// the loop is exited. This to prevent a major security vuln where external parties can DOS you with blocks
+// and halt your mining operation for as long as the DOS continues.
+func (miner *Miner) update() {
+	defer miner.wg.Done()
+
+	events := miner.mux.Subscribe(downloader.StartEvent{}, downloader.DoneEvent{}, downloader.FailedEvent{})
+	defer func() {
+		if !events.Closed() {
+			events.Unsubscribe()
+		}
+	}()
+
+	shouldStart := false
+	canStart := true
+	dlEventCh := events.Chan()
+	for {
+		select {
+		case ev := <-dlEventCh:
+			if ev == nil {
+				// Unsubscription done, stop listening
+				dlEventCh = nil
+				continue
+			}
+			switch ev.Data.(type) {
+			case downloader.StartEvent:
+				wasMining := miner.Mining()
+				miner.worker.stopMining()
+				canStart = false
+				if wasMining {
+					// Resume mining after sync was finished
+					shouldStart = true
+					log.Info("Mining aborted due to sync")
+				}
+				miner.worker.syncing.Store(true)
+
+			case downloader.FailedEvent:
+				canStart = true
+				if shouldStart {
+					miner.worker.startMining()
+				}
+				miner.worker.syncing.Store(false)
+
+			case downloader.DoneEvent:
+				canStart = true
+				if shouldStart {
+					miner.worker.startMining()
+				}
+				miner.worker.syncing.Store(false)
+
+				// Stop reacting to downloader events
+				events.Unsubscribe()
+			}
+		case <-miner.startCh:
+			if canStart {
+				miner.worker.startMining()
+			}
+			shouldStart = true
+		case <-miner.stopCh:
+			shouldStart = false
+			miner.worker.stopMining()
+		case <-miner.exitCh:
+			miner.worker.close()
+			return
+		}
+	}
+}
+
+func (miner *Miner) Start() {
+	miner.startCh <- struct{}{}
+}
+
+func (miner *Miner) Stop() {
+	miner.stopCh <- struct{}{}
+}
+
+func (miner *Miner) Close() {
+	close(miner.exitCh)
+	miner.wg.Wait()
+}
+
+func (miner *Miner) Mining() bool {
+	return miner.worker.isMining()
+}

--- a/beacon/impl/miner/miner.go
+++ b/beacon/impl/miner/miner.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
@@ -17,36 +18,51 @@ import (
 type Backend interface {
 	BlockChain() *core.BlockChain
 	Engine() consensus.Engine
+
+	Synced() bool
 }
 
 // Miner is the main object which takes care of submitting new work to consensus
 // engine and gathering the sealing result.
 type Miner struct {
 	mux     *event.TypeMux
-	engine  consensus.Engine
+	backend Backend
 	exitCh  chan struct{}
 	startCh chan struct{}
 	stopCh  chan struct{}
 
 	worker *worker
-	rpc    *rpc.Client
 
 	wg sync.WaitGroup
 }
 
-func New(eth Backend, rpc *rpc.Client, mux *event.TypeMux, coinbase common.Address) *Miner {
+func New(eth Backend, rpc *rpc.Client, mux *event.TypeMux, coinbase common.Address,
+	shouldPreserve func(header *types.Header) bool) *Miner {
 	miner := &Miner{
 		mux:     mux,
-		engine:  eth.Engine(),
+		backend: eth,
 		exitCh:  make(chan struct{}),
 		startCh: make(chan struct{}),
 		stopCh:  make(chan struct{}),
-		worker:  newWorker(eth, rpc, coinbase),
-		rpc:     rpc,
+		worker:  newWorker(eth, rpc, coinbase, shouldPreserve),
 	}
 	miner.wg.Add(1)
 	go miner.update()
 	return miner
+}
+
+// DispatchBlock sends back mined block to EL.
+func (miner *Miner) DispatchBlock(block *types.Block) error {
+	// If snap sync is running, deny importing weird blocks. This is a problematic
+	// clause when starting up a new network, because snap-syncing miners might not
+	// accept each others' blocks until a restart. Unfortunately we haven't figured
+	// out a way yet where nodes can decide unilaterally whether the network is new
+	// or not. This should be fixed if we figure out a solution.
+	if !miner.backend.Synced() {
+		log.Warn("Syncing, discarded propagated block", "number", block.Number(), "hash", block.Hash())
+		return nil
+	}
+	return miner.worker.feedback(block)
 }
 
 // update keeps track of the downloader events. Please be aware that this is a one shot type of update loop.

--- a/beacon/impl/miner/miner.go
+++ b/beacon/impl/miner/miner.go
@@ -41,7 +41,7 @@ func New(eth Backend, rpc *rpc.Client, mux *event.TypeMux, coinbase common.Addre
 		exitCh:  make(chan struct{}),
 		startCh: make(chan struct{}),
 		stopCh:  make(chan struct{}),
-		worker:  newWorker(eth, rpc, mux, coinbase),
+		worker:  newWorker(eth, rpc, coinbase),
 		rpc:     rpc,
 	}
 	miner.wg.Add(1)

--- a/beacon/impl/miner/miner_test.go
+++ b/beacon/impl/miner/miner_test.go
@@ -1,5 +1,4 @@
-// Package beacon implements minimized Ethereum beacon client.
-package impl
+package miner
 
 import (
 	"math/big"
@@ -41,137 +40,137 @@ func (m *mockBackend) Engine() consensus.Engine {
 	return m.engine
 }
 
-func TestBeacon(t *testing.T) {
+func TestMiner(t *testing.T) {
 	t.Parallel()
-	beacon, mux, cleanup := createBeacon(t)
+	miner, mux, cleanup := createMiner(t)
 	defer cleanup(false)
 
-	beacon.Start()
-	waitForMiningState(t, beacon, true)
+	miner.Start()
+	waitForMiningState(t, miner, true)
 	// Start the downloader
 	mux.Post(downloader.StartEvent{})
-	waitForMiningState(t, beacon, false)
+	waitForMiningState(t, miner, false)
 	// Stop the downloader and wait for the update loop to run
 	mux.Post(downloader.DoneEvent{})
-	waitForMiningState(t, beacon, true)
+	waitForMiningState(t, miner, true)
 
 	// Subsequent downloader events after a successful DoneEvent should not cause the
-	// beacon to start or stop. This prevents a security vulnerability
+	// miner to start or stop. This prevents a security vulnerability
 	// that would allow entities to present fake high blocks that would
 	// stop mining operations by causing a downloader sync
 	// until it was discovered they were invalid, whereon mining would resume.
 	mux.Post(downloader.StartEvent{})
-	waitForMiningState(t, beacon, true)
+	waitForMiningState(t, miner, true)
 
 	mux.Post(downloader.FailedEvent{})
-	waitForMiningState(t, beacon, true)
+	waitForMiningState(t, miner, true)
 }
 
-// TestBeaconDownloaderFirstFails tests that mining is only
+// TestMinerDownloaderFirstFails tests that mining is only
 // permitted to run indefinitely once the downloader sees a DoneEvent (success).
 // An initial FailedEvent should allow mining to stop on a subsequent
 // downloader StartEvent.
-func TestBeaconDownloaderFirstFails(t *testing.T) {
+func TestMinerDownloaderFirstFails(t *testing.T) {
 	t.Parallel()
-	beacon, mux, cleanup := createBeacon(t)
+	miner, mux, cleanup := createMiner(t)
 	defer cleanup(false)
 
-	beacon.Start()
-	waitForMiningState(t, beacon, true)
+	miner.Start()
+	waitForMiningState(t, miner, true)
 	// Start the downloader
 	mux.Post(downloader.StartEvent{})
-	waitForMiningState(t, beacon, false)
+	waitForMiningState(t, miner, false)
 
 	// Stop the downloader and wait for the update loop to run
 	mux.Post(downloader.FailedEvent{})
-	waitForMiningState(t, beacon, true)
+	waitForMiningState(t, miner, true)
 
 	// Since the downloader hasn't yet emitted a successful DoneEvent,
-	// we expect the beacon to stop on next StartEvent.
+	// we expect the miner to stop on next StartEvent.
 	mux.Post(downloader.StartEvent{})
-	waitForMiningState(t, beacon, false)
+	waitForMiningState(t, miner, false)
 
 	// Downloader finally succeeds.
 	mux.Post(downloader.DoneEvent{})
-	waitForMiningState(t, beacon, true)
+	waitForMiningState(t, miner, true)
 
 	// Downloader starts again.
-	// Since it has achieved a DoneEvent once, we expect beacon
+	// Since it has achieved a DoneEvent once, we expect miner
 	// state to be unchanged.
 	mux.Post(downloader.StartEvent{})
-	waitForMiningState(t, beacon, true)
+	waitForMiningState(t, miner, true)
 
 	mux.Post(downloader.FailedEvent{})
-	waitForMiningState(t, beacon, true)
+	waitForMiningState(t, miner, true)
 }
 
-func TestBeaconStartStopAfterDownloaderEvents(t *testing.T) {
+func TestMinerStartStopAfterDownloaderEvents(t *testing.T) {
 	t.Parallel()
-	beacon, mux, cleanup := createBeacon(t)
+	miner, mux, cleanup := createMiner(t)
 	defer cleanup(false)
 
-	beacon.Start()
-	waitForMiningState(t, beacon, true)
+	miner.Start()
+	waitForMiningState(t, miner, true)
 	// Start the downloader
 	mux.Post(downloader.StartEvent{})
-	waitForMiningState(t, beacon, false)
+	waitForMiningState(t, miner, false)
 
 	// Downloader finally succeeds.
 	mux.Post(downloader.DoneEvent{})
-	waitForMiningState(t, beacon, true)
+	waitForMiningState(t, miner, true)
 
-	beacon.Stop()
-	waitForMiningState(t, beacon, false)
+	miner.Stop()
+	waitForMiningState(t, miner, false)
 
-	beacon.Start()
-	waitForMiningState(t, beacon, true)
+	miner.Start()
+	waitForMiningState(t, miner, true)
 
-	beacon.Stop()
-	waitForMiningState(t, beacon, false)
+	miner.Stop()
+	waitForMiningState(t, miner, false)
 }
 
 func TestStartWhileDownload(t *testing.T) {
 	t.Parallel()
-	beacon, mux, cleanup := createBeacon(t)
+	miner, mux, cleanup := createMiner(t)
 	defer cleanup(false)
-	waitForMiningState(t, beacon, false)
-	beacon.Start()
-	waitForMiningState(t, beacon, true)
+	waitForMiningState(t, miner, false)
+	miner.Start()
+	waitForMiningState(t, miner, true)
 	// Stop the downloader and wait for the update loop to run
 	mux.Post(downloader.StartEvent{})
-	waitForMiningState(t, beacon, false)
-	// Starting the beacon after the downloader should not work
-	beacon.Start()
-	waitForMiningState(t, beacon, false)
+	waitForMiningState(t, miner, false)
+	// Starting the miner after the downloader should not work
+	miner.Start()
+	waitForMiningState(t, miner, false)
 }
 
-func TestStartStopBeacon(t *testing.T) {
+func TestStartStopMiner(t *testing.T) {
 	t.Parallel()
-	beacon, _, cleanup := createBeacon(t)
+	miner, _, cleanup := createMiner(t)
 	defer cleanup(false)
-	waitForMiningState(t, beacon, false)
-	beacon.Start()
-	waitForMiningState(t, beacon, true)
-	beacon.Stop()
-	waitForMiningState(t, beacon, false)
+	waitForMiningState(t, miner, false)
+	miner.Start()
+	waitForMiningState(t, miner, true)
+	miner.Stop()
+	waitForMiningState(t, miner, false)
 }
 
-func TestCloseBeacon(t *testing.T) {
+func TestCloseMiner(t *testing.T) {
 	t.Parallel()
-	beacon, _, cleanup := createBeacon(t)
+	miner, _, cleanup := createMiner(t)
 	defer cleanup(true)
-	waitForMiningState(t, beacon, false)
-	beacon.Start()
-	waitForMiningState(t, beacon, true)
-	// Terminate the beacon and wait for the update loop to run
-	beacon.Close()
-	waitForMiningState(t, beacon, false)
+	waitForMiningState(t, miner, false)
+	miner.Start()
+	waitForMiningState(t, miner, true)
+	// Terminate the miner and wait for the update loop to run
+	miner.Close()
+	waitForMiningState(t, miner, false)
 }
 
 // waitForMiningState waits until either
 // * the desired mining state was reached
 // * a timeout was reached which fails the test
-func waitForMiningState(t *testing.T, m *Beacon, mining bool) {
+func waitForMiningState(t *testing.T, m *Miner, mining bool) {
 	t.Helper()
 
 	var state bool
@@ -184,7 +183,7 @@ func waitForMiningState(t *testing.T, m *Beacon, mining bool) {
 	t.Fatalf("Mining() == %t, want %t", state, mining)
 }
 
-func beaconTestGenesisBlock(period uint64, gasLimit uint64, faucet common.Address) *core.Genesis {
+func minerTestGenesisBlock(period uint64, gasLimit uint64, faucet common.Address) *core.Genesis {
 	config := *params.AllCliqueProtocolChanges
 	config.Clique = &params.CliqueConfig{
 		Period: period,
@@ -213,13 +212,13 @@ func beaconTestGenesisBlock(period uint64, gasLimit uint64, faucet common.Addres
 	}
 }
 
-func createBeacon(t *testing.T) (*Beacon, *event.TypeMux, func(skipBeacon bool)) {
+func createMiner(t *testing.T) (*Miner, *event.TypeMux, func(skipMiner bool)) {
 	// Init coinbase
 	etherbase := common.HexToAddress("123456789")
 	// Create chainConfig
 	chainDB := rawdb.NewMemoryDatabase()
 	triedb := triedb.NewDatabase(chainDB, nil)
-	genesis := beaconTestGenesisBlock(15, 11_500_000, common.HexToAddress("12345"))
+	genesis := minerTestGenesisBlock(15, 11_500_000, common.HexToAddress("12345"))
 	chainConfig, _, _, err := core.SetupGenesisBlock(chainDB, triedb, genesis)
 	if err != nil {
 		t.Fatalf("can't create new chain config: %v", err)
@@ -232,18 +231,18 @@ func createBeacon(t *testing.T) (*Beacon, *event.TypeMux, func(skipBeacon bool))
 		t.Fatalf("can't create new chain %v", err)
 	}
 
-	// Create Beacon
+	// Create Miner
 	backend := NewMockBackend(bc, engine)
 	// Create event Mux
 	mux := new(event.TypeMux)
-	// Create Beacon
-	beacon := New(backend, &rpc.Client{}, mux, etherbase)
-	cleanup := func(skipBeacon bool) {
+	// Create Miner
+	miner := New(backend, &rpc.Client{}, mux, etherbase)
+	cleanup := func(skipMiner bool) {
 		bc.Stop()
 		engine.Close()
-		if !skipBeacon {
-			beacon.Close()
+		if !skipMiner {
+			miner.Close()
 		}
 	}
-	return beacon, mux, cleanup
+	return miner, mux, cleanup
 }

--- a/beacon/impl/miner/miner_test.go
+++ b/beacon/impl/miner/miner_test.go
@@ -40,6 +40,10 @@ func (m *mockBackend) Engine() consensus.Engine {
 	return m.engine
 }
 
+func (m *mockBackend) Synced() bool {
+	panic("not implemented")
+}
+
 func TestMiner(t *testing.T) {
 	t.Parallel()
 	miner, mux, cleanup := createMiner(t)
@@ -236,7 +240,10 @@ func createMiner(t *testing.T) (*Miner, *event.TypeMux, func(skipMiner bool)) {
 	// Create event Mux
 	mux := new(event.TypeMux)
 	// Create Miner
-	miner := New(backend, &rpc.Client{}, mux, etherbase)
+	shouldPreserve := func(_ *types.Header) bool {
+		return false
+	}
+	miner := New(backend, &rpc.Client{}, mux, etherbase, shouldPreserve)
 	cleanup := func(skipMiner bool) {
 		bc.Stop()
 		engine.Close()

--- a/beacon/impl/miner/worker.go
+++ b/beacon/impl/miner/worker.go
@@ -1,4 +1,4 @@
-package impl
+package miner
 
 import (
 	"context"

--- a/beacon/impl/miner/worker.go
+++ b/beacon/impl/miner/worker.go
@@ -4,16 +4,15 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"math/big"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/beacon/engine"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
@@ -28,23 +27,19 @@ const (
 
 	// chainHeadChanSize is the size of channel listening to ChainHeadEvent.
 	chainHeadChanSize = 10
-
-	// staleThreshold is the maximum depth of the acceptable stale block.
-	staleThreshold = 0
 )
 
 // newWorkReq represents a request for new sealing work submitting.
 type newWorkReq struct {
-	event     core.ChainHeadEvent
 	timestamp uint64
 }
 
 // task contains all information for consensus engine sealing and result submitting.
 type task struct {
-	receipts  []*types.Receipt
-	state     *state.StateDB
-	block     *types.Block
-	createdAt time.Time
+	block           *types.Block
+	versionedHashes []common.Hash
+	requests        [][]byte
+	createdAt       time.Time
 }
 
 // worker is the main object which takes care of submitting new work to consensus engine
@@ -53,6 +48,7 @@ type worker struct {
 	chainConfig  *params.ChainConfig
 	engine       consensus.Engine
 	chain        *core.BlockChain
+	forker       *core.ForkChoice
 	rpc          *rpc.Client
 	feeRecipient common.Address
 
@@ -69,20 +65,20 @@ type worker struct {
 
 	wg sync.WaitGroup
 
-	// Cache indexed by sealing hash
-	pendingMu    sync.RWMutex
-	pendingTasks map[common.Hash]*task
-
 	// Atomic status counters
 	mining  atomic.Bool // The indicator whether the consensus engine is running or not.
 	syncing atomic.Bool // The indicator whether the node is still syncing.
+
+	// Mutex to prevent parallel fork request.
+	forkMu sync.Mutex
 }
 
-func newWorker(eth Backend, rpc *rpc.Client, feeRecipient common.Address) *worker {
+func newWorker(eth Backend, rpc *rpc.Client, feeRecipient common.Address, shouldPreserve func(header *types.Header) bool) *worker {
 	worker := &worker{
 		chainConfig:  eth.BlockChain().Config(),
 		engine:       eth.Engine(),
 		chain:        eth.BlockChain(),
+		forker:       core.NewForkChoice(eth.BlockChain(), shouldPreserve),
 		rpc:          rpc,
 		feeRecipient: feeRecipient,
 		chainHeadCh:  make(chan core.ChainHeadEvent, chainHeadChanSize),
@@ -91,16 +87,14 @@ func newWorker(eth Backend, rpc *rpc.Client, feeRecipient common.Address) *worke
 		resultCh:     make(chan *types.Block, resultQueueSize),
 		startCh:      make(chan struct{}, 1),
 		exitCh:       make(chan struct{}),
-		pendingTasks: make(map[common.Hash]*task),
 	}
 
 	// Subscribe events for blockchain
 	worker.chainHeadSub = eth.BlockChain().SubscribeChainHeadEvent(worker.chainHeadCh)
 
-	worker.wg.Add(4)
+	worker.wg.Add(3)
 	go worker.mainLoop()
 	go worker.newWorkLoop()
-	go worker.resultLoop()
 	go worker.taskLoop()
 
 	return worker
@@ -133,42 +127,23 @@ func (w *worker) close() {
 // newWorkLoop is a standalone goroutine to submit new sealing work upon received events.
 func (w *worker) newWorkLoop() {
 	defer w.wg.Done()
-	var (
-		timestamp uint64 // timestamp for each round of sealing.
-	)
 
 	// commit aborts in-flight transaction execution with given signal and resubmits a new one.
-	commit := func(event core.ChainHeadEvent) {
+	commit := func(timestamp uint64) {
 		select {
-		case w.newWorkCh <- &newWorkReq{event: event, timestamp: timestamp}:
+		case w.newWorkCh <- &newWorkReq{timestamp: timestamp}:
 		case <-w.exitCh:
 			return
 		}
 	}
-	// clearPending cleans the stale pending tasks.
-	clearPending := func(number uint64) {
-		w.pendingMu.Lock()
-		for h, t := range w.pendingTasks {
-			if t.block.NumberU64()+staleThreshold <= number {
-				delete(w.pendingTasks, h)
-			}
-		}
-		w.pendingMu.Unlock()
-	}
 
 	for {
 		select {
-		case <-w.startCh: // Trigger a new check manually.
-			clearPending(w.chain.CurrentBlock().Number.Uint64())
-			timestamp = uint64(time.Now().Unix())
-			commit(core.ChainHeadEvent{
-				Header: w.chain.CurrentBlock(),
-			})
+		case <-w.startCh: // Trigger a new build manually.
+			commit(uint64(time.Now().Unix()))
 
-		case head := <-w.chainHeadCh: // A new head from network, commit a miner check.
-			clearPending(head.Header.Number.Uint64())
-			timestamp = uint64(time.Now().Unix())
-			commit(head)
+		case <-w.chainHeadCh: // A new head from network, commit a miner check.
+			commit(uint64(time.Now().Unix()))
 
 		case <-w.exitCh:
 			return
@@ -186,7 +161,7 @@ func (w *worker) mainLoop() {
 	for {
 		select {
 		case req := <-w.newWorkCh:
-			w.requestWork(req.event, req.timestamp)
+			w.requestWork(req.timestamp)
 
 		// System stopped
 		case <-w.exitCh:
@@ -204,83 +179,9 @@ func (w *worker) taskLoop() {
 	for {
 		select {
 		case task := <-w.taskCh:
-			sealHash := w.engine.SealHash(task.block.Header())
-			w.pendingMu.Lock()
-			w.pendingTasks[sealHash] = task
-			w.pendingMu.Unlock()
 			if err := w.engine.Seal(w.chain, task.block, w.resultCh); err != nil {
 				log.Warn("Block sealing failed", "err", err)
-				w.pendingMu.Lock()
-				delete(w.pendingTasks, sealHash)
-				w.pendingMu.Unlock()
 			}
-		case <-w.exitCh:
-			return
-		}
-	}
-}
-
-// resultLoop is a standalone goroutine to handle sealing result submitting
-// and flush relative data to the database.
-func (w *worker) resultLoop() {
-	defer w.wg.Done()
-	for {
-		select {
-		case block := <-w.resultCh:
-			// Short circuit when receiving empty result.
-			if block == nil {
-				continue
-			}
-			// Short circuit when receiving duplicate result caused by resubmitting.
-			if w.chain.HasBlock(block.Hash(), block.NumberU64()) {
-				continue
-			}
-			var (
-				sealhash = w.engine.SealHash(block.Header())
-				hash     = block.Hash()
-			)
-			w.pendingMu.RLock()
-			task, exist := w.pendingTasks[sealhash]
-			w.pendingMu.RUnlock()
-			if !exist {
-				log.Error("Block found but no relative pending task", "number", block.Number(), "sealhash", sealhash, "hash", hash)
-				continue
-			}
-			// Different block could share same sealhash, deep copy here to prevent write-write conflict.
-			var (
-				receipts = make([]*types.Receipt, len(task.receipts))
-				logs     []*types.Log
-			)
-			for i, taskReceipt := range task.receipts {
-				receipt := new(types.Receipt)
-				receipts[i] = receipt
-				*receipt = *taskReceipt
-
-				// add block location fields
-				receipt.BlockHash = hash
-				receipt.BlockNumber = block.Number()
-				receipt.TransactionIndex = uint(i)
-
-				// Update the block hash in all logs since it is now available and not when the
-				// receipt/log of individual transactions were created.
-				receipt.Logs = make([]*types.Log, len(taskReceipt.Logs))
-				for i, taskLog := range taskReceipt.Logs {
-					log := new(types.Log)
-					receipt.Logs[i] = log
-					*log = *taskLog
-					log.BlockHash = hash
-				}
-				logs = append(logs, receipt.Logs...)
-			}
-			// Commit block and state to database.
-			_, err := w.chain.WriteBlockAndSetHead(block, receipts, logs, task.state, true)
-			if err != nil {
-				log.Error("Failed writing block to chain", "err", err)
-				continue
-			}
-			log.Info("Successfully sealed new block", "number", block.Number(), "sealhash", sealhash, "hash", hash,
-				"elapsed", common.PrettyDuration(time.Since(task.createdAt)))
-
 		case <-w.exitCh:
 			return
 		}
@@ -288,74 +189,57 @@ func (w *worker) resultLoop() {
 }
 
 // requestWork requests a new sealing task from EL miner through RPC.
-func (w *worker) requestWork(event core.ChainHeadEvent, timestamp uint64) {
+func (w *worker) requestWork(timestamp uint64) {
 	// Abort committing if node is still syncing
 	if w.syncing.Load() {
 		return
 	}
-	start := time.Now()
-
-	// Find a proper latest header, and use it as parent.
-	if event.Header == nil {
-		log.Error("Missing parent")
+	if !w.isMining() {
 		return
 	}
+	start := time.Now()
 
-	// Send the latest head info to EL.
-	resp, err := w.sendForkChoice(event.Header.Hash(), timestamp)
+	// Trigger payload build through the fork choice request.
+	resp, err := w.sendForkChoice(w.chain.CurrentHeader(), timestamp, true)
 	if err != nil {
 		log.Error("Failed to prepare payload", "err", err)
 		return
 	}
+	if resp.PayloadID == nil {
+		log.Error("Missing payload ID")
+		return
+	}
+	payload, err := w.getPayload(resp.PayloadID)
+	if err != nil {
+		log.Error("Failed to fetch payload", "err", err)
+		return
+	}
 
-	// Get the EL payload through RPC request, if there is one.
-	if resp.PayloadID != nil {
-		payload, err := w.getPayload(resp.PayloadID, timestamp)
-		if err != nil {
-			log.Error("Failed to fetch payload", "err", err)
-			return
-		}
+	// Rebuild the block from execution payload.
+	var versionedHashes []common.Hash
+	for _, commitment := range payload.BlobsBundle.Commitments {
+		versionedHashes = append(versionedHashes, convertKzgCommitmentToVersionedHash(commitment))
+	}
+	block, err := engine.ExecutableDataToBlock(*payload.ExecutionPayload, versionedHashes, &types.EmptyRootHash, payload.Requests)
+	if err != nil {
+		log.Error("Failed to rebuild full block", "err", err)
+		return
+	}
 
-		// Rebuild the block from execution payload.
-		var versionedHashes []common.Hash
-		for _, commitment := range payload.BlobsBundle.Commitments {
-			versionedHashes = append(versionedHashes, convertKzgCommitmentToVersionedHash(commitment))
-		}
-		block, err := engine.ExecutableDataToBlock(*payload.ExecutionPayload, versionedHashes, &types.EmptyRootHash, payload.Requests)
-		if err != nil {
-			log.Error("Failed to rebuild full block", "err", err)
-			return
-		}
-
-		// Submit the generated block for consensus sealing.
-		err = w.commit(block, start)
-		if err != nil {
-			log.Error("Failed to commit payload", "err", err)
-			return
-		}
+	// Submit the generated block for consensus sealing.
+	err = w.commit(block, versionedHashes, payload.Requests, start)
+	if err != nil {
+		log.Error("Failed to commit payload", "err", err)
+		return
 	}
 }
 
 // commit commits new work to consensus engine.
-func (w *worker) commit(block *types.Block, start time.Time) error {
-	// Execute the transactions of the block to get the state and receipts.
-	parent := w.chain.GetHeader(block.Header().ParentHash, block.Header().Number.Uint64()-1)
-	parentState, err := w.chain.StateAt(parent.Root)
-	if err != nil {
-		return err
-	}
-	state, res, err := w.chain.ProcessState(block, parentState)
-	if err != nil {
-		return err
-	}
-
+func (w *worker) commit(block *types.Block, versionedHashes []common.Hash, requests [][]byte, start time.Time) error {
 	select {
-	case w.taskCh <- &task{receipts: res.Receipts, state: state, block: block, createdAt: time.Now()}:
-		fees := totalFees(block, res.Receipts)
-		feesInEther := new(big.Float).Quo(new(big.Float).SetInt(fees), big.NewFloat(params.Ether))
+	case w.taskCh <- &task{block: block, versionedHashes: versionedHashes, requests: requests, createdAt: time.Now()}:
 		log.Info("Commit new sealing work", "number", block.Number(), "sealhash", w.engine.SealHash(block.Header()),
-			"txs", len(block.Transactions()), "gas", block.GasUsed(), "fees", feesInEther,
-			"elapsed", common.PrettyDuration(time.Since(start)))
+			"txs", len(block.Transactions()), "gas", block.GasUsed(), "elapsed", common.PrettyDuration(time.Since(start)))
 
 	case <-w.exitCh:
 		log.Info("Worker has exited")
@@ -363,15 +247,62 @@ func (w *worker) commit(block *types.Block, start time.Time) error {
 	return nil
 }
 
+// feedback sends signed block back to EL for execution.
+func (w *worker) feedback(block *types.Block) error {
+	payload := engine.BlockToExecutableData(block, nil, nil, nil)
+	var executionRequests []hexutil.Bytes
+	if w.chainConfig.IsPrague(block.Number(), block.Time()) {
+		executionRequests = []hexutil.Bytes{}
+	}
+
+	// Collect requests.
+	_, res, err := w.chain.ProcessState(block, nil)
+	if err != nil {
+		return err
+	}
+	for _, v := range res.Requests {
+		executionRequests = append(executionRequests, v)
+	}
+
+	// Send payload through RPC. TODO: collect and include versioned hashes if possible
+	status, err := w.sendPayload(payload.ExecutionPayload, make([]common.Hash, 0), &types.EmptyRootHash, executionRequests, block.Time())
+	if err != nil {
+		return err
+	}
+	if status.Status == engine.INVALID {
+		return fmt.Errorf("block rejected by EL, err: %v", *status.ValidationError)
+	}
+
+	// Set head based on reorg check.
+	reorg, err := w.forker.ReorgNeeded(w.chain.CurrentHeader(), block.Header())
+	if err != nil {
+		return err
+	}
+	if !reorg {
+		return nil
+	}
+	// Send the latest head info to EL.
+	resp, err := w.sendForkChoice(block.Header(), block.Time(), false)
+	if err != nil {
+		return err
+	}
+	if resp.PayloadStatus.Status != engine.VALID {
+		return fmt.Errorf("set head failed, status: %v", resp.PayloadStatus.Status)
+	}
+	return nil
+}
+
 // sendForkChoice sends new chain head information to EL miner API through RPC.
-func (w *worker) sendForkChoice(headHash common.Hash, timestamp uint64) (engine.ForkChoiceResponse, error) {
+func (w *worker) sendForkChoice(head *types.Header, timestamp uint64, requestMine bool) (engine.ForkChoiceResponse, error) {
+	w.forkMu.Lock()
+	defer w.forkMu.Unlock()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
 	update := engine.ForkchoiceStateV1{
-		HeadBlockHash:      headHash,
-		SafeBlockHash:      common.Hash{},
-		FinalizedBlockHash: common.Hash{},
+		HeadBlockHash:      head.Hash(),
+		SafeBlockHash:      head.ParentHash,
+		FinalizedBlockHash: head.ParentHash,
 	}
 	attributes := engine.PayloadAttributes{
 		Timestamp:             timestamp,
@@ -397,7 +328,7 @@ func (w *worker) sendForkChoice(headHash common.Hash, timestamp uint64) (engine.
 
 	// Set mining attributes only when the worker is set to be mining.
 	var err error
-	if w.isMining() {
+	if requestMine {
 		err = w.rpc.CallContext(ctx, &resp, forkChoiceMethod, update, attributes)
 	} else {
 		err = w.rpc.CallContext(ctx, &resp, forkChoiceMethod, update, nil)
@@ -409,21 +340,19 @@ func (w *worker) sendForkChoice(headHash common.Hash, timestamp uint64) (engine.
 }
 
 // getPayload requests new block payload from EL miner through RPC.
-func (w *worker) getPayload(payloadID *engine.PayloadID, timestamp uint64) (engine.ExecutionPayloadEnvelope, error) {
+func (w *worker) getPayload(payloadID *engine.PayloadID) (engine.ExecutionPayloadEnvelope, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 
 	var getPayloadMethod string
 	var payload engine.ExecutionPayloadEnvelope
-	switch w.chain.Config().LatestFork(timestamp) {
-	case forks.Paris, forks.Shanghai:
+	switch payloadID.Version() {
+	case engine.PayloadV1, engine.PayloadV2:
 		getPayloadMethod = "engine_getPayloadV2"
-	case forks.Cancun:
-		getPayloadMethod = "engine_getPayloadV3"
-	case forks.Prague:
+	case engine.PayloadV3:
 		getPayloadMethod = "engine_getPayloadV4"
 	default:
-		return engine.ExecutionPayloadEnvelope{}, fmt.Errorf("fork %s is not supported for engine_getPayload", w.chain.Config().LatestFork(timestamp).String())
+		return engine.ExecutionPayloadEnvelope{}, fmt.Errorf("version %v is not supported for engine_getPayload", payloadID.Version())
 	}
 	err := w.rpc.CallContext(ctx, &payload, getPayloadMethod, payloadID)
 	if err != nil {
@@ -432,15 +361,28 @@ func (w *worker) getPayload(payloadID *engine.PayloadID, timestamp uint64) (engi
 	return payload, nil
 }
 
-// totalFees computes total consumed miner fees in Wei. Block transactions and receipts have to have the same order.
-func totalFees(block *types.Block, receipts []*types.Receipt) *big.Int {
-	feesWei := new(big.Int)
-	for i, tx := range block.Transactions() {
-		minerFee, _ := tx.EffectiveGasTip(block.BaseFee())
-		feesWei.Add(feesWei, new(big.Int).Mul(new(big.Int).SetUint64(receipts[i].GasUsed), minerFee))
-		// TODO (MariusVanDerWijden) add blob fees
+// sendPayload sends new block back to EL through RPC.
+func (w *worker) sendPayload(payload *engine.ExecutableData, versionedHashes []common.Hash, beaconRoot *common.Hash, executionRequests []hexutil.Bytes, timestamp uint64) (engine.PayloadStatusV1, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	var newPayloadMethod string
+	var status engine.PayloadStatusV1
+	switch w.chain.Config().LatestFork(timestamp) {
+	case forks.Paris, forks.Shanghai:
+		newPayloadMethod = "engine_newPayloadV2"
+	case forks.Cancun:
+		newPayloadMethod = "engine_newPayloadV3"
+	case forks.Prague:
+		newPayloadMethod = "engine_newPayloadV4"
+	default:
+		return engine.PayloadStatusV1{}, fmt.Errorf("fork %s is not supported for engine_getPayload", w.chain.Config().LatestFork(timestamp).String())
 	}
-	return feesWei
+	err := w.rpc.CallContext(ctx, &status, newPayloadMethod, payload, versionedHashes, beaconRoot, executionRequests)
+	if err != nil {
+		return engine.PayloadStatusV1{}, err
+	}
+	return status, nil
 }
 
 const blobCommitmentVersionKZG uint8 = 0x01

--- a/beacon/impl/miner/worker.go
+++ b/beacon/impl/miner/worker.go
@@ -57,7 +57,6 @@ type worker struct {
 	feeRecipient common.Address
 
 	// Subscriptions
-	mux          *event.TypeMux
 	chainHeadCh  chan core.ChainHeadEvent
 	chainHeadSub event.Subscription
 
@@ -79,13 +78,12 @@ type worker struct {
 	syncing atomic.Bool // The indicator whether the node is still syncing.
 }
 
-func newWorker(eth Backend, rpc *rpc.Client, mux *event.TypeMux, feeRecipient common.Address) *worker {
+func newWorker(eth Backend, rpc *rpc.Client, feeRecipient common.Address) *worker {
 	worker := &worker{
 		chainConfig:  eth.BlockChain().Config(),
 		engine:       eth.Engine(),
 		chain:        eth.BlockChain(),
 		rpc:          rpc,
-		mux:          mux,
 		feeRecipient: feeRecipient,
 		chainHeadCh:  make(chan core.ChainHeadEvent, chainHeadChanSize),
 		newWorkCh:    make(chan *newWorkReq),
@@ -282,9 +280,6 @@ func (w *worker) resultLoop() {
 			}
 			log.Info("Successfully sealed new block", "number", block.Number(), "sealhash", sealhash, "hash", hash,
 				"elapsed", common.PrettyDuration(time.Since(task.createdAt)))
-
-			// Broadcast the block and announce chain insertion event
-			w.mux.Post(core.NewMinedBlockEvent{Block: block})
 
 		case <-w.exitCh:
 			return

--- a/consensus/dbft/blockqueue.go
+++ b/consensus/dbft/blockqueue.go
@@ -1,19 +1,16 @@
 package dbft
 
 import (
-	"fmt"
-
-	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
-	"github.com/ethereum/go-ethereum/log"
 )
 
 // blockQueue is an entity that collects sealed blocks from dBFT and stores these
 // blocks in the chain.
 type blockQueue struct {
-	chain ChainHeaderWriter
-	feed  *event.Feed
+	chain       ChainHeaderReader
+	feed        *event.Feed
+	insertChain ChainInsertFn
 }
 
 // newBlockQueue creates an instance of blockQueue. It's not ready for usage until
@@ -24,60 +21,24 @@ func newBlockQueue(feed *event.Feed) *blockQueue {
 	}
 }
 
-// SetChain initializes ChainHeaderWriter instanse needed for proper blockQueue
+// SetChain initializes ChainHeaderReader instanse needed for proper blockQueue
 // functioning.
-func (bq *blockQueue) SetChain(chain ChainHeaderWriter) {
+func (bq *blockQueue) SetChain(chain ChainHeaderReader, inserter ChainInsertFn) {
 	bq.chain = chain
+	bq.insertChain = inserter
 }
 
-// PutBlock routs block either to miner or (if there's no suitable sealing task)
-// directly to blockchain. No block verification is performed, it is assumed that
-// provided block is sealed and valid.
-func (bq *blockQueue) PutBlock(b *types.Block, state *state.StateDB, receipts []*types.Receipt) error {
+// PutBlock routes block to blockchain. No block verification is performed, it is
+// assumed that provided block is sealed and valid.
+func (bq *blockQueue) PutBlock(b *types.Block) error {
 	hash := b.Hash()
 	if bq.chain.HasBlock(hash, b.NumberU64()) {
 		return nil
 	}
 
-	// Short circuit if we don't have pre-calculated state (it's possible only in case of
-	// reorg if dBFT tries to insert new parent during PrepareRequest construction).
-	if state == nil {
-		_, err := bq.chain.InsertChain(types.Blocks{b})
-		if err != nil {
-			return fmt.Errorf("failed to insert block into chain: %w", err)
-		}
-		log.Info("Successfully inserted new block", "number", b.Number(), "hash", hash)
-
-		// Broadcast the block and announce chain insertion event
-		bq.feed.Send(b)
-		return nil
+	if err := bq.insertChain(b); err != nil {
+		return err
 	}
-
-	currH := bq.chain.CurrentBlock().Number
-	// Insert state directly if we have one.
-	var logs []*types.Log
-	for i, receipt := range receipts {
-		// Add block location fields.
-		receipt.BlockHash = hash
-		receipt.BlockNumber = b.Number()
-		receipt.TransactionIndex = uint(i)
-
-		// Update the block hash in all logs since it is now available and not when the
-		// receipt/log of individual transactions were created.
-		for _, taskLog := range receipt.Logs {
-			taskLog.BlockHash = hash
-		}
-		logs = append(logs, receipt.Logs...)
-	}
-	// Commit block and state to database.
-	_, err := bq.chain.WriteBlockAndSetHead(b, receipts, logs, state, b.Number().Cmp(currH) > 0)
-	if err != nil {
-		log.Error("Failed to write block to chain and set head",
-			"number", b.NumberU64(),
-			"err", err)
-		return fmt.Errorf("failed to write block into chain: %w", err)
-	}
-	log.Info("Successfully wrote new block with state", "number", b.Number(), "hash", hash)
 
 	// Broadcast the block and announce chain insertion event
 	bq.feed.Send(b)

--- a/consensus/dbft/blockqueue.go
+++ b/consensus/dbft/blockqueue.go
@@ -3,7 +3,6 @@ package dbft
 import (
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/event"
@@ -14,24 +13,21 @@ import (
 // blocks in the chain.
 type blockQueue struct {
 	chain ChainHeaderWriter
-	mux   *event.TypeMux
+	feed  *event.Feed
 }
 
 // newBlockQueue creates an instance of blockQueue. It's not ready for usage until
 // an instance of ChainHeaderWriter is properly set.
-func newBlockQueue() *blockQueue {
-	return &blockQueue{}
+func newBlockQueue(feed *event.Feed) *blockQueue {
+	return &blockQueue{
+		feed: feed,
+	}
 }
 
 // SetChain initializes ChainHeaderWriter instanse needed for proper blockQueue
 // functioning.
 func (bq *blockQueue) SetChain(chain ChainHeaderWriter) {
 	bq.chain = chain
-}
-
-// SetMux initializes mux instanse needed for proper blockQueue functioning.
-func (bq *blockQueue) SetMux(mux *event.TypeMux) {
-	bq.mux = mux
 }
 
 // PutBlock routs block either to miner or (if there's no suitable sealing task)
@@ -53,8 +49,7 @@ func (bq *blockQueue) PutBlock(b *types.Block, state *state.StateDB, receipts []
 		log.Info("Successfully inserted new block", "number", b.Number(), "hash", hash)
 
 		// Broadcast the block and announce chain insertion event
-		bq.mux.Post(core.NewMinedBlockEvent{Block: b})
-		
+		bq.feed.Send(b)
 		return nil
 	}
 
@@ -85,7 +80,6 @@ func (bq *blockQueue) PutBlock(b *types.Block, state *state.StateDB, receipts []
 	log.Info("Successfully wrote new block with state", "number", b.Number(), "hash", hash)
 
 	// Broadcast the block and announce chain insertion event
-	bq.mux.Post(core.NewMinedBlockEvent{Block: b})
-
+	bq.feed.Send(b)
 	return nil
 }

--- a/consensus/dbft/chainreader.go
+++ b/consensus/dbft/chainreader.go
@@ -25,10 +25,5 @@ type ChainHeaderReader interface {
 	Engine() consensus.Engine
 }
 
-// ChainHeaderWriter is a Blockchain API abstraction needed for proper blockQueue
-// work.
-type ChainHeaderWriter interface {
-	ChainHeaderReader
-	InsertChain(chain types.Blocks) (int, error)
-	WriteBlockAndSetHead(block *types.Block, receipts []*types.Receipt, logs []*types.Log, state *state.StateDB, emitHeadEvent bool) (core.WriteStatus, error)
-}
+// ChainInsertFn is a callback type to insert a block into the local chain.
+type ChainInsertFn func(*types.Block) error

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -560,7 +560,7 @@ func (c *DBFT) processBlockCb(b dbft.Block[common.Hash]) error {
 	res := types.NewBlockWithHeader(dbftBlock.header).WithBody(types.Body{Transactions: dbftBlock.transactions, Uncles: nil, Withdrawals: dbftBlock.withdrawals})
 
 	// Firstly, notify chain about new block.
-	if err := c.blockQueue.PutBlock(res, dbftBlock.state, dbftBlock.receipts); err != nil {
+	if err := c.blockQueue.PutBlock(res); err != nil {
 		// The block might already be added via the regular network
 		// interaction.
 		if h := c.chain.GetHeaderByNumber(res.Number().Uint64()); h == nil {
@@ -918,7 +918,7 @@ func (c *DBFT) verifyPrepareRequestCb(p dbft.ConsensusPayload[common.Hash]) erro
 		oldHash := c.lastBlockHash
 		oldExtra := c.lastBlockExtra
 		parentHeader.Extra = req.ParentExtra
-		err = c.blockQueue.PutBlock(parent.WithSeal(parentHeader), nil, nil)
+		err = c.blockQueue.PutBlock(parent.WithSeal(parentHeader))
 		if err != nil {
 			err = fmt.Errorf("failed to enqueue parent with updated extra for height %d (old hash %s, new hash %s): %w",
 				req.SealingProposal.Number.Uint64()-1,
@@ -2177,10 +2177,10 @@ func (c *DBFT) Authorize(signer common.Address, signFn SignerFn, amevKeystore *a
 
 // Start initializes last block cache, fetches fresh proposal from miner, starts
 // DBFT engine event loop and starts dBFT consensus process.
-func (c *DBFT) Start(chain ChainHeaderWriter) {
+func (c *DBFT) Start(chain ChainHeaderReader, inserter ChainInsertFn) {
 	if c.dbftStarted.CompareAndSwap(false, true) {
 		c.chain = chain
-		c.blockQueue.chain = chain
+		c.blockQueue.SetChain(chain, inserter)
 		c.staticPool = newStaticPool(c.chain)
 
 		// Subscribe for minted blocks prior to accessing current chain header.

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -2152,6 +2152,12 @@ func (c *DBFT) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *ty
 			return nil, errors.New("parentBeaconRoot set before Cancun activation")
 		}
 	}
+	prague := chain.Config().IsPrague(header.Number, header.Time)
+	if !prague {
+		if header.RequestsHash != nil {
+			return nil, errors.New("RequestsHash set before Prague activation")
+		}
+	}
 
 	// Finalize block
 	c.Finalize(chain, header, state, body)

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -220,6 +220,7 @@ type DBFT struct {
 	lock         sync.RWMutex      // Protects signer, signFn and amevKeystore fields
 
 	envelopeFeed event.Feed              // Event feed for new Envelopes
+	blockFeed    event.Feed              // Event feed for new Blocks
 	scope        event.SubscriptionScope // Subscription scope for dBFT events
 
 	dbft             *dbft.DBFT[common.Hash]
@@ -357,13 +358,12 @@ func New(chainCfg *params.ChainConfig, _ ethdb.Database, statisticsCfg Statistic
 	}
 
 	c := &DBFT{
-		config:     cfg,
-		blockQueue: newBlockQueue(),
+		config:       cfg,
+		signerConfig: types.LatestSigner(chainCfg),
 
 		messages:        make(chan Payload, msgsChCap),
 		txs:             make(chan *types.Transaction, txSubCap),
 		chainHeadEvents: make(chan core.ChainHeadEvent, 2),
-		signerConfig:    types.LatestSigner(chainCfg),
 
 		quit:                     make(chan struct{}),
 		eventLoopToCloseCh:       make(chan struct{}),
@@ -377,6 +377,7 @@ func New(chainCfg *params.ChainConfig, _ ethdb.Database, statisticsCfg Statistic
 		dkgTaskExecutorCh: make(chan *taskList, 2), // The maximum number of task lists per epoch is 3
 		dkgTaskWatcherCh:  make(chan *taskList, 2),
 	}
+	c.blockQueue = newBlockQueue(&c.blockFeed)
 
 	var err error
 	logger, logLevel, err := buildLogger()
@@ -1581,8 +1582,6 @@ func (c *DBFT) WithRequestTxs(f func(hashed []common.Hash)) {
 // the ongoing node sync process.
 func (c *DBFT) WithMux(mux *event.TypeMux) {
 	c.mux = mux
-	c.blockQueue.SetMux(mux)
-
 	go c.syncWatcher()
 }
 
@@ -2849,6 +2848,7 @@ func (c *DBFT) Close() error {
 		<-c.dkgTaskWatcherToCloseCh
 		close(c.dkgTaskExecutorCh)
 		close(c.dkgTaskWatcherCh)
+		c.scope.Close()
 	}
 	log.Info("dBFT engine stopped")
 	return nil
@@ -2866,6 +2866,13 @@ func (c *DBFT) APIs(chain consensus.ChainHeaderReader) []rpc.API {
 // SubscribeEnvelopeEvent creates a subscription that fires for all new envelopes that enter the consensus engine.
 func (c *DBFT) SubscribeEnvelopeEvent(ch chan<- []*antimev.EnvelopeInfo) event.Subscription {
 	return c.scope.Track(c.envelopeFeed.Subscribe(ch))
+}
+
+// SubscribeNewBlockEvent creates a subscription that fires new blocks.
+// NewMinedBlockEvent is removed from EL so new blocks will not be sent to node directly.
+// This is only necessary for dBFT, so absent from the general consensus interface.
+func (c *DBFT) SubscribeNewBlockEvent(ch chan<- *types.Block) event.Subscription {
+	return c.scope.Track(c.blockFeed.Subscribe(ch))
 }
 
 // getValidatorsSorted returns validators chosen in the result of the latest

--- a/core/events.go
+++ b/core/events.go
@@ -26,9 +26,6 @@ type NewTxsEvent struct{ Txs []*types.Transaction }
 // ReannoTxsEvent is posted when a batch of pending transactions exceed a specified duration.
 type ReannoTxsEvent struct{ Txs []*types.Transaction }
 
-// NewMinedBlockEvent is posted when a block has been imported.
-type NewMinedBlockEvent struct{ Block *types.Block }
-
 // RemovedLogsEvent is posted when a reorg happens
 type RemovedLogsEvent struct{ Logs []*types.Log }
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -562,7 +562,7 @@ func (s *Ethereum) StartMining() error {
 		// introduced to speed sync times.
 		s.handler.enableSyncedFeatures()
 
-		go s.beacon.Start()
+		go s.beacon.StartMining()
 		if bft != nil {
 			go bft.Start(s.blockchain)
 		}
@@ -581,7 +581,7 @@ func (s *Ethereum) StopMining() {
 		th.SetThreads(-1)
 	}
 	// Stop the block creating itself
-	s.beacon.Stop()
+	s.beacon.StopMining()
 }
 
 func (s *Ethereum) Miner() *miner.Miner { return s.miner }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -379,7 +379,10 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 
 	// Set up local beacon client
 	eth.internalRPC = stack.Attach()
-	eth.beacon = beaconImpl.New(eth, eth.internalRPC, eth.EventMux(), eth.feeRecipient)
+	if bft != nil {
+		eth.beacon = beaconImpl.New(eth, eth.internalRPC, bft, eth.EventMux(), eth.feeRecipient)
+		eth.handler.connectBeacon(eth.beacon)
+	}
 
 	// Successful startup; push a marker and check previous unclean shutdowns.
 	eth.shutdownTracker.MarkStartup()
@@ -740,7 +743,9 @@ func (s *Ethereum) Stop() error {
 	<-ch
 	s.filterMaps.Stop()
 	s.txPool.Close()
-	s.beacon.Close()
+	if s.beacon != nil {
+		s.beacon.Close()
+	}
 	s.internalRPC.Close()
 	s.blockchain.Stop()
 	s.engine.Close()

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -48,6 +48,7 @@ import (
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/eth/gasprice"
+	beaconproto "github.com/ethereum/go-ethereum/eth/protocols/beacon"
 	dbftproto "github.com/ethereum/go-ethereum/eth/protocols/dbft"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/eth/protocols/snap"
@@ -605,10 +606,11 @@ func (s *Ethereum) SyncMode() downloader.SyncMode {
 // network protocols to start.
 func (s *Ethereum) Protocols() []p2p.Protocol {
 	protos := eth.MakeProtocols((*ethHandler)(s.handler), s.networkID, s.discmix)
-	protos = append(protos, s.dbftSrv.MakeProtocols()...)
+	protos = append(protos, beaconproto.MakeProtocols((*beaconHandler)(s.handler))...)
 	if s.config.SnapshotCache > 0 {
 		protos = append(protos, snap.MakeProtocols((*snapHandler)(s.handler))...)
 	}
+	protos = append(protos, s.dbftSrv.MakeProtocols()...)
 	return protos
 }
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -379,9 +379,10 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 
 	// Set up local beacon client
 	eth.internalRPC = stack.Attach()
+	eth.beacon = beaconImpl.New(eth, eth.internalRPC, eth.EventMux(), eth.feeRecipient, eth.shouldPreserve)
+	eth.handler.connectBeacon(eth.beacon)
 	if bft != nil {
-		eth.beacon = beaconImpl.New(eth, eth.internalRPC, bft, eth.EventMux(), eth.feeRecipient)
-		eth.handler.connectBeacon(eth.beacon)
+		bft.SubscribeNewBlockEvent(eth.beacon.BlockBroadcaster())
 	}
 
 	// Successful startup; push a marker and check previous unclean shutdowns.
@@ -567,7 +568,7 @@ func (s *Ethereum) StartMining() error {
 
 		go s.beacon.StartMining()
 		if bft != nil {
-			go bft.Start(s.blockchain)
+			go bft.Start(s.blockchain, s.beacon.InsertBlock)
 		}
 	}
 	return nil
@@ -743,9 +744,7 @@ func (s *Ethereum) Stop() error {
 	<-ch
 	s.filterMaps.Stop()
 	s.txPool.Close()
-	if s.beacon != nil {
-		s.beacon.Close()
-	}
+	s.beacon.Close()
 	s.internalRPC.Close()
 	s.blockchain.Stop()
 	s.engine.Close()

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -869,6 +869,7 @@ func (api *ConsensusAPI) newPayload(params engine.ExecutableData, versionedHashe
 			"params.GasLimit", params.GasLimit,
 			"params.GasUsed", params.GasUsed,
 			"params.Timestamp", params.Timestamp,
+			"params.Nonce", params.Nonce,
 			"params.ExtraData", common.PrettyBytes(params.ExtraData),
 			"params.BaseFeePerGas", params.BaseFeePerGas,
 			"params.BlobGasUsed", bgu,
@@ -909,8 +910,10 @@ func (api *ConsensusAPI) newPayload(params engine.ExecutableData, versionedHashe
 	// We have an existing parent, do some sanity checks to avoid the beacon client
 	// triggering too early
 	var (
-		ptd  = api.eth.BlockChain().GetTd(parent.Hash(), parent.NumberU64())
-		ttd  = api.eth.BlockChain().Config().TerminalTotalDifficulty
+		ptd = api.eth.BlockChain().GetTd(parent.Hash(), parent.NumberU64())
+		// TODO: Should revert after real TTD reaches or has a better solution.
+		// ttd = api.eth.BlockChain().Config().TerminalTotalDifficulty
+		ttd  = ptd
 		gptd = api.eth.BlockChain().GetTd(parent.ParentHash(), parent.NumberU64()-1)
 	)
 	if ptd.Cmp(ttd) < 0 {

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -99,8 +99,10 @@ type Downloader struct {
 	mode atomic.Uint32  // Synchronisation mode defining the strategy used (per sync cycle), use d.getMode() to get the SyncMode
 	mux  *event.TypeMux // Event multiplexer to announce sync operation events
 
-	queue *queue   // Scheduler for selecting the hashes to download
-	peers *peerSet // Set of active peers from which download can proceed
+	queue         *queue                // Scheduler for selecting the hashes to download
+	peers         *peerSet              // Set of active peers from which download can proceed
+	pendingBeacon map[string]beaconPeer // Set of beacon peers waiting for `eth` protocol connection
+	pendingLock   sync.RWMutex          // Lock protecting the pending beacon fields
 
 	stateDB ethdb.Database // Database to state sync into (and deduplicate via)
 
@@ -230,6 +232,7 @@ func New(stateDb ethdb.Database, mux *event.TypeMux, chain BlockChain, dropPeer 
 		mux:               mux,
 		queue:             newQueue(blockCacheMaxItems, blockCacheInitialItems),
 		peers:             newPeerSet(),
+		pendingBeacon:     make(map[string]beaconPeer),
 		blockchain:        chain,
 		chainCutoffNumber: cutoffNumber,
 		chainCutoffHash:   cutoffHash,
@@ -292,7 +295,7 @@ func (d *Downloader) Progress() ethereum.SyncProgress {
 
 // RegisterPeer injects a new download peer into the set of block source to be
 // used for fetching hashes and blocks from.
-func (d *Downloader) RegisterPeer(id string, version uint, peer Peer) error {
+func (d *Downloader) RegisterPeer(id string, version uint, peer ethPeer) error {
 	var logger log.Logger
 	if len(id) < 16 {
 		// Tests use short IDs, don't choke on them
@@ -305,7 +308,35 @@ func (d *Downloader) RegisterPeer(id string, version uint, peer Peer) error {
 		logger.Error("Failed to register sync peer", "err", err)
 		return err
 	}
+	d.pendingLock.Lock()
+	defer d.pendingLock.Unlock()
+	if p := d.pendingBeacon[id]; p != nil {
+		d.peers.ConnectBeacon(id, p)
+		delete(d.pendingBeacon, id)
+	}
 	return nil
+}
+
+// RegisterBeacon connects a download peer with a beacon peer with the same ID.
+func (d *Downloader) RegisterBeacon(id string, peer beaconPeer) error {
+	var logger log.Logger
+	if len(id) < 16 {
+		// Tests use short IDs, don't choke on them
+		logger = log.New("beacon", id)
+	} else {
+		logger = log.New("beacon", id[:8])
+	}
+	logger.Trace("Registering sync beacon")
+	d.pendingLock.Lock()
+	defer d.pendingLock.Unlock()
+	if p := d.peers.Peer(id); p != nil {
+		return d.peers.ConnectBeacon(id, peer)
+	} else if d.pendingBeacon[id] == nil {
+		d.pendingBeacon[id] = peer
+		return nil
+	} else {
+		return errAlreadyRegistered
+	}
 }
 
 // UnregisterPeer remove a peer from the known list, preventing any action from
@@ -321,6 +352,13 @@ func (d *Downloader) UnregisterPeer(id string) error {
 		logger = log.New("peer", id[:8])
 	}
 	logger.Trace("Unregistering sync peer")
+	d.pendingLock.Lock()
+	defer d.pendingLock.Unlock()
+	if p := d.peers.Peer(id); p != nil {
+		if p.beacon != nil {
+			d.pendingBeacon[id] = p.beacon
+		}
+	}
 	if err := d.peers.Unregister(id); err != nil {
 		logger.Error("Failed to unregister sync peer", "err", err)
 		return err
@@ -328,6 +366,29 @@ func (d *Downloader) UnregisterPeer(id string) error {
 	d.queue.Revoke(id)
 
 	return nil
+}
+
+// UnregisterBeacon disconnects the beacon from a download peer.
+func (d *Downloader) UnregisterBeacon(id string) error {
+	// Unregister the peer from the active peer set and revoke any fetch tasks
+	var logger log.Logger
+	if len(id) < 16 {
+		// Tests use short IDs, don't choke on them
+		logger = log.New("beacon", id)
+	} else {
+		logger = log.New("beacon", id[:8])
+	}
+	logger.Trace("Unregistering sync beacon")
+	d.pendingLock.Lock()
+	defer d.pendingLock.Unlock()
+	if p := d.peers.Peer(id); p != nil {
+		return d.peers.DisconnectBeacon(id)
+	} else if d.pendingBeacon[id] != nil {
+		delete(d.pendingBeacon, id)
+		return nil
+	} else {
+		return errNotRegistered
+	}
 }
 
 // LegacySync tries to sync up our local block chain with a remote peer, both
@@ -755,7 +816,7 @@ func (d *Downloader) fetchHead(p *peerConnection) (head *types.Header, pivot *ty
 	mode := d.getMode()
 
 	// Request the advertised remote head block and wait for the response
-	latest, _ := p.peer.Head()
+	latest, _ := p.beacon.Head()
 	fetch := 1
 	if mode == SnapSync {
 		fetch = 2 // head + pivot headers

--- a/eth/downloader/downloader_test.go
+++ b/eth/downloader/downloader_test.go
@@ -112,6 +112,10 @@ func (dl *downloadTester) newPeer(id string, version uint, blocks []*types.Block
 	dl.lock.Lock()
 	defer dl.lock.Unlock()
 
+	beacon := &downloadTesterBeacon{
+		id:    id,
+		chain: newTestBlockchain(blocks),
+	}
 	peer := &downloadTesterPeer{
 		dl:              dl,
 		id:              id,
@@ -121,6 +125,9 @@ func (dl *downloadTester) newPeer(id string, version uint, blocks []*types.Block
 	dl.peers[id] = peer
 
 	if err := dl.downloader.RegisterPeer(id, version, peer); err != nil {
+		panic(err)
+	}
+	if err := dl.downloader.RegisterBeacon(id, beacon); err != nil {
 		panic(err)
 	}
 	if err := dl.downloader.SnapSyncer.Register(peer); err != nil {
@@ -137,6 +144,19 @@ func (dl *downloadTester) dropPeer(id string) {
 	delete(dl.peers, id)
 	dl.downloader.SnapSyncer.Unregister(id)
 	dl.downloader.UnregisterPeer(id)
+	dl.downloader.UnregisterBeacon(id)
+}
+
+type downloadTesterBeacon struct {
+	id    string
+	chain *core.BlockChain
+}
+
+// Head constructs a function to retrieve a peer's current head hash
+// and total difficulty.
+func (dlb *downloadTesterBeacon) Head() (common.Hash, *big.Int) {
+	head := dlb.chain.CurrentBlock()
+	return head.Hash(), dlb.chain.GetTd(head.Hash(), head.Number.Uint64())
 }
 
 type downloadTesterPeer struct {
@@ -145,13 +165,6 @@ type downloadTesterPeer struct {
 	chain *core.BlockChain
 
 	withholdHeaders map[common.Hash]struct{}
-}
-
-// Head constructs a function to retrieve a peer's current head hash
-// and total difficulty.
-func (dlp *downloadTesterPeer) Head() (common.Hash, *big.Int) {
-	head := dlp.chain.CurrentBlock()
-	return head.Hash(), dlp.chain.GetTd(head.Hash(), head.Number.Uint64())
 }
 
 func unmarshalRlpHeaders(rlpdata []rlp.RawValue) []*types.Header {

--- a/eth/downloader/peer.go
+++ b/eth/downloader/peer.go
@@ -48,16 +48,21 @@ type peerConnection struct {
 	rates   *msgrate.Tracker         // Tracker to hone in on the number of items retrievable per second
 	lacking map[common.Hash]struct{} // Set of hashes not to request (didn't have previously)
 
-	peer Peer
+	beacon beaconPeer
+	peer   ethPeer
 
 	version uint       // Eth protocol version number to switch strategies
 	log     log.Logger // Contextual logger to add extra infos to peer logs
 	lock    sync.RWMutex
 }
 
-// Peer encapsulates the methods required to synchronise with a remote full peer.
-type Peer interface {
+// beaconPeer encapsulates the methods required to know head information.
+type beaconPeer interface {
 	Head() (common.Hash, *big.Int)
+}
+
+// ethPeer encapsulates the methods required to synchronise with a remote full peer.
+type ethPeer interface {
 	RequestHeadersByHash(common.Hash, int, int, bool, chan *eth.Response) (*eth.Request, error)
 	RequestHeadersByNumber(uint64, int, int, bool, chan *eth.Response) (*eth.Request, error)
 
@@ -66,13 +71,23 @@ type Peer interface {
 }
 
 // newPeerConnection creates a new downloader peer.
-func newPeerConnection(id string, version uint, peer Peer, logger log.Logger) *peerConnection {
+func newPeerConnection(id string, version uint, peer ethPeer, logger log.Logger) *peerConnection {
 	return &peerConnection{
 		id:      id,
 		lacking: make(map[common.Hash]struct{}),
 		peer:    peer,
 		version: version,
 		log:     logger,
+	}
+}
+
+// ConnectBeacon connects a downloader peer with a beacon peer.
+func (p *peerConnection) ConnectBeacon(peer beaconPeer) error {
+	if p.beacon != nil {
+		return errAlreadyRegistered
+	} else {
+		p.beacon = peer
+		return nil
 	}
 }
 
@@ -220,6 +235,24 @@ func (ps *peerSet) Register(p *peerConnection) error {
 	ps.peers[p.id] = p
 	ps.lock.Unlock()
 
+	if p.beacon != nil && p.peer != nil {
+		ps.events.Send(&peeringEvent{peer: p, join: true})
+	}
+	return nil
+}
+
+// RegisterBeacon connects a peer with its beacon, or returns an error if the
+// peer is not known.
+func (ps *peerSet) ConnectBeacon(id string, beacon beaconPeer) error {
+	ps.lock.Lock()
+	p, ok := ps.peers[id]
+	if !ok {
+		ps.lock.Unlock()
+		return errNotRegistered
+	}
+	p.ConnectBeacon(beacon)
+	ps.lock.Unlock()
+
 	ps.events.Send(&peeringEvent{peer: p, join: true})
 	return nil
 }
@@ -235,6 +268,23 @@ func (ps *peerSet) Unregister(id string) error {
 	}
 	delete(ps.peers, id)
 	ps.rates.Untrack(id)
+	ps.lock.Unlock()
+
+	if p.beacon != nil && p.peer != nil {
+		ps.events.Send(&peeringEvent{peer: p, join: false})
+	}
+	return nil
+}
+
+// DisconnectBeacon removes the beacon connection from a remote peer.
+func (ps *peerSet) DisconnectBeacon(id string) error {
+	ps.lock.Lock()
+	p, ok := ps.peers[id]
+	if !ok || p.beacon == nil {
+		ps.lock.Unlock()
+		return errNotRegistered
+	}
+	p.beacon = nil
 	ps.lock.Unlock()
 
 	ps.events.Send(&peeringEvent{peer: p, join: false})

--- a/eth/downloader/skeleton_test.go
+++ b/eth/downloader/skeleton_test.go
@@ -71,6 +71,16 @@ func (hf *hookedBackfiller) resume() {
 	}
 }
 
+// skeletonTestBeacon is a mock peer that can only serve head requests.
+type skeletonTestBeacon struct {
+	id      string          // Unique identifier of the mock peer
+	headers []*types.Header // Headers to serve when requested
+}
+
+func (p *skeletonTestBeacon) Head() (common.Hash, *big.Int) {
+	panic("skeleton sync must not request the remote head")
+}
+
 // skeletonTestPeer is a mock peer that can only serve header requests from a
 // pre-perated header chain (which may be arbitrarily wrong for testing).
 //
@@ -187,10 +197,6 @@ func (p *skeletonTestPeer) RequestHeadersByNumber(origin uint64, amount int, ski
 		}
 	}()
 	return req, nil
-}
-
-func (p *skeletonTestPeer) Head() (common.Hash, *big.Int) {
-	panic("skeleton sync must not request the remote head")
 }
 
 func (p *skeletonTestPeer) RequestHeadersByHash(common.Hash, int, int, bool, chan *eth.Response) (*eth.Request, error) {
@@ -839,6 +845,7 @@ func TestSkeletonSyncRetrievals(t *testing.T) {
 		peerset := newPeerSet()
 		for _, peer := range tt.peers {
 			peerset.Register(newPeerConnection(peer.id, eth.ETH68, peer, log.New("id", peer.id)))
+			peerset.ConnectBeacon(peer.id, &skeletonTestBeacon{id: peer.id, headers: peer.headers})
 		}
 		// Create a peer dropper to track malicious peers
 		dropped := make(map[string]int)
@@ -908,6 +915,7 @@ func TestSkeletonSyncRetrievals(t *testing.T) {
 			if err := peerset.Register(newPeerConnection(tt.newPeer.id, eth.ETH68, tt.newPeer, log.New("id", tt.newPeer.id))); err != nil {
 				t.Errorf("test %d: failed to register new peer: %v", i, err)
 			}
+			peerset.ConnectBeacon(tt.newPeer.id, &skeletonTestBeacon{id: tt.newPeer.id, headers: tt.newPeer.headers})
 			time.Sleep(time.Millisecond * 50) // given time for peer registration
 			endpeers = append(tt.peers, tt.newPeer)
 		}

--- a/eth/fetcher/block_fetcher.go
+++ b/eth/fetcher/block_fetcher.go
@@ -76,10 +76,10 @@ var (
 type blockRetrievalFn func(common.Hash) *types.Block
 
 // headerRequesterFn is a callback type for sending a header retrieval request.
-type headerRequesterFn func(common.Hash, chan *eth.Response) (*eth.Request, error)
+type headerRequesterFn func(string, common.Hash, chan *eth.Response) (*eth.Request, error)
 
 // bodyRequesterFn is a callback type for sending a body retrieval request.
-type bodyRequesterFn func([]common.Hash, chan *eth.Response) (*eth.Request, error)
+type bodyRequesterFn func(string, []common.Hash, chan *eth.Response) (*eth.Request, error)
 
 // headerVerifierFn is a callback type to verify a block's header for fast propagation.
 type headerVerifierFn func(header *types.Header) error
@@ -108,9 +108,6 @@ type blockAnnounce struct {
 	time   time.Time     // Timestamp of the announcement
 
 	origin string // Identifier of the peer originating the notification
-
-	fetchHeader headerRequesterFn // Fetcher function to retrieve the header of an announced block
-	fetchBodies bodyRequesterFn   // Fetcher function to retrieve the body of an announced block
 }
 
 // headerFilterTask represents a batch of headers needing fetcher filtering.
@@ -189,6 +186,9 @@ type BlockFetcher struct {
 	insertChain          chainInsertFn          // Injects a batch of blocks into the chain
 	dropPeer             peerDropFn             // Drops a peer for misbehaving
 
+	fetchHeader headerRequesterFn // Fetcher function to retrieve the header of an announced block
+	fetchBodies bodyRequesterFn   // Fetcher function to retrieve the body of an announced block
+
 	// Testing hooks
 	announceChangeHook func(common.Hash, bool)           // Method to call upon adding or deleting a hash from the blockAnnounce list
 	queueChangeHook    func(common.Hash, bool)           // Method to call upon adding or deleting a block from the import queue
@@ -199,7 +199,8 @@ type BlockFetcher struct {
 
 // NewBlockFetcher creates a block fetcher to retrieve blocks based on hash announcements.
 func NewBlockFetcher(getBlock blockRetrievalFn, verifyHeader headerVerifierFn, broadcastBlock blockBroadcasterFn,
-	chainHeight chainHeightFn, chainFinalizedHeight chainFinalizedHeightFn, insertChain chainInsertFn, dropPeer peerDropFn) *BlockFetcher {
+	chainHeight chainHeightFn, chainFinalizedHeight chainFinalizedHeightFn, insertChain chainInsertFn, dropPeer peerDropFn,
+	fetchHeader headerRequesterFn, fetchBodies bodyRequesterFn) *BlockFetcher {
 	return &BlockFetcher{
 		notify:               make(chan *blockAnnounce),
 		inject:               make(chan *blockOrHeaderInject),
@@ -223,6 +224,8 @@ func NewBlockFetcher(getBlock blockRetrievalFn, verifyHeader headerVerifierFn, b
 		chainFinalizedHeight: chainFinalizedHeight,
 		insertChain:          insertChain,
 		dropPeer:             dropPeer,
+		fetchHeader:          fetchHeader,
+		fetchBodies:          fetchBodies,
 	}
 }
 
@@ -240,15 +243,12 @@ func (f *BlockFetcher) Stop() {
 
 // Notify announces the fetcher of the potential availability of a new block in
 // the network.
-func (f *BlockFetcher) Notify(peer string, hash common.Hash, number uint64, time time.Time,
-	headerFetcher headerRequesterFn, bodyFetcher bodyRequesterFn) error {
+func (f *BlockFetcher) Notify(peer string, hash common.Hash, number uint64, time time.Time) error {
 	block := &blockAnnounce{
-		hash:        hash,
-		number:      number,
-		time:        time,
-		origin:      peer,
-		fetchHeader: headerFetcher,
-		fetchBodies: bodyFetcher,
+		hash:   hash,
+		number: number,
+		time:   time,
+		origin: peer,
 	}
 	select {
 	case f.notify <- block:
@@ -469,9 +469,6 @@ func (f *BlockFetcher) loop() {
 			for peer, hashes := range request {
 				log.Trace("Fetching scheduled headers", "peer", peer, "list", hashes)
 
-				// Create a closure of the fetch and schedule in on a new thread
-				fetchHeader := f.fetching[hashes[0]].fetchHeader
-
 				go func(peer string) {
 					if f.fetchingHook != nil {
 						f.fetchingHook(hashes)
@@ -481,7 +478,7 @@ func (f *BlockFetcher) loop() {
 						go func(hash common.Hash) {
 							resCh := make(chan *eth.Response)
 
-							req, err := fetchHeader(hash, resCh)
+							req, err := f.fetchHeader(peer, hash, resCh)
 							if err != nil {
 								return // Legacy code, yolo
 							}
@@ -532,13 +529,12 @@ func (f *BlockFetcher) loop() {
 				if f.completingHook != nil {
 					f.completingHook(hashes)
 				}
-				fetchBodies := f.completing[hashes[0]].fetchBodies
 				bodyFetchMeter.Mark(int64(len(hashes)))
 
 				go func(peer string, hashes []common.Hash) {
 					resCh := make(chan *eth.Response)
 
-					req, err := fetchBodies(hashes, resCh)
+					req, err := f.fetchBodies(peer, hashes, resCh)
 					if err != nil {
 						return // Legacy code, yolo
 					}

--- a/eth/fetcher/block_fetcher_test.go
+++ b/eth/fetcher/block_fetcher_test.go
@@ -103,7 +103,7 @@ func newTester() *fetcherTester {
 		drops:   make(map[string]bool),
 	}
 	tester.fetcher = NewBlockFetcher(tester.getBlock, tester.verifyHeader, tester.broadcastBlock,
-		tester.chainHeight, tester.chainFinalizedHeight, tester.insertChain, tester.dropPeer)
+		tester.chainHeight, tester.chainFinalizedHeight, tester.insertChain, tester.dropPeer, nil, nil)
 	tester.fetcher.Start()
 
 	return tester
@@ -174,13 +174,13 @@ func (f *fetcherTester) dropPeer(peer string) {
 }
 
 // makeHeaderFetcher retrieves a block header fetcher associated with a simulated peer.
-func (f *fetcherTester) makeHeaderFetcher(peer string, blocks map[common.Hash]*types.Block, drift time.Duration) headerRequesterFn {
+func (f *fetcherTester) makeHeaderFetcher(blocks map[common.Hash]*types.Block, drift time.Duration) headerRequesterFn {
 	closure := make(map[common.Hash]*types.Block)
 	for hash, block := range blocks {
 		closure[hash] = block
 	}
 	// Create a function that return a header from the closure
-	return func(hash common.Hash, sink chan *eth.Response) (*eth.Request, error) {
+	return func(peer string, hash common.Hash, sink chan *eth.Response) (*eth.Request, error) {
 		// Gather the blocks to return
 		headers := make([]*types.Header, 0, 1)
 		if block, ok := closure[hash]; ok {
@@ -204,13 +204,13 @@ func (f *fetcherTester) makeHeaderFetcher(peer string, blocks map[common.Hash]*t
 }
 
 // makeBodyFetcher retrieves a block body fetcher associated with a simulated peer.
-func (f *fetcherTester) makeBodyFetcher(peer string, blocks map[common.Hash]*types.Block, drift time.Duration) bodyRequesterFn {
+func (f *fetcherTester) makeBodyFetcher(blocks map[common.Hash]*types.Block, drift time.Duration) bodyRequesterFn {
 	closure := make(map[common.Hash]*types.Block)
 	for hash, block := range blocks {
 		closure[hash] = block
 	}
 	// Create a function that returns blocks from the closure
-	return func(hashes []common.Hash, sink chan *eth.Response) (*eth.Request, error) {
+	return func(peer string, hashes []common.Hash, sink chan *eth.Response) (*eth.Request, error) {
 		// Gather the block bodies to return
 		transactions := make([][]*types.Transaction, 0, len(hashes))
 		uncles := make([][]*types.Header, 0, len(hashes))
@@ -348,8 +348,8 @@ func testSequentialAnnouncements(t *testing.T) {
 
 	tester := newTester()
 	defer tester.fetcher.Stop()
-	headerFetcher := tester.makeHeaderFetcher("valid", blocks, -gatherSlack)
-	bodyFetcher := tester.makeBodyFetcher("valid", blocks, 0)
+	tester.fetcher.fetchHeader = tester.makeHeaderFetcher(blocks, -gatherSlack)
+	tester.fetcher.fetchBodies = tester.makeBodyFetcher(blocks, 0)
 
 	// Iteratively announce blocks until all are imported
 	imported := make(chan interface{})
@@ -360,7 +360,7 @@ func testSequentialAnnouncements(t *testing.T) {
 		imported <- block
 	}
 	for i := len(hashes) - 2; i >= 0; i-- {
-		tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+		tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout))
 		verifyImportEvent(t, imported, true)
 	}
 	verifyImportDone(t, imported)
@@ -378,20 +378,16 @@ func testConcurrentAnnouncements(t *testing.T) {
 
 	// Assemble a tester with a built in counter for the requests
 	tester := newTester()
-	firstHeaderFetcher := tester.makeHeaderFetcher("first", blocks, -gatherSlack)
-	firstBodyFetcher := tester.makeBodyFetcher("first", blocks, 0)
-	secondHeaderFetcher := tester.makeHeaderFetcher("second", blocks, -gatherSlack)
-	secondBodyFetcher := tester.makeBodyFetcher("second", blocks, 0)
+	headerFetcher := tester.makeHeaderFetcher(blocks, -gatherSlack)
+	bodyFetcher := tester.makeBodyFetcher(blocks, 0)
 
 	var counter atomic.Uint32
-	firstHeaderWrapper := func(hash common.Hash, sink chan *eth.Response) (*eth.Request, error) {
+	headerWrapper := func(peer string, hash common.Hash, sink chan *eth.Response) (*eth.Request, error) {
 		counter.Add(1)
-		return firstHeaderFetcher(hash, sink)
+		return headerFetcher(peer, hash, sink)
 	}
-	secondHeaderWrapper := func(hash common.Hash, sink chan *eth.Response) (*eth.Request, error) {
-		counter.Add(1)
-		return secondHeaderFetcher(hash, sink)
-	}
+	tester.fetcher.fetchHeader = headerWrapper
+	tester.fetcher.fetchBodies = bodyFetcher
 	// Iteratively announce blocks until all are imported
 	imported := make(chan interface{})
 	tester.fetcher.importedHook = func(header *types.Header, block *types.Block) {
@@ -401,9 +397,9 @@ func testConcurrentAnnouncements(t *testing.T) {
 		imported <- block
 	}
 	for i := len(hashes) - 2; i >= 0; i-- {
-		tester.fetcher.Notify("first", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), firstHeaderWrapper, firstBodyFetcher)
-		tester.fetcher.Notify("second", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout+time.Millisecond), secondHeaderWrapper, secondBodyFetcher)
-		tester.fetcher.Notify("second", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout-time.Millisecond), secondHeaderWrapper, secondBodyFetcher)
+		tester.fetcher.Notify("first", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout))
+		tester.fetcher.Notify("second", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout+time.Millisecond))
+		tester.fetcher.Notify("second", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout-time.Millisecond))
 		verifyImportEvent(t, imported, true)
 	}
 	verifyImportDone(t, imported)
@@ -425,8 +421,8 @@ func testOverlappingAnnouncements(t *testing.T) {
 	hashes, blocks := makeChain(targetBlocks, 0, genesis)
 
 	tester := newTester()
-	headerFetcher := tester.makeHeaderFetcher("valid", blocks, -gatherSlack)
-	bodyFetcher := tester.makeBodyFetcher("valid", blocks, 0)
+	tester.fetcher.fetchHeader = tester.makeHeaderFetcher(blocks, -gatherSlack)
+	tester.fetcher.fetchBodies = tester.makeBodyFetcher(blocks, 0)
 
 	// Iteratively announce blocks, but overlap them continuously
 	overlap := 16
@@ -442,7 +438,7 @@ func testOverlappingAnnouncements(t *testing.T) {
 	}
 
 	for i := len(hashes) - 2; i >= 0; i-- {
-		tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+		tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout))
 		select {
 		case <-imported:
 		case <-time.After(time.Second):
@@ -463,17 +459,17 @@ func testPendingDeduplication(t *testing.T) {
 
 	// Assemble a tester with a built in counter and delayed fetcher
 	tester := newTester()
-	headerFetcher := tester.makeHeaderFetcher("repeater", blocks, -gatherSlack)
-	bodyFetcher := tester.makeBodyFetcher("repeater", blocks, 0)
+	headerFetcher := tester.makeHeaderFetcher(blocks, -gatherSlack)
+	bodyFetcher := tester.makeBodyFetcher(blocks, 0)
 
 	delay := 50 * time.Millisecond
 	var counter atomic.Uint32
-	headerWrapper := func(hash common.Hash, sink chan *eth.Response) (*eth.Request, error) {
+	headerWrapper := func(peer string, hash common.Hash, sink chan *eth.Response) (*eth.Request, error) {
 		counter.Add(1)
 
 		// Simulate a long running fetch
 		resink := make(chan *eth.Response)
-		req, err := headerFetcher(hash, resink)
+		req, err := headerFetcher(peer, hash, resink)
 		if err == nil {
 			go func() {
 				res := <-resink
@@ -483,12 +479,14 @@ func testPendingDeduplication(t *testing.T) {
 		}
 		return req, err
 	}
+	tester.fetcher.fetchHeader = headerWrapper
+	tester.fetcher.fetchBodies = bodyFetcher
 	checkNonExist := func() bool {
 		return tester.getBlock(hashes[0]) == nil
 	}
 	// Announce the same block many times until it's fetched (wait for any pending ops)
 	for checkNonExist() {
-		tester.fetcher.Notify("repeater", hashes[0], 1, time.Now().Add(-arriveTimeout), headerWrapper, bodyFetcher)
+		tester.fetcher.Notify("repeater", hashes[0], 1, time.Now().Add(-arriveTimeout))
 		time.Sleep(time.Millisecond)
 	}
 	time.Sleep(delay)
@@ -511,8 +509,8 @@ func testRandomArrivalImport(t *testing.T) {
 	skip := targetBlocks / 2
 
 	tester := newTester()
-	headerFetcher := tester.makeHeaderFetcher("valid", blocks, -gatherSlack)
-	bodyFetcher := tester.makeBodyFetcher("valid", blocks, 0)
+	tester.fetcher.fetchHeader = tester.makeHeaderFetcher(blocks, -gatherSlack)
+	tester.fetcher.fetchBodies = tester.makeBodyFetcher(blocks, 0)
 
 	// Iteratively announce blocks, skipping one entry
 	imported := make(chan interface{}, len(hashes)-1)
@@ -524,12 +522,12 @@ func testRandomArrivalImport(t *testing.T) {
 	}
 	for i := len(hashes) - 1; i >= 0; i-- {
 		if i != skip {
-			tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+			tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout))
 			time.Sleep(time.Millisecond)
 		}
 	}
 	// Finally announce the skipped entry and check full import
-	tester.fetcher.Notify("valid", hashes[skip], uint64(len(hashes)-skip-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+	tester.fetcher.Notify("valid", hashes[skip], uint64(len(hashes)-skip-1), time.Now().Add(-arriveTimeout))
 	verifyImportCount(t, imported, len(hashes)-1)
 	verifyChainHeight(t, tester, uint64(len(hashes)-1))
 }
@@ -543,8 +541,8 @@ func TestQueueGapFill(t *testing.T) {
 	skip := targetBlocks / 2
 
 	tester := newTester()
-	headerFetcher := tester.makeHeaderFetcher("valid", blocks, -gatherSlack)
-	bodyFetcher := tester.makeBodyFetcher("valid", blocks, 0)
+	tester.fetcher.fetchHeader = tester.makeHeaderFetcher(blocks, -gatherSlack)
+	tester.fetcher.fetchBodies = tester.makeBodyFetcher(blocks, 0)
 
 	// Iteratively announce blocks, skipping one entry
 	imported := make(chan interface{}, len(hashes)-1)
@@ -552,7 +550,7 @@ func TestQueueGapFill(t *testing.T) {
 
 	for i := len(hashes) - 1; i >= 0; i-- {
 		if i != skip {
-			tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+			tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout))
 			time.Sleep(time.Millisecond)
 		}
 	}
@@ -570,8 +568,8 @@ func TestImportDeduplication(t *testing.T) {
 
 	// Create the tester and wrap the importer with a counter
 	tester := newTester()
-	headerFetcher := tester.makeHeaderFetcher("valid", blocks, -gatherSlack)
-	bodyFetcher := tester.makeBodyFetcher("valid", blocks, 0)
+	tester.fetcher.fetchHeader = tester.makeHeaderFetcher(blocks, -gatherSlack)
+	tester.fetcher.fetchBodies = tester.makeBodyFetcher(blocks, 0)
 
 	var counter atomic.Uint32
 	tester.fetcher.insertChain = func(blocks types.Blocks) (int, error) {
@@ -585,7 +583,7 @@ func TestImportDeduplication(t *testing.T) {
 	tester.fetcher.importedHook = func(header *types.Header, block *types.Block) { imported <- block }
 
 	// Announce the duplicating block, wait for retrieval, and also propagate directly
-	tester.fetcher.Notify("valid", hashes[0], 1, time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+	tester.fetcher.Notify("valid", hashes[0], 1, time.Now().Add(-arriveTimeout))
 	<-fetching
 
 	tester.fetcher.Enqueue("valid", blocks[hashes[0]])
@@ -653,21 +651,21 @@ func testDistantAnnouncementDiscarding(t *testing.T) {
 	tester.blocks = map[common.Hash]*types.Block{head: blocks[head]}
 	tester.lock.Unlock()
 
-	headerFetcher := tester.makeHeaderFetcher("lower", blocks, -gatherSlack)
-	bodyFetcher := tester.makeBodyFetcher("lower", blocks, 0)
+	tester.fetcher.fetchHeader = tester.makeHeaderFetcher(blocks, -gatherSlack)
+	tester.fetcher.fetchBodies = tester.makeBodyFetcher(blocks, 0)
 
 	fetching := make(chan struct{}, 2)
 	tester.fetcher.fetchingHook = func(hashes []common.Hash) { fetching <- struct{}{} }
 
 	// Ensure that a block with a lower number than the threshold is discarded
-	tester.fetcher.Notify("lower", hashes[low], blocks[hashes[low]].NumberU64(), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+	tester.fetcher.Notify("lower", hashes[low], blocks[hashes[low]].NumberU64(), time.Now().Add(-arriveTimeout))
 	select {
 	case <-time.After(50 * time.Millisecond):
 	case <-fetching:
 		t.Fatalf("fetcher requested stale header")
 	}
 	// Ensure that a block with a higher number than the threshold is discarded
-	tester.fetcher.Notify("higher", hashes[high], blocks[hashes[high]].NumberU64(), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+	tester.fetcher.Notify("higher", hashes[high], blocks[hashes[high]].NumberU64(), time.Now().Add(-arriveTimeout))
 	select {
 	case <-time.After(50 * time.Millisecond):
 	case <-fetching:
@@ -711,21 +709,21 @@ func testFinalizedAnnouncementDiscarding(t *testing.T) {
 	}
 	tester.lock.Unlock()
 
-	headerFetcher := tester.makeHeaderFetcher("lower", blocks, -gatherSlack)
-	bodyFetcher := tester.makeBodyFetcher("lower", blocks, 0)
+	tester.fetcher.fetchHeader = tester.makeHeaderFetcher(blocks, -gatherSlack)
+	tester.fetcher.fetchBodies = tester.makeBodyFetcher(blocks, 0)
 
 	fetching := make(chan struct{}, 2)
 	tester.fetcher.fetchingHook = func(hashes []common.Hash) { fetching <- struct{}{} }
 
 	// Ensure that a block with a lower number than the finalized height is discarded
-	tester.fetcher.Notify("lower", hashes[low], blocks[hashes[low]].NumberU64(), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+	tester.fetcher.Notify("lower", hashes[low], blocks[hashes[low]].NumberU64(), time.Now().Add(-arriveTimeout))
 	select {
 	case <-time.After(50 * time.Millisecond):
 	case <-fetching:
 		t.Fatalf("fetcher requested stale header")
 	}
 	// Ensure that a block with a same number of the finalized height is discarded
-	tester.fetcher.Notify("equal", hashes[equal], blocks[hashes[equal]].NumberU64(), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+	tester.fetcher.Notify("equal", hashes[equal], blocks[hashes[equal]].NumberU64(), time.Now().Add(-arriveTimeout))
 	select {
 	case <-time.After(50 * time.Millisecond):
 	case <-fetching:
@@ -742,8 +740,8 @@ func testInvalidNumberAnnouncement(t *testing.T) {
 	hashes, blocks := makeChain(1, 0, genesis)
 
 	tester := newTester()
-	badHeaderFetcher := tester.makeHeaderFetcher("bad", blocks, -gatherSlack)
-	badBodyFetcher := tester.makeBodyFetcher("bad", blocks, 0)
+	tester.fetcher.fetchHeader = tester.makeHeaderFetcher(blocks, -gatherSlack)
+	tester.fetcher.fetchBodies = tester.makeBodyFetcher(blocks, 0)
 
 	imported := make(chan interface{})
 	announced := make(chan interface{}, 2)
@@ -757,7 +755,7 @@ func testInvalidNumberAnnouncement(t *testing.T) {
 	tester.fetcher.announceChangeHook = func(hash common.Hash, b bool) {
 		announced <- nil
 	}
-	tester.fetcher.Notify("bad", hashes[0], 2, time.Now().Add(-arriveTimeout), badHeaderFetcher, badBodyFetcher)
+	tester.fetcher.Notify("bad", hashes[0], 2, time.Now().Add(-arriveTimeout))
 	verifyAnnounce := func() {
 		for i := 0; i < 2; i++ {
 			select {
@@ -777,10 +775,8 @@ func testInvalidNumberAnnouncement(t *testing.T) {
 	if !dropped {
 		t.Fatalf("peer with invalid numbered announcement not dropped")
 	}
-	goodHeaderFetcher := tester.makeHeaderFetcher("good", blocks, -gatherSlack)
-	goodBodyFetcher := tester.makeBodyFetcher("good", blocks, 0)
 	// Make sure a good announcement passes without a drop
-	tester.fetcher.Notify("good", hashes[0], 1, time.Now().Add(-arriveTimeout), goodHeaderFetcher, goodBodyFetcher)
+	tester.fetcher.Notify("good", hashes[0], 1, time.Now().Add(-arriveTimeout))
 	verifyAnnounce()
 	verifyImportEvent(t, imported, true)
 
@@ -802,8 +798,8 @@ func TestEmptyBlockShortCircuit(t *testing.T) {
 
 	tester := newTester()
 	defer tester.fetcher.Stop()
-	headerFetcher := tester.makeHeaderFetcher("valid", blocks, -gatherSlack)
-	bodyFetcher := tester.makeBodyFetcher("valid", blocks, 0)
+	tester.fetcher.fetchHeader = tester.makeHeaderFetcher(blocks, -gatherSlack)
+	tester.fetcher.fetchBodies = tester.makeBodyFetcher(blocks, 0)
 
 	// Add a monitoring hook for all internal events
 	fetching := make(chan []common.Hash)
@@ -821,7 +817,7 @@ func TestEmptyBlockShortCircuit(t *testing.T) {
 	}
 	// Iteratively announce blocks until all are imported
 	for i := len(hashes) - 2; i >= 0; i-- {
-		tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), headerFetcher, bodyFetcher)
+		tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout))
 
 		// All announces should fetch the header
 		verifyFetchingEvent(t, fetching, true)
@@ -854,19 +850,17 @@ func TestHashMemoryExhaustionAttack(t *testing.T) {
 	// Create a valid chain and an infinite junk chain
 	targetBlocks := hashLimit + 2*maxQueueDist
 	hashes, blocks := makeChain(targetBlocks, 0, genesis)
-	validHeaderFetcher := tester.makeHeaderFetcher("valid", blocks, -gatherSlack)
-	validBodyFetcher := tester.makeBodyFetcher("valid", blocks, 0)
+	tester.fetcher.fetchHeader = tester.makeHeaderFetcher(blocks, -gatherSlack)
+	tester.fetcher.fetchBodies = tester.makeBodyFetcher(blocks, 0)
 
 	attack, _ := makeChain(targetBlocks, 0, unknownBlock)
-	attackerHeaderFetcher := tester.makeHeaderFetcher("attacker", nil, -gatherSlack)
-	attackerBodyFetcher := tester.makeBodyFetcher("attacker", nil, 0)
 
 	// Feed the tester a huge hashset from the attacker, and a limited from the valid peer
 	for i := 0; i < len(attack); i++ {
 		if i < maxQueueDist {
-			tester.fetcher.Notify("valid", hashes[len(hashes)-2-i], uint64(i+1), time.Now(), validHeaderFetcher, validBodyFetcher)
+			tester.fetcher.Notify("valid", hashes[len(hashes)-2-i], uint64(i+1), time.Now())
 		}
-		tester.fetcher.Notify("attacker", attack[i], 1 /* don't distance drop */, time.Now(), attackerHeaderFetcher, attackerBodyFetcher)
+		tester.fetcher.Notify("attacker", attack[i], 1 /* don't distance drop */, time.Now())
 	}
 	if count := announces.Load(); count != hashLimit+maxQueueDist {
 		t.Fatalf("queued announce count mismatch: have %d, want %d", count, hashLimit+maxQueueDist)
@@ -876,7 +870,7 @@ func TestHashMemoryExhaustionAttack(t *testing.T) {
 
 	// Feed the remaining valid hashes to ensure DOS protection state remains clean
 	for i := len(hashes) - maxQueueDist - 2; i >= 0; i-- {
-		tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout), validHeaderFetcher, validBodyFetcher)
+		tester.fetcher.Notify("valid", hashes[i], uint64(len(hashes)-i-1), time.Now().Add(-arriveTimeout))
 		verifyImportEvent(t, imported, true)
 	}
 	verifyImportDone(t, imported)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -24,6 +24,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	beaconfetch "github.com/ethereum/go-ethereum/beacon/impl/fetcher"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/beacon"
 	"github.com/ethereum/go-ethereum/consensus/dbft"
@@ -96,6 +97,16 @@ type txPool interface {
 	SubscribeReannoTransactions(chan<- core.ReannoTxsEvent) event.Subscription
 }
 
+type Beacon interface {
+	StartBlockFetcher(
+		broadcastBlock beaconfetch.BlockBroadcasterFn, insertChain beaconfetch.ChainInsertFn,
+		dropPeer beaconfetch.PeerDropFn, fetchHeader beaconfetch.HeaderRequesterFn,
+		fetchBodies beaconfetch.BodyRequesterFn,
+	)
+	NotifyBlockAnnon(peer string, hash common.Hash, number uint64, time time.Time)
+	EnqueueBlock(peer string, block *types.Block)
+}
+
 // handlerConfig is the collection of initialization parameters to create a full
 // node network handler.
 type handlerConfig struct {
@@ -123,10 +134,10 @@ type handler struct {
 	chain    *core.BlockChain
 	maxPeers int
 
-	downloader   *downloader.Downloader
-	blockFetcher *fetcher.BlockFetcher
-	txFetcher    *fetcher.TxFetcher
-	peers        *peerSet
+	downloader *downloader.Downloader
+	beacon     Beacon
+	txFetcher  *fetcher.TxFetcher
+	peers      *peerSet
 
 	eventMux      *event.TypeMux
 	txsCh         chan core.NewTxsEvent
@@ -201,43 +212,6 @@ func newHandler(config *handlerConfig) (*handler, error) {
 	}
 	// Construct the downloader (long sync)
 	h.downloader = downloader.New(config.Database, h.eventMux, h.chain, h.removePeer, h.enableSyncedFeatures)
-	// Construct the fetcher (short sync)
-	validator := func(header *types.Header) error {
-		// Reject all the PoS style headers in the first place. No matter
-		// the chain has finished the transition or not, the PoS headers
-		// should only come from the trusted consensus layer instead of
-		// p2p network.
-		if beacon, ok := h.chain.Engine().(*beacon.Beacon); ok {
-			if beacon.IsPoSHeader(header) {
-				return errors.New("unexpected post-merge header")
-			}
-		}
-		return h.chain.Engine().VerifyHeader(h.chain, header)
-	}
-	heighter := func() uint64 {
-		return h.chain.CurrentBlock().Number.Uint64()
-	}
-	finalizeHeighter := func() uint64 {
-		fblock := h.chain.CurrentFinalBlock()
-		if fblock == nil {
-			return 0
-		}
-		return fblock.Number.Uint64()
-	}
-	inserter := func(blocks types.Blocks) (int, error) {
-		// If snap sync is running, deny importing weird blocks. This is a problematic
-		// clause when starting up a new network, because snap-syncing miners might not
-		// accept each others' blocks until a restart. Unfortunately we haven't figured
-		// out a way yet where nodes can decide unilaterally whether the network is new
-		// or not. This should be fixed if we figure out a solution.
-		if !h.synced.Load() {
-			log.Warn("Syncing, discarded propagated block", "number", blocks[0].Number(), "hash", blocks[0].Hash())
-			return 0, nil
-		}
-		return h.chain.InsertChain(blocks)
-	}
-	h.blockFetcher = fetcher.NewBlockFetcher(h.chain.GetBlockByHash, validator, h.BroadcastBlock,
-		heighter, finalizeHeighter, inserter, h.removePeer, h.fetchHeader, h.fetchBodies)
 
 	fetchTx := func(peer string, hashes []common.Hash) error {
 		p := h.peers.peer(peer)
@@ -265,6 +239,24 @@ func newHandler(config *handlerConfig) (*handler, error) {
 	h.txFetcher = fetcher.NewTxFetcher(h.txpool.Has, addTxs, fetchTx, h.removePeer)
 	h.chainSync = newChainSyncer(h)
 	return h, nil
+}
+
+// connectBeacon connects beacon client to the protocols, and inits its handler.
+func (h *handler) connectBeacon(beacon Beacon) {
+	inserter := func(blocks types.Blocks) (int, error) {
+		// If snap sync is running, deny importing weird blocks. This is a problematic
+		// clause when starting up a new network, because snap-syncing miners might not
+		// accept each others' blocks until a restart. Unfortunately we haven't figured
+		// out a way yet where nodes can decide unilaterally whether the network is new
+		// or not. This should be fixed if we figure out a solution.
+		if !h.synced.Load() {
+			log.Warn("Syncing, discarded propagated block", "number", blocks[0].Number(), "hash", blocks[0].Hash())
+			return 0, nil
+		}
+		return h.chain.InsertChain(blocks)
+	}
+	h.beacon = beacon
+	h.beacon.StartBlockFetcher(h.BroadcastBlock, inserter, h.removePeer, h.fetchHeader, h.fetchBodies)
 }
 
 // protoTracker tracks the number of active protocol handlers.

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -139,12 +139,11 @@ type handler struct {
 	txFetcher  *fetcher.TxFetcher
 	peers      *peerSet
 
-	eventMux      *event.TypeMux
-	txsCh         chan core.NewTxsEvent
-	txsSub        event.Subscription
-	reannoTxsCh   chan core.ReannoTxsEvent
-	reannoTxsSub  event.Subscription
-	minedBlockSub *event.TypeMuxSubscription
+	eventMux     *event.TypeMux
+	txsCh        chan core.NewTxsEvent
+	txsSub       event.Subscription
+	reannoTxsCh  chan core.ReannoTxsEvent
+	reannoTxsSub event.Subscription
 
 	requiredBlocks map[uint64]common.Hash
 
@@ -579,11 +578,6 @@ func (h *handler) Start(maxPeers int) {
 	h.reannoTxsSub = h.txpool.SubscribeReannoTransactions(h.reannoTxsCh)
 	go h.txReannounceLoop()
 
-	// broadcast mined blocks
-	h.wg.Add(1)
-	h.minedBlockSub = h.eventMux.Subscribe(core.NewMinedBlockEvent{})
-	go h.minedBroadcastLoop()
-
 	// start sync handlers
 	h.wg.Add(1)
 	go h.chainSync.loop()
@@ -594,9 +588,8 @@ func (h *handler) Start(maxPeers int) {
 }
 
 func (h *handler) Stop() {
-	h.txsSub.Unsubscribe()        // quits txBroadcastLoop
-	h.reannoTxsSub.Unsubscribe()  // quits txReannounceLoop
-	h.minedBlockSub.Unsubscribe() // quits blockBroadcastLoop
+	h.txsSub.Unsubscribe()       // quits txBroadcastLoop
+	h.reannoTxsSub.Unsubscribe() // quits txReannounceLoop
 
 	// Quit chainSync and txsync64.
 	// After this is done, no new peers will be accepted.
@@ -755,18 +748,6 @@ func (h *handler) ReannounceTransactions(txs types.Transactions) {
 	}
 	log.Debug("Transaction reannounce", "txs", len(txs),
 		"announce packs", peersCount, "announced hashes", peersCount*uint(len(hashes)))
-}
-
-// minedBroadcastLoop sends mined blocks to connected peers.
-func (h *handler) minedBroadcastLoop() {
-	defer h.wg.Done()
-
-	for obj := range h.minedBlockSub.Chan() {
-		if ev, ok := obj.Data.(core.NewMinedBlockEvent); ok {
-			h.BroadcastBlock(ev.Block, true)  // First propagate block to peers
-			h.BroadcastBlock(ev.Block, false) // Only then announce to the rest
-		}
-	}
 }
 
 // txBroadcastLoop announces new transactions to connected peers.

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -99,9 +99,8 @@ type txPool interface {
 
 type Beacon interface {
 	StartBlockFetcher(
-		broadcastBlock beaconfetch.BlockBroadcasterFn, insertChain beaconfetch.ChainInsertFn,
-		dropPeer beaconfetch.PeerDropFn, fetchHeader beaconfetch.HeaderRequesterFn,
-		fetchBodies beaconfetch.BodyRequesterFn,
+		broadcastBlock beaconfetch.BlockBroadcasterFn, dropPeer beaconfetch.PeerDropFn,
+		fetchHeader beaconfetch.HeaderRequesterFn, fetchBodies beaconfetch.BodyRequesterFn,
 	)
 	NotifyBlockAnnon(peer string, hash common.Hash, number uint64, time time.Time)
 	EnqueueBlock(peer string, block *types.Block)
@@ -242,20 +241,8 @@ func newHandler(config *handlerConfig) (*handler, error) {
 
 // connectBeacon connects beacon client to the protocols, and inits its handler.
 func (h *handler) connectBeacon(beacon Beacon) {
-	inserter := func(blocks types.Blocks) (int, error) {
-		// If snap sync is running, deny importing weird blocks. This is a problematic
-		// clause when starting up a new network, because snap-syncing miners might not
-		// accept each others' blocks until a restart. Unfortunately we haven't figured
-		// out a way yet where nodes can decide unilaterally whether the network is new
-		// or not. This should be fixed if we figure out a solution.
-		if !h.synced.Load() {
-			log.Warn("Syncing, discarded propagated block", "number", blocks[0].Number(), "hash", blocks[0].Hash())
-			return 0, nil
-		}
-		return h.chain.InsertChain(blocks)
-	}
 	h.beacon = beacon
-	h.beacon.StartBlockFetcher(h.BroadcastBlock, inserter, h.removePeer, h.fetchHeader, h.fetchBodies)
+	h.beacon.StartBlockFetcher(h.BroadcastBlock, h.removePeer, h.fetchHeader, h.fetchBodies)
 }
 
 // protoTracker tracks the number of active protocol handlers.

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/eth/fetcher"
+	beaconproto "github.com/ethereum/go-ethereum/eth/protocols/beacon"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/eth/protocols/snap"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -200,16 +201,6 @@ func newHandler(config *handlerConfig) (*handler, error) {
 	}
 	// Construct the downloader (long sync)
 	h.downloader = downloader.New(config.Database, h.eventMux, h.chain, h.removePeer, h.enableSyncedFeatures)
-	if ttd := h.chain.Config().TerminalTotalDifficulty; ttd != nil {
-		head := h.chain.CurrentBlock()
-		if td := h.chain.GetTd(head.Hash(), head.Number.Uint64()); td.Cmp(ttd) >= 0 {
-			log.Info("Chain post-TTD, sync via beacon client")
-		} else {
-			log.Warn("Chain pre-merge, sync via PoW (ensure beacon client is ready)")
-		}
-	} else {
-		log.Error("Chain configured without TTD")
-	}
 	// Construct the fetcher (short sync)
 	validator := func(header *types.Header) error {
 		// Reject all the PoS style headers in the first place. No matter
@@ -246,7 +237,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		return h.chain.InsertChain(blocks)
 	}
 	h.blockFetcher = fetcher.NewBlockFetcher(h.chain.GetBlockByHash, validator, h.BroadcastBlock,
-		heighter, finalizeHeighter, inserter, h.removePeer)
+		heighter, finalizeHeighter, inserter, h.removePeer, h.fetchHeader, h.fetchBodies)
 
 	fetchTx := func(peer string, hashes []common.Hash) error {
 		p := h.peers.peer(peer)
@@ -312,6 +303,56 @@ func (h *handler) decHandlers() {
 	h.handlerDoneCh <- struct{}{}
 }
 
+// runBeaconPeer registers an beacon peer into the joint beacon peerset, adds it to
+// various subsystems and starts handling messages.
+func (h *handler) runBeaconPeer(peer *beaconproto.Peer, handler beaconproto.Handler) error {
+	if !h.incHandlers() {
+		return p2p.DiscQuitting
+	}
+	defer h.decHandlers()
+
+	// Execute the Beacon handshake
+	var (
+		genesis = h.chain.Genesis()
+		head    = h.chain.CurrentHeader()
+		hash    = head.Hash()
+		number  = head.Number.Uint64()
+		td      = h.chain.GetTd(hash, number)
+	)
+	forkID := forkid.NewID(h.chain.Config(), genesis, number, head.Time)
+	if err := peer.Handshake(h.networkID, td, hash, genesis.Hash(), forkID, h.forkFilter); err != nil {
+		peer.Log().Debug("Beacon handshake failed", "err", err)
+		return err
+	}
+	// Ignore maxPeers if this is a trusted peer
+	if !peer.Peer.Info().Network.Trusted {
+		if h.peers.beaconLen() >= h.maxPeers {
+			return p2p.DiscTooManyPeers
+		}
+	}
+	peer.Log().Debug("Beacon peer connected", "name", peer.Name())
+
+	// Register the peer locally
+	if err := h.peers.registerBeacon(peer); err != nil {
+		peer.Log().Error("Beacon peer registration failed", "err", err)
+		return err
+	}
+	defer h.unregisterBeacon(peer.ID())
+
+	p := h.peers.beacon(peer.ID())
+	if p == nil {
+		return errors.New("peer dropped during handling")
+	}
+	// Register the peer in the downloader. If the downloader considers it banned, we disconnect
+	if err := h.downloader.RegisterBeacon(peer.ID(), peer); err != nil {
+		peer.Log().Error("Failed to register peer in eth syncer", "err", err)
+		return err
+	}
+	h.chainSync.handlePeerEvent()
+
+	return handler(peer)
+}
+
 // runEthPeer registers an eth peer into the joint eth/snap peerset, adds it to
 // various subsystems and starts handling messages.
 func (h *handler) runEthPeer(peer *eth.Peer, handler eth.Handler) error {
@@ -328,7 +369,7 @@ func (h *handler) runEthPeer(peer *eth.Peer, handler eth.Handler) error {
 		return err
 	}
 
-	// Execute the Ethereum handshake
+	// Execute the Ethereum handshake, but td and head is no longer referred
 	var (
 		genesis = h.chain.Genesis()
 		head    = h.chain.CurrentHeader()
@@ -464,9 +505,39 @@ func (h *handler) runSnapExtension(peer *snap.Peer, handler snap.Handler) error 
 
 // removePeer requests disconnection of a peer.
 func (h *handler) removePeer(id string) {
+	beacon := h.peers.beacon(id)
+	if beacon != nil {
+		beacon.Peer.Disconnect(p2p.DiscUselessPeer)
+	}
 	peer := h.peers.peer(id)
 	if peer != nil {
 		peer.Peer.Disconnect(p2p.DiscUselessPeer)
+	}
+}
+
+// unregisterBeacon removes a beacon from the downloader, fetchers and main peer set.
+func (h *handler) unregisterBeacon(id string) {
+	// Create a custom logger to avoid printing the entire id
+	var logger log.Logger
+	if len(id) < 16 {
+		// Tests use short IDs, don't choke on them
+		logger = log.New("beacon", id)
+	} else {
+		logger = log.New("beacon", id[:8])
+	}
+	// Abort if the peer does not exist
+	peer := h.peers.beacon(id)
+	if peer == nil {
+		logger.Warn("Beacon peer removal failed", "err", errPeerNotRegistered)
+		return
+	}
+	// Remove the `beacon` peer if it exists
+	logger.Debug("Removing Beacon peer")
+
+	h.downloader.UnregisterBeacon(id)
+
+	if err := h.peers.unregisterBeacon(id); err != nil {
+		logger.Error("Beacon peer removal failed", "err", err)
 	}
 }
 
@@ -559,7 +630,7 @@ func (h *handler) BroadcastBlock(block *types.Block, propagate bool) {
 		}
 	}
 	hash := block.Hash()
-	peers := h.peers.peersWithoutBlock(hash)
+	peers := h.peers.beaconsWithoutBlock(hash)
 
 	// If propagation is requested, send to a subset of the peer
 	if propagate {
@@ -586,6 +657,16 @@ func (h *handler) BroadcastBlock(block *types.Block, propagate bool) {
 		}
 		log.Trace("Announced block", "hash", hash, "recipients", len(peers), "duration", common.PrettyDuration(time.Since(block.ReceivedAt)))
 	}
+}
+
+// fetchHeader is the bridge to use a hash to get the header from `eth` protocol.
+func (h *handler) fetchHeader(id string, hash common.Hash, sink chan *eth.Response) (*eth.Request, error) {
+	return h.peers.peer(id).RequestOneHeader(hash, sink)
+}
+
+// fetchBodies is the bridge to use a hash array to get the block bodies from `eth` protocol.
+func (h *handler) fetchBodies(id string, hashes []common.Hash, sink chan *eth.Response) (*eth.Request, error) {
+	return h.peers.peer(id).RequestBodies(hashes, sink)
 }
 
 // BroadcastTransactions will propagate a batch of transactions

--- a/eth/handler_beacon.go
+++ b/eth/handler_beacon.go
@@ -61,8 +61,10 @@ func (h *beaconHandler) handleBlockAnnounces(peer *beacon.Peer, hashes []common.
 			unknownNumbers = append(unknownNumbers, numbers[i])
 		}
 	}
-	for i := 0; i < len(unknownHashes); i++ {
-		h.blockFetcher.Notify(peer.ID(), unknownHashes[i], unknownNumbers[i], time.Now())
+	if h.beacon != nil {
+		for i := 0; i < len(unknownHashes); i++ {
+			h.beacon.NotifyBlockAnnon(peer.ID(), unknownHashes[i], unknownNumbers[i], time.Now())
+		}
 	}
 	return nil
 }
@@ -74,7 +76,9 @@ func (h *beaconHandler) handleBlockBroadcast(peer *beacon.Peer, packet *beacon.N
 	td := packet.TD
 
 	// Schedule the block for import
-	h.blockFetcher.Enqueue(peer.ID(), block)
+	if h.beacon != nil {
+		h.beacon.EnqueueBlock(peer.ID(), block)
+	}
 
 	// Assuming the block is importable by the peer, but possibly not yet done so,
 	// calculate the head hash and TD that the peer truly must have.

--- a/eth/handler_beacon.go
+++ b/eth/handler_beacon.go
@@ -1,0 +1,91 @@
+package eth
+
+import (
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/eth/protocols/beacon"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+// beaconHandler implements the eth.Backend interface to handle the various network
+// packets that are sent as replies or broadcasts.
+type beaconHandler handler
+
+func (h *beaconHandler) Chain() *core.BlockChain { return h.chain }
+
+// RunPeer is invoked when a peer joins on the `beacon` protocol.
+func (h *beaconHandler) RunPeer(peer *beacon.Peer, hand beacon.Handler) error {
+	return (*handler)(h).runBeaconPeer(peer, hand)
+}
+
+// PeerInfo retrieves all known `beacon` information about a peer.
+func (h *beaconHandler) PeerInfo(id enode.ID) interface{} {
+	if p := h.peers.beacon(id.String()); p != nil {
+		return p.info()
+	}
+	return nil
+}
+
+// Handle is a callback to be invoked when a data packet is received from
+// the remote peer. Only packets not consumed by the protocol handler will
+// be forwarded to the backend.
+func (h *beaconHandler) Handle(peer *beacon.Peer, packet beacon.Packet) error {
+	switch packet := packet.(type) {
+	case *beacon.NewBlockHashesPacket:
+		hashes, numbers := packet.Unpack()
+		return h.handleBlockAnnounces(peer, hashes, numbers)
+
+	case *beacon.NewBlockPacket:
+		return h.handleBlockBroadcast(peer, packet)
+
+	default:
+		return fmt.Errorf("unexpected beacon packet type: %T", packet)
+	}
+}
+
+// handleBlockAnnounces is invoked from a peer's message handler when it transmits a
+// batch of block announcements for the local node to process.
+func (h *beaconHandler) handleBlockAnnounces(peer *beacon.Peer, hashes []common.Hash, numbers []uint64) error {
+	// Schedule all the unknown hashes for retrieval
+	var (
+		unknownHashes  = make([]common.Hash, 0, len(hashes))
+		unknownNumbers = make([]uint64, 0, len(numbers))
+	)
+	for i := 0; i < len(hashes); i++ {
+		if !h.chain.HasBlock(hashes[i], numbers[i]) {
+			unknownHashes = append(unknownHashes, hashes[i])
+			unknownNumbers = append(unknownNumbers, numbers[i])
+		}
+	}
+	for i := 0; i < len(unknownHashes); i++ {
+		h.blockFetcher.Notify(peer.ID(), unknownHashes[i], unknownNumbers[i], time.Now())
+	}
+	return nil
+}
+
+// handleBlockBroadcast is invoked from a peer's message handler when it transmits a
+// block broadcast for the local node to process.
+func (h *beaconHandler) handleBlockBroadcast(peer *beacon.Peer, packet *beacon.NewBlockPacket) error {
+	block := packet.Block
+	td := packet.TD
+
+	// Schedule the block for import
+	h.blockFetcher.Enqueue(peer.ID(), block)
+
+	// Assuming the block is importable by the peer, but possibly not yet done so,
+	// calculate the head hash and TD that the peer truly must have.
+	var (
+		trueHead = block.ParentHash()
+		trueTD   = new(big.Int).Sub(td, block.Difficulty())
+	)
+	// Update the peer's total difficulty if better than the previous
+	if _, td := peer.Head(); trueTD.Cmp(td) > 0 {
+		peer.SetHead(trueHead, trueTD)
+		h.chainSync.handlePeerEvent()
+	}
+	return nil
+}

--- a/eth/handler_beacon_test.go
+++ b/eth/handler_beacon_test.go
@@ -1,0 +1,193 @@
+package eth
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/forkid"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/eth/protocols/beacon"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+// testBeaconHandler is a mock event handler to listen for inbound network requests
+// on the `beacon` protocol and convert them into a more easily testable form.
+type testBeaconHandler struct {
+	blockBroadcasts event.Feed
+}
+
+func (h *testBeaconHandler) Chain() *core.BlockChain                    { panic("no backing chain") }
+func (h *testBeaconHandler) RunPeer(*beacon.Peer, beacon.Handler) error { panic("not used in tests") }
+func (h *testBeaconHandler) PeerInfo(enode.ID) interface{}              { panic("not used in tests") }
+
+func (h *testBeaconHandler) Handle(peer *beacon.Peer, packet beacon.Packet) error {
+	switch packet := packet.(type) {
+	case *beacon.NewBlockPacket:
+		h.blockBroadcasts.Send(packet.Block)
+		return nil
+
+	default:
+		panic(fmt.Sprintf("unexpected beacon packet type in tests: %T", packet))
+	}
+}
+
+// Tests that blocks are broadcast to a sqrt number of peers only.
+func TestBroadcastBlock1Peer(t *testing.T)    { testBroadcastBlock(t, 1, 1) }
+func TestBroadcastBlock2Peers(t *testing.T)   { testBroadcastBlock(t, 2, 1) }
+func TestBroadcastBlock3Peers(t *testing.T)   { testBroadcastBlock(t, 3, 1) }
+func TestBroadcastBlock4Peers(t *testing.T)   { testBroadcastBlock(t, 4, 2) }
+func TestBroadcastBlock5Peers(t *testing.T)   { testBroadcastBlock(t, 5, 2) }
+func TestBroadcastBlock8Peers(t *testing.T)   { testBroadcastBlock(t, 9, 3) }
+func TestBroadcastBlock12Peers(t *testing.T)  { testBroadcastBlock(t, 12, 3) }
+func TestBroadcastBlock16Peers(t *testing.T)  { testBroadcastBlock(t, 16, 4) }
+func TestBroadcastBloc26Peers(t *testing.T)   { testBroadcastBlock(t, 26, 5) }
+func TestBroadcastBlock100Peers(t *testing.T) { testBroadcastBlock(t, 100, 10) }
+
+func testBroadcastBlock(t *testing.T, peers, bcasts int) {
+	t.Parallel()
+
+	// Create a source handler to broadcast blocks from and a number of sinks
+	// to receive them.
+	source := newTestHandlerWithBlocks(1)
+	defer source.close()
+
+	sinks := make([]*testBeaconHandler, peers)
+	for i := 0; i < len(sinks); i++ {
+		sinks[i] = new(testBeaconHandler)
+	}
+	// Interconnect all the sink handlers with the source handler
+	var (
+		genesis = source.chain.Genesis()
+		td      = source.chain.GetTd(genesis.Hash(), genesis.NumberU64())
+	)
+	for i, sink := range sinks {
+		sink := sink // Closure for gorotuine below
+
+		sourcePipe, sinkPipe := p2p.MsgPipe()
+		defer sourcePipe.Close()
+		defer sinkPipe.Close()
+
+		sourcePeer := beacon.NewPeer(beacon.BEACON1, p2p.NewPeerPipe(enode.ID{byte(i)}, "", nil, sourcePipe), sourcePipe)
+		sinkPeer := beacon.NewPeer(beacon.BEACON1, p2p.NewPeerPipe(enode.ID{0}, "", nil, sinkPipe), sinkPipe)
+		defer sourcePeer.Close()
+		defer sinkPeer.Close()
+
+		go source.handler.runBeaconPeer(sourcePeer, func(peer *beacon.Peer) error {
+			return beacon.Handle((*beaconHandler)(source.handler), peer)
+		})
+		if err := sinkPeer.Handshake(1, td, genesis.Hash(), genesis.Hash(), forkid.NewIDWithChain(source.chain), forkid.NewFilter(source.chain)); err != nil {
+			t.Fatalf("failed to run protocol handshake")
+		}
+		go beacon.Handle(sink, sinkPeer)
+	}
+	// Subscribe to all the block channels
+	blockChs := make([]chan *types.Block, len(sinks))
+	for i := 0; i < len(sinks); i++ {
+		blockChs[i] = make(chan *types.Block, 1)
+		defer close(blockChs[i])
+
+		sub := sinks[i].blockBroadcasts.Subscribe(blockChs[i])
+		defer sub.Unsubscribe()
+	}
+	// Initiate a block propagation across the peers
+	time.Sleep(100 * time.Millisecond)
+	header := source.chain.CurrentBlock()
+	source.handler.BroadcastBlock(source.chain.GetBlock(header.Hash(), header.Number.Uint64()), true)
+
+	// Iterate through all the sinks and ensure the correct number got the block
+	done := make(chan struct{}, peers)
+	for _, ch := range blockChs {
+		ch := ch
+		go func() {
+			<-ch
+			done <- struct{}{}
+		}()
+	}
+	var received int
+	for {
+		select {
+		case <-done:
+			received++
+
+		case <-time.After(100 * time.Millisecond):
+			if received != bcasts {
+				t.Errorf("broadcast count mismatch: have %d, want %d", received, bcasts)
+			}
+			return
+		}
+	}
+}
+
+// Tests that a propagated malformed block (uncles or transactions don't match
+// with the hashes in the header) gets discarded and not broadcast forward.
+func TestBroadcastMalformedBlock1(t *testing.T) { testBroadcastMalformedBlock(t, beacon.BEACON1) }
+
+func testBroadcastMalformedBlock(t *testing.T, protocol uint) {
+	t.Parallel()
+
+	// Create a source handler to broadcast blocks from and a number of sinks
+	// to receive them.
+	source := newTestHandlerWithBlocks(1)
+	defer source.close()
+
+	// Create a source handler to send messages through and a sink peer to receive them
+	p2pSrc, p2pSink := p2p.MsgPipe()
+	defer p2pSrc.Close()
+	defer p2pSink.Close()
+
+	src := beacon.NewPeer(protocol, p2p.NewPeerPipe(enode.ID{1}, "", nil, p2pSrc), p2pSrc)
+	sink := beacon.NewPeer(protocol, p2p.NewPeerPipe(enode.ID{2}, "", nil, p2pSink), p2pSink)
+	defer src.Close()
+	defer sink.Close()
+
+	go source.handler.runBeaconPeer(src, func(peer *beacon.Peer) error {
+		return beacon.Handle((*beaconHandler)(source.handler), peer)
+	})
+	// Run the handshake locally to avoid spinning up a sink handler
+	var (
+		genesis = source.chain.Genesis()
+		td      = source.chain.GetTd(genesis.Hash(), genesis.NumberU64())
+	)
+	if err := sink.Handshake(1, td, genesis.Hash(), genesis.Hash(), forkid.NewIDWithChain(source.chain), forkid.NewFilter(source.chain)); err != nil {
+		t.Fatalf("failed to run protocol handshake")
+	}
+	// After the handshake completes, the source handler should stream the sink
+	// the blocks, subscribe to inbound network events
+	backend := new(testBeaconHandler)
+
+	blocks := make(chan *types.Block, 1)
+	sub := backend.blockBroadcasts.Subscribe(blocks)
+	defer sub.Unsubscribe()
+
+	go beacon.Handle(backend, sink)
+
+	// Create various combinations of malformed blocks
+	head := source.chain.CurrentBlock()
+	block := source.chain.GetBlock(head.Hash(), head.Number.Uint64())
+
+	malformedUncles := head
+	malformedUncles.UncleHash[0]++
+	malformedTransactions := head
+	malformedTransactions.TxHash[0]++
+	malformedEverything := head
+	malformedEverything.UncleHash[0]++
+	malformedEverything.TxHash[0]++
+
+	// Try to broadcast all malformations and ensure they all get discarded
+	for _, header := range []*types.Header{malformedUncles, malformedTransactions, malformedEverything} {
+		block := types.NewBlockWithHeader(header).WithBody(types.Body{Transactions: block.Transactions(), Uncles: block.Uncles()})
+		if err := src.SendNewBlock(block, big.NewInt(131136)); err != nil {
+			t.Fatalf("failed to broadcast block: %v", err)
+		}
+		select {
+		case <-blocks:
+			t.Fatalf("malformed block forwarded")
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}

--- a/eth/handler_eth.go
+++ b/eth/handler_eth.go
@@ -19,10 +19,7 @@ package eth
 import (
 	"errors"
 	"fmt"
-	"math/big"
-	"time"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
@@ -60,13 +57,6 @@ func (h *ethHandler) AcceptTxs() bool {
 func (h *ethHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 	// Consume any broadcasts and announces, forwarding the rest to the downloader
 	switch packet := packet.(type) {
-	case *eth.NewBlockHashesPacket:
-		hashes, numbers := packet.Unpack()
-		return h.handleBlockAnnounces(peer, hashes, numbers)
-
-	case *eth.NewBlockPacket:
-		return h.handleBlockBroadcast(peer, packet)
-
 	case *eth.NewPooledTransactionHashesPacket:
 		return h.txFetcher.Notify(peer.ID(), packet.Types, packet.Sizes, packet.Hashes)
 
@@ -97,47 +87,4 @@ func (h *ethHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 	default:
 		return fmt.Errorf("unexpected eth packet type: %T", packet)
 	}
-}
-
-// handleBlockAnnounces is invoked from a peer's message handler when it transmits a
-// batch of block announcements for the local node to process.
-func (h *ethHandler) handleBlockAnnounces(peer *eth.Peer, hashes []common.Hash, numbers []uint64) error {
-	// Schedule all the unknown hashes for retrieval
-	var (
-		unknownHashes  = make([]common.Hash, 0, len(hashes))
-		unknownNumbers = make([]uint64, 0, len(numbers))
-	)
-	for i := 0; i < len(hashes); i++ {
-		if !h.chain.HasBlock(hashes[i], numbers[i]) {
-			unknownHashes = append(unknownHashes, hashes[i])
-			unknownNumbers = append(unknownNumbers, numbers[i])
-		}
-	}
-	for i := 0; i < len(unknownHashes); i++ {
-		h.blockFetcher.Notify(peer.ID(), unknownHashes[i], unknownNumbers[i], time.Now(), peer.RequestOneHeader, peer.RequestBodies)
-	}
-	return nil
-}
-
-// handleBlockBroadcast is invoked from a peer's message handler when it transmits a
-// block broadcast for the local node to process.
-func (h *ethHandler) handleBlockBroadcast(peer *eth.Peer, packet *eth.NewBlockPacket) error {
-	block := packet.Block
-	td := packet.TD
-
-	// Schedule the block for import
-	h.blockFetcher.Enqueue(peer.ID(), block)
-
-	// Assuming the block is importable by the peer, but possibly not yet done so,
-	// calculate the head hash and TD that the peer truly must have.
-	var (
-		trueHead = block.ParentHash()
-		trueTD   = new(big.Int).Sub(td, block.Difficulty())
-	)
-	// Update the peer's total difficulty if better than the previous
-	if _, td := peer.Head(); trueTD.Cmp(td) > 0 {
-		peer.SetHead(trueHead, trueTD)
-		h.chainSync.handlePeerEvent()
-	}
-	return nil
 }

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -40,9 +40,8 @@ import (
 // testEthHandler is a mock event handler to listen for inbound network requests
 // on the `eth` protocol and convert them into a more easily testable form.
 type testEthHandler struct {
-	blockBroadcasts event.Feed
-	txAnnounces     event.Feed
-	txBroadcasts    event.Feed
+	txAnnounces  event.Feed
+	txBroadcasts event.Feed
 }
 
 func (h *testEthHandler) Chain() *core.BlockChain              { panic("no backing chain") }
@@ -53,10 +52,6 @@ func (h *testEthHandler) PeerInfo(enode.ID) interface{}        { panic("not used
 
 func (h *testEthHandler) Handle(peer *eth.Peer, packet eth.Packet) error {
 	switch packet := packet.(type) {
-	case *eth.NewBlockPacket:
-		h.blockBroadcasts.Send(packet.Block)
-		return nil
-
 	case *eth.NewPooledTransactionHashesPacket:
 		h.txAnnounces.Send(packet.Hashes)
 		return nil
@@ -488,162 +483,6 @@ func testTransactionReannounce(t *testing.T, protocol uint) {
 			arrived += len(event.Txs)
 		case <-time.NewTimer(time.Second).C:
 			t.Errorf("sink: transaction propagation timed out: have %d, want %d", arrived, len(txs))
-		}
-	}
-}
-
-// Tests that blocks are broadcast to a sqrt number of peers only.
-func TestBroadcastBlock1Peer(t *testing.T)    { testBroadcastBlock(t, 1, 1) }
-func TestBroadcastBlock2Peers(t *testing.T)   { testBroadcastBlock(t, 2, 1) }
-func TestBroadcastBlock3Peers(t *testing.T)   { testBroadcastBlock(t, 3, 1) }
-func TestBroadcastBlock4Peers(t *testing.T)   { testBroadcastBlock(t, 4, 2) }
-func TestBroadcastBlock5Peers(t *testing.T)   { testBroadcastBlock(t, 5, 2) }
-func TestBroadcastBlock8Peers(t *testing.T)   { testBroadcastBlock(t, 9, 3) }
-func TestBroadcastBlock12Peers(t *testing.T)  { testBroadcastBlock(t, 12, 3) }
-func TestBroadcastBlock16Peers(t *testing.T)  { testBroadcastBlock(t, 16, 4) }
-func TestBroadcastBloc26Peers(t *testing.T)   { testBroadcastBlock(t, 26, 5) }
-func TestBroadcastBlock100Peers(t *testing.T) { testBroadcastBlock(t, 100, 10) }
-
-func testBroadcastBlock(t *testing.T, peers, bcasts int) {
-	t.Parallel()
-
-	// Create a source handler to broadcast blocks from and a number of sinks
-	// to receive them.
-	source := newTestHandlerWithBlocks(1)
-	defer source.close()
-
-	sinks := make([]*testEthHandler, peers)
-	for i := 0; i < len(sinks); i++ {
-		sinks[i] = new(testEthHandler)
-	}
-	// Interconnect all the sink handlers with the source handler
-	var (
-		genesis = source.chain.Genesis()
-		td      = source.chain.GetTd(genesis.Hash(), genesis.NumberU64())
-	)
-	for i, sink := range sinks {
-		sink := sink // Closure for gorotuine below
-
-		sourcePipe, sinkPipe := p2p.MsgPipe()
-		defer sourcePipe.Close()
-		defer sinkPipe.Close()
-
-		sourcePeer := eth.NewPeer(eth.ETH68, p2p.NewPeerPipe(enode.ID{byte(i)}, "", nil, sourcePipe), sourcePipe, nil)
-		sinkPeer := eth.NewPeer(eth.ETH68, p2p.NewPeerPipe(enode.ID{0}, "", nil, sinkPipe), sinkPipe, nil)
-		defer sourcePeer.Close()
-		defer sinkPeer.Close()
-
-		go source.handler.runEthPeer(sourcePeer, func(peer *eth.Peer) error {
-			return eth.Handle((*ethHandler)(source.handler), peer)
-		})
-		if err := sinkPeer.Handshake(1, td, genesis.Hash(), genesis.Hash(), forkid.NewIDWithChain(source.chain), forkid.NewFilter(source.chain)); err != nil {
-			t.Fatalf("failed to run protocol handshake")
-		}
-		go eth.Handle(sink, sinkPeer)
-	}
-	// Subscribe to all the transaction pools
-	blockChs := make([]chan *types.Block, len(sinks))
-	for i := 0; i < len(sinks); i++ {
-		blockChs[i] = make(chan *types.Block, 1)
-		defer close(blockChs[i])
-
-		sub := sinks[i].blockBroadcasts.Subscribe(blockChs[i])
-		defer sub.Unsubscribe()
-	}
-	// Initiate a block propagation across the peers
-	time.Sleep(100 * time.Millisecond)
-	header := source.chain.CurrentBlock()
-	source.handler.BroadcastBlock(source.chain.GetBlock(header.Hash(), header.Number.Uint64()), true)
-
-	// Iterate through all the sinks and ensure the correct number got the block
-	done := make(chan struct{}, peers)
-	for _, ch := range blockChs {
-		ch := ch
-		go func() {
-			<-ch
-			done <- struct{}{}
-		}()
-	}
-	var received int
-	for {
-		select {
-		case <-done:
-			received++
-
-		case <-time.After(100 * time.Millisecond):
-			if received != bcasts {
-				t.Errorf("broadcast count mismatch: have %d, want %d", received, bcasts)
-			}
-			return
-		}
-	}
-}
-
-// Tests that a propagated malformed block (uncles or transactions don't match
-// with the hashes in the header) gets discarded and not broadcast forward.
-func TestBroadcastMalformedBlock68(t *testing.T) { testBroadcastMalformedBlock(t, eth.ETH68) }
-
-func testBroadcastMalformedBlock(t *testing.T, protocol uint) {
-	t.Parallel()
-
-	// Create a source handler to broadcast blocks from and a number of sinks
-	// to receive them.
-	source := newTestHandlerWithBlocks(1)
-	defer source.close()
-
-	// Create a source handler to send messages through and a sink peer to receive them
-	p2pSrc, p2pSink := p2p.MsgPipe()
-	defer p2pSrc.Close()
-	defer p2pSink.Close()
-
-	src := eth.NewPeer(protocol, p2p.NewPeerPipe(enode.ID{1}, "", nil, p2pSrc), p2pSrc, source.txpool)
-	sink := eth.NewPeer(protocol, p2p.NewPeerPipe(enode.ID{2}, "", nil, p2pSink), p2pSink, source.txpool)
-	defer src.Close()
-	defer sink.Close()
-
-	go source.handler.runEthPeer(src, func(peer *eth.Peer) error {
-		return eth.Handle((*ethHandler)(source.handler), peer)
-	})
-	// Run the handshake locally to avoid spinning up a sink handler
-	var (
-		genesis = source.chain.Genesis()
-		td      = source.chain.GetTd(genesis.Hash(), genesis.NumberU64())
-	)
-	if err := sink.Handshake(1, td, genesis.Hash(), genesis.Hash(), forkid.NewIDWithChain(source.chain), forkid.NewFilter(source.chain)); err != nil {
-		t.Fatalf("failed to run protocol handshake")
-	}
-	// After the handshake completes, the source handler should stream the sink
-	// the blocks, subscribe to inbound network events
-	backend := new(testEthHandler)
-
-	blocks := make(chan *types.Block, 1)
-	sub := backend.blockBroadcasts.Subscribe(blocks)
-	defer sub.Unsubscribe()
-
-	go eth.Handle(backend, sink)
-
-	// Create various combinations of malformed blocks
-	head := source.chain.CurrentBlock()
-	block := source.chain.GetBlock(head.Hash(), head.Number.Uint64())
-
-	malformedUncles := head
-	malformedUncles.UncleHash[0]++
-	malformedTransactions := head
-	malformedTransactions.TxHash[0]++
-	malformedEverything := head
-	malformedEverything.UncleHash[0]++
-	malformedEverything.TxHash[0]++
-
-	// Try to broadcast all malformations and ensure they all get discarded
-	for _, header := range []*types.Header{malformedUncles, malformedTransactions, malformedEverything} {
-		block := types.NewBlockWithHeader(header).WithBody(types.Body{Transactions: block.Transactions(), Uncles: block.Uncles()})
-		if err := src.SendNewBlock(block, big.NewInt(131136)); err != nil {
-			t.Fatalf("failed to broadcast block: %v", err)
-		}
-		select {
-		case <-blocks:
-			t.Fatalf("malformed block forwarded")
-		case <-time.After(100 * time.Millisecond):
 		}
 	}
 }

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -17,6 +17,7 @@
 package eth
 
 import (
+	"github.com/ethereum/go-ethereum/eth/protocols/beacon"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/eth/protocols/snap"
 )
@@ -54,6 +55,24 @@ type snapPeer struct {
 // info gathers and returns some `snap` protocol metadata known about a peer.
 func (p *snapPeer) info() *snapPeerInfo {
 	return &snapPeerInfo{
+		Version: p.Version(),
+	}
+}
+
+// beaconPeerInfo represents a short summary of the `beacon` sub-protocol metadata known
+// about a connected peer.
+type beaconPeerInfo struct {
+	Version uint `json:"version"` // Beacon protocol version negotiated
+}
+
+// beaconPeer is a wrapper around beacon.Peer to maintain a few extra metadata.
+type beaconPeer struct {
+	*beacon.Peer
+}
+
+// info gathers and returns some `beacon` protocol metadata known about a peer.
+func (p *beaconPeer) info() *beaconPeerInfo {
+	return &beaconPeerInfo{
 		Version: p.Version(),
 	}
 }

--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/eth/protocols/beacon"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/eth/protocols/snap"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -49,8 +50,9 @@ var (
 // peerSet represents the collection of active peers currently participating in
 // the `eth` protocol, with or without the `snap` extension.
 type peerSet struct {
-	peers     map[string]*ethPeer // Peers connected on the `eth` protocol
-	snapPeers int                 // Number of `snap` compatible peers for connection prioritization
+	beacons   map[string]*beaconPeer // Peers connected on the `beacon` protocol
+	peers     map[string]*ethPeer    // Peers connected on the `eth` protocol
+	snapPeers int                    // Number of `snap` compatible peers for connection prioritization
 
 	snapWait map[string]chan *snap.Peer // Peers connected on `eth` waiting for their snap extension
 	snapPend map[string]*snap.Peer      // Peers connected on the `snap` protocol, but not yet on `eth`
@@ -63,6 +65,7 @@ type peerSet struct {
 // newPeerSet creates a new peer set to track the active participants.
 func newPeerSet() *peerSet {
 	return &peerSet{
+		beacons:  make(map[string]*beaconPeer),
 		peers:    make(map[string]*ethPeer),
 		snapWait: make(map[string]chan *snap.Peer),
 		snapPend: make(map[string]*snap.Peer),
@@ -142,6 +145,27 @@ func (ps *peerSet) waitSnapExtension(peer *eth.Peer) (*snap.Peer, error) {
 	}
 }
 
+// registerBeacon injects a new `beacon` peer into the working set, or returns an error
+// if the peer is already known.
+func (ps *peerSet) registerBeacon(peer *beacon.Peer) error {
+	// Start tracking the new peer
+	ps.lock.Lock()
+	defer ps.lock.Unlock()
+
+	if ps.closed {
+		return errPeerSetClosed
+	}
+	id := peer.ID()
+	if _, ok := ps.beacons[id]; ok {
+		return errPeerAlreadyRegistered
+	}
+	beacon := &beaconPeer{
+		Peer: peer,
+	}
+	ps.beacons[id] = beacon
+	return nil
+}
+
 // registerPeer injects a new `eth` peer into the working set, or returns an error
 // if the peer is already known.
 func (ps *peerSet) registerPeer(peer *eth.Peer, ext *snap.Peer) error {
@@ -184,6 +208,28 @@ func (ps *peerSet) unregisterPeer(id string) error {
 	return nil
 }
 
+// unregisterBeacon removes a remote beacon peer from the active set, disabling any
+// further actions to/from that particular entity.
+func (ps *peerSet) unregisterBeacon(id string) error {
+	ps.lock.Lock()
+	defer ps.lock.Unlock()
+
+	_, ok := ps.beacons[id]
+	if !ok {
+		return errPeerNotRegistered
+	}
+	delete(ps.beacons, id)
+	return nil
+}
+
+// beacon retrieves the registered beacon peer with the given id.
+func (ps *peerSet) beacon(id string) *beaconPeer {
+	ps.lock.RLock()
+	defer ps.lock.RUnlock()
+
+	return ps.beacons[id]
+}
+
 // peer retrieves the registered peer with the given id.
 func (ps *peerSet) peer(id string) *ethPeer {
 	ps.lock.RLock()
@@ -192,16 +238,16 @@ func (ps *peerSet) peer(id string) *ethPeer {
 	return ps.peers[id]
 }
 
-// peersWithoutBlock retrieves a list of peers that do not have a given block in
+// beaconsWithoutBlock retrieves a list of peers that do not have a given block in
 // their set of known hashes so it might be propagated to them.
-func (ps *peerSet) peersWithoutBlock(hash common.Hash) []*ethPeer {
+func (ps *peerSet) beaconsWithoutBlock(hash common.Hash) []*beaconPeer {
 	ps.lock.RLock()
 	defer ps.lock.RUnlock()
 
-	list := make([]*ethPeer, 0, len(ps.peers))
-	for _, p := range ps.peers {
-		if !p.KnownBlock(hash) {
-			list = append(list, p)
+	list := make([]*beaconPeer, 0, len(ps.peers))
+	for _, b := range ps.beacons {
+		if !b.KnownBlock(hash) {
+			list = append(list, b)
 		}
 	}
 	return list
@@ -263,6 +309,14 @@ func (ps *peerSet) len() int {
 	return len(ps.peers)
 }
 
+// beaconLen returns if the current number of `beacon` peers in the set.
+func (ps *peerSet) beaconLen() int {
+	ps.lock.RLock()
+	defer ps.lock.RUnlock()
+
+	return len(ps.beacons)
+}
+
 // snapLen returns if the current number of `snap` peers in the set.
 func (ps *peerSet) snapLen() int {
 	ps.lock.RLock()
@@ -273,20 +327,23 @@ func (ps *peerSet) snapLen() int {
 
 // peerWithHighestTD retrieves the known peer with the currently highest total
 // difficulty, but below the given PoS switchover threshold.
-func (ps *peerSet) peerWithHighestTD() *eth.Peer {
+func (ps *peerSet) peerWithHighestTD() (*beacon.Peer, *eth.Peer) {
 	ps.lock.RLock()
 	defer ps.lock.RUnlock()
 
 	var (
-		bestPeer *eth.Peer
-		bestTd   *big.Int
+		bestBeacon *beacon.Peer
+		bestPeer   *eth.Peer
+		bestTd     *big.Int
 	)
-	for _, p := range ps.peers {
-		if _, td := p.Head(); bestPeer == nil || td.Cmp(bestTd) > 0 {
-			bestPeer, bestTd = p.Peer, td
+	for _, b := range ps.beacons {
+		if _, td := b.Head(); bestPeer == nil || td.Cmp(bestTd) > 0 {
+			if p := ps.peers[b.ID()]; p != nil {
+				bestBeacon, bestPeer, bestTd = b.Peer, p.Peer, td
+			}
 		}
 	}
-	return bestPeer
+	return bestBeacon, bestPeer
 }
 
 // close disconnects all peers.
@@ -296,6 +353,9 @@ func (ps *peerSet) close() {
 
 	for _, p := range ps.peers {
 		p.Disconnect(p2p.DiscQuitting)
+	}
+	for _, b := range ps.beacons {
+		b.Disconnect(p2p.DiscQuitting)
 	}
 	if !ps.closed {
 		close(ps.quitCh)

--- a/eth/protocols/beacon/broadcast.go
+++ b/eth/protocols/beacon/broadcast.go
@@ -1,0 +1,39 @@
+package beacon
+
+import (
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+// blockPropagation is a block propagation event, waiting for its turn in the
+// broadcast queue.
+type blockPropagation struct {
+	block *types.Block
+	td    *big.Int
+}
+
+// broadcastBlocks is a write loop that multiplexes blocks and block announcements
+// to the remote peer. The goal is to have an async writer that does not lock up
+// node internals and at the same time rate limits queued data.
+func (p *Peer) broadcastBlocks() {
+	for {
+		select {
+		case prop := <-p.queuedBlocks:
+			if err := p.SendNewBlock(prop.block, prop.td); err != nil {
+				return
+			}
+			p.Log().Trace("Propagated block", "number", prop.block.Number(), "hash", prop.block.Hash(), "td", prop.td)
+
+		case block := <-p.queuedBlockAnns:
+			if err := p.SendNewBlockHashes([]common.Hash{block.Hash()}, []uint64{block.NumberU64()}); err != nil {
+				return
+			}
+			p.Log().Trace("Announced block", "number", block.Number(), "hash", block.Hash())
+
+		case <-p.term:
+			return
+		}
+	}
+}

--- a/eth/protocols/beacon/discovery.go
+++ b/eth/protocols/beacon/discovery.go
@@ -1,0 +1,16 @@
+package beacon
+
+import (
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// enrEntry is the ENR entry which advertises `beacon` protocol on the discovery.
+type enrEntry struct {
+	// Ignore additional fields (for forward compatibility).
+	Rest []rlp.RawValue `rlp:"tail"`
+}
+
+// ENRKey implements enr.Entry.
+func (e enrEntry) ENRKey() string {
+	return "beacon"
+}

--- a/eth/protocols/beacon/dispatcher.go
+++ b/eth/protocols/beacon/dispatcher.go
@@ -1,0 +1,239 @@
+package beacon
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p"
+)
+
+var (
+	// errDisconnected is returned if a request is attempted to be made to a peer
+	// that was already closed.
+	errDisconnected = errors.New("disconnected")
+
+	// errDanglingResponse is returned if a response arrives with a request id
+	// which does not match to any existing pending requests.
+	errDanglingResponse = errors.New("response to non-existent request")
+
+	// errMismatchingResponseType is returned if the remote peer sent a different
+	// packet type as a response to a request than what the local node expected.
+	errMismatchingResponseType = errors.New("mismatching response type")
+)
+
+// Request is a pending request to allow tracking it and delivering a response
+// back to the requester on their chosen channel.
+type Request struct {
+	peer *Peer  // Peer to which this request belongs for untracking
+	id   uint64 // Request ID to match up replies to
+
+	sink   chan *Response // Channel to deliver the response on
+	cancel chan struct{}  // Channel to cancel requests ahead of time
+
+	code uint64      // Message code of the request packet
+	want uint64      // Message code of the response packet
+	data interface{} // Data content of the request packet
+
+	Peer string    // Demultiplexer if cross-peer requests are batched together
+	Sent time.Time // Timestamp when the request was sent
+}
+
+// Close aborts an in-flight request. Although there's no way to notify the
+// remote peer about the cancellation, this method notifies the dispatcher to
+// discard any late responses.
+func (r *Request) Close() error {
+	if r.peer == nil { // Tests mock out the dispatcher, skip internal cancellation
+		return nil
+	}
+	cancelOp := &cancel{
+		id:   r.id,
+		fail: make(chan error),
+	}
+	select {
+	case r.peer.reqCancel <- cancelOp:
+		if err := <-cancelOp.fail; err != nil {
+			return err
+		}
+		close(r.cancel)
+		return nil
+	case <-r.peer.term:
+		return errDisconnected
+	}
+}
+
+// request is a wrapper around a client Request that has an error channel to
+// signal on if sending the request already failed on a network level.
+type request struct {
+	req  *Request
+	fail chan error
+}
+
+// cancel is a maintenance type on the dispatcher to stop tracking a pending
+// request.
+type cancel struct {
+	id   uint64 // Request ID to stop tracking
+	fail chan error
+}
+
+// Response is a reply packet to a previously created request. It is delivered
+// on the channel assigned by the requester subsystem and contains the original
+// request embedded to allow uniquely matching it caller side.
+type Response struct {
+	id   uint64    // Request ID to match up this reply to
+	recv time.Time // Timestamp when the request was received
+	code uint64    // Response packet type to cross validate with request
+
+	Req  *Request      // Original request to cross-reference with
+	Res  interface{}   // Remote response for the request query
+	Meta interface{}   // Metadata generated locally on the receiver thread
+	Time time.Duration // Time it took for the request to be served
+	Done chan error    // Channel to signal message handling to the reader
+}
+
+// response is a wrapper around a remote Response that has an error channel to
+// signal on if processing the response failed.
+type response struct {
+	res  *Response
+	fail chan error
+}
+
+// dispatchRequest schedules the request to the dispatcher for tracking and
+// network serialization, blocking until it's successfully sent.
+//
+// The returned Request must either be closed before discarding it, or the reply
+// must be waited for and the Response's Done channel signalled.
+func (p *Peer) dispatchRequest(req *Request) error {
+	reqOp := &request{
+		req:  req,
+		fail: make(chan error),
+	}
+	req.cancel = make(chan struct{})
+	req.peer = p
+	req.Peer = p.id
+
+	select {
+	case p.reqDispatch <- reqOp:
+		return <-reqOp.fail
+	case <-p.term:
+		return errDisconnected
+	}
+}
+
+// dispatchResponse fulfils a pending request and delivers it to the requested
+// sink.
+func (p *Peer) dispatchResponse(res *Response, metadata func() interface{}) error {
+	resOp := &response{
+		res:  res,
+		fail: make(chan error),
+	}
+	res.recv = time.Now()
+	res.Done = make(chan error)
+
+	select {
+	case p.resDispatch <- resOp:
+		// Ensure the response is accepted by the dispatcher
+		if err := <-resOp.fail; err != nil {
+			return nil
+		}
+		// Request was accepted, run any postprocessing step to generate metadata
+		// on the receiver thread, not the sink thread
+		if metadata != nil {
+			res.Meta = metadata()
+		}
+		// Deliver the filled out response and wait until it's handled. This
+		// path is a bit funky as Go's select has no order, so if a response
+		// arrives to an already cancelled request, there's a 50-50% changes
+		// of picking on channel or the other. To avoid such cases delivering
+		// the packet upstream, check for cancellation first and only after
+		// block on delivery.
+		select {
+		case <-res.Req.cancel:
+			return nil // Request cancelled, silently discard response
+		default:
+			// Request not yet cancelled, attempt to deliver it, but do watch
+			// for fresh cancellations too
+			select {
+			case res.Req.sink <- res:
+				return <-res.Done // Response delivered, return any errors
+			case <-res.Req.cancel:
+				return nil // Request cancelled, silently discard response
+			case <-p.term:
+				return errDisconnected
+			}
+		}
+
+	case <-p.term:
+		return errDisconnected
+	}
+}
+
+// dispatcher is a loop that accepts requests from higher layer packages, pushes
+// it to the network and tracks and dispatches the responses back to the original
+// requester.
+func (p *Peer) dispatcher() {
+	pending := make(map[uint64]*Request)
+
+	for {
+		select {
+		case reqOp := <-p.reqDispatch:
+			req := reqOp.req
+			req.Sent = time.Now()
+
+			requestTracker.Track(p.id, p.version, req.code, req.want, req.id)
+			err := p2p.Send(p.rw, req.code, req.data)
+			reqOp.fail <- err
+
+			if err == nil {
+				pending[req.id] = req
+			}
+
+		case cancelOp := <-p.reqCancel:
+			// Retrieve the pending request to cancel and short circuit if it
+			// has already been serviced and is not available anymore
+			req := pending[cancelOp.id]
+			if req == nil {
+				cancelOp.fail <- nil
+				continue
+			}
+			// Stop tracking the request
+			delete(pending, cancelOp.id)
+			cancelOp.fail <- nil
+
+		case resOp := <-p.resDispatch:
+			res := resOp.res
+			res.Req = pending[res.id]
+
+			// Independent if the request exists or not, track this packet
+			requestTracker.Fulfil(p.id, p.version, res.code, res.id)
+
+			switch {
+			case res.Req == nil:
+				// Response arrived with an untracked ID. Since even cancelled
+				// requests are tracked until fulfillment, a dangling response
+				// means the remote peer implements the protocol badly.
+				resOp.fail <- errDanglingResponse
+
+			case res.Req.want != res.code:
+				// Response arrived, but it's a different packet type than the
+				// one expected by the requester. Either the local code is bad,
+				// or the remote peer send junk. In neither cases can we handle
+				// the packet.
+				resOp.fail <- fmt.Errorf("%w: have %d, want %d", errMismatchingResponseType, res.code, res.Req.want)
+
+			default:
+				// All dispatcher checks passed and the response was initialized
+				// with the matching request. Signal to the delivery routine that
+				// it can wait for a handler response and dispatch the data.
+				res.Time = res.recv.Sub(res.Req.Sent)
+				resOp.fail <- nil
+
+				// Stop tracking the request, the response dispatcher will deliver
+				delete(pending, res.id)
+			}
+
+		case <-p.term:
+			return
+		}
+	}
+}

--- a/eth/protocols/beacon/handler.go
+++ b/eth/protocols/beacon/handler.go
@@ -1,0 +1,124 @@
+package beacon
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/metrics"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+)
+
+// Handler is a callback to invoke from an outside runner after the boilerplate
+// exchanges have passed.
+type Handler func(peer *Peer) error
+
+type Backend interface {
+	// RunPeer is invoked when a peer joins on the `beacon` protocol. The handler
+	// should do any peer maintenance work, handshakes and validations. If all
+	// is passed, control should be given back to the `handler` to process the
+	// inbound messages going forward.
+	RunPeer(peer *Peer, handler Handler) error
+
+	// PeerInfo retrieves all known `beacon` information about a peer.
+	PeerInfo(id enode.ID) interface{}
+
+	// Handle is a callback to be invoked when a data packet is received from
+	// the remote peer. Only packets not consumed by the protocol handler will
+	// be forwarded to the backend.
+	Handle(peer *Peer, packet Packet) error
+}
+
+// MakeProtocols constructs the P2P protocol definitions for `beacon`.
+func MakeProtocols(backend Backend) []p2p.Protocol {
+	protocols := make([]p2p.Protocol, len(ProtocolVersions))
+	for i, version := range ProtocolVersions {
+		protocols[i] = p2p.Protocol{
+			Name:    ProtocolName,
+			Version: version,
+			Length:  protocolLengths[version],
+			Run: func(p *p2p.Peer, rw p2p.MsgReadWriter) error {
+				peer := NewPeer(version, p, rw)
+				defer peer.Close()
+
+				return backend.RunPeer(peer, func(peer *Peer) error {
+					return Handle(backend, peer)
+				})
+			},
+			NodeInfo: func() interface{} {
+				return nodeInfo()
+			},
+			PeerInfo: func(id enode.ID) interface{} {
+				return backend.PeerInfo(id)
+			},
+			Attributes: []enr.Entry{&enrEntry{}},
+		}
+	}
+	return protocols
+}
+
+// NodeInfo represents a short summary of the `beacon` sub-protocol metadata
+// known about the host peer.
+type NodeInfo struct{}
+
+// nodeInfo retrieves some `beacon` protocol metadata about the running host node.
+func nodeInfo() *NodeInfo {
+	return &NodeInfo{}
+}
+
+// Handle is the callback invoked to manage the life cycle of a `beacon` peer.
+// When this function terminates, the peer is disconnected.
+func Handle(backend Backend, peer *Peer) error {
+	for {
+		if err := handleMessage(backend, peer); err != nil {
+			peer.Log().Debug("Message handling failed in `beacon`", "err", err)
+			return err
+		}
+	}
+}
+
+type msgHandler func(backend Backend, msg Decoder, peer *Peer) error
+type Decoder interface {
+	Decode(val interface{}) error
+	Time() time.Time
+}
+
+var beacon1 = map[uint64]msgHandler{
+	NewBlockHashesMsg: handleNewBlockhashes,
+	NewBlockMsg:       handleNewBlock,
+}
+
+// handleMessage is invoked whenever an inbound message is received from a
+// remote peer on the `beacon` protocol. The remote connection is torn down upon
+// returning any error.
+func handleMessage(backend Backend, peer *Peer) error {
+	// Read the next message from the remote peer, and ensure it's fully consumed
+	msg, err := peer.rw.ReadMsg()
+	if err != nil {
+		return err
+	}
+	if msg.Size > maxMessageSize {
+		return fmt.Errorf("%w: %v > %v", errMsgTooLarge, msg.Size, maxMessageSize)
+	}
+	defer msg.Discard()
+
+	var handlers = beacon1
+
+	// Track the amount of time it takes to serve the request and run the handler
+	if metrics.Enabled() {
+		h := fmt.Sprintf("%s/%s/%d/%#02x", p2p.HandleHistName, ProtocolName, peer.Version(), msg.Code)
+		defer func(start time.Time) {
+			sampler := func() metrics.Sample {
+				return metrics.ResettingSample(
+					metrics.NewExpDecaySample(1028, 0.015),
+				)
+			}
+			metrics.GetOrRegisterHistogramLazy(h, nil, sampler).Update(time.Since(start).Microseconds())
+		}(time.Now())
+	}
+	if handler := handlers[msg.Code]; handler != nil {
+		return handler(backend, msg, peer)
+	}
+	return fmt.Errorf("%w: %v", errInvalidMsgCode, msg.Code)
+}

--- a/eth/protocols/beacon/handlers.go
+++ b/eth/protocols/beacon/handlers.go
@@ -1,0 +1,46 @@
+package beacon
+
+import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/ethereum/go-ethereum/trie"
+)
+
+func handleNewBlockhashes(backend Backend, msg Decoder, peer *Peer) error {
+	// A batch of new block announcements just arrived
+	ann := new(NewBlockHashesPacket)
+	if err := msg.Decode(ann); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	// Mark the hashes as present at the remote node
+	for _, block := range *ann {
+		peer.markBlock(block.Hash)
+	}
+	// Deliver them all to the backend for queuing
+	return backend.Handle(peer, ann)
+}
+
+func handleNewBlock(backend Backend, msg Decoder, peer *Peer) error {
+	// Retrieve and decode the propagated block
+	ann := new(NewBlockPacket)
+	if err := msg.Decode(ann); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if hash := types.CalcUncleHash(ann.Block.Uncles()); hash != ann.Block.UncleHash() {
+		log.Warn("Propagated block has invalid uncles", "have", hash, "exp", ann.Block.UncleHash())
+		return nil // TODO(karalabe): return error eventually, but wait a few releases
+	}
+	if hash := types.DeriveSha(ann.Block.Transactions(), trie.NewStackTrie(nil)); hash != ann.Block.TxHash() {
+		log.Warn("Propagated block has invalid body", "have", hash, "exp", ann.Block.TxHash())
+		return nil // TODO(karalabe): return error eventually, but wait a few releases
+	}
+	ann.Block.ReceivedAt = msg.Time()
+	ann.Block.ReceivedFrom = peer
+
+	// Mark the peer as owning the block
+	peer.markBlock(ann.Block.Hash())
+
+	return backend.Handle(peer, ann)
+}

--- a/eth/protocols/beacon/handshake.go
+++ b/eth/protocols/beacon/handshake.go
@@ -1,36 +1,18 @@
-// Copyright 2020 The go-ethereum Authors
-// This file is part of the go-ethereum library.
-//
-// The go-ethereum library is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// The go-ethereum library is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public License
-// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
-
-package eth
+package beacon
 
 import (
-	"errors"
 	"fmt"
 	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/forkid"
-	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"
 )
 
 const (
-	// handshakeTimeout is the maximum allowed time for the `eth` handshake to
-	// complete before dropping the connection.= as malicious.
+	// handshakeTimeout is the maximum allowed time for the `beacon` handshake to
+	// complete before dropping the connection as malicious.
 	handshakeTimeout = 5 * time.Second
 )
 
@@ -61,14 +43,13 @@ func (p *Peer) Handshake(network uint64, td *big.Int, head common.Hash, genesis 
 		select {
 		case err := <-errc:
 			if err != nil {
-				markError(p, err)
 				return err
 			}
 		case <-timeout.C:
-			markError(p, p2p.DiscReadTimeout)
 			return p2p.DiscReadTimeout
 		}
 	}
+	p.td, p.head = status.TD, status.Head
 	return nil
 }
 
@@ -101,26 +82,4 @@ func (p *Peer) readStatus(network uint64, status *StatusPacket, genesis common.H
 		return fmt.Errorf("%w: %v", errForkIDRejected, err)
 	}
 	return nil
-}
-
-// markError registers the error with the corresponding metric.
-func markError(p *Peer, err error) {
-	if !metrics.Enabled() {
-		return
-	}
-	m := meters.get(p.Inbound())
-	switch errors.Unwrap(err) {
-	case errNetworkIDMismatch:
-		m.networkIDMismatch.Mark(1)
-	case errProtocolVersionMismatch:
-		m.protocolVersionMismatch.Mark(1)
-	case errGenesisMismatch:
-		m.genesisMismatch.Mark(1)
-	case errForkIDRejected:
-		m.forkidRejected.Mark(1)
-	case p2p.DiscReadTimeout:
-		m.timeoutError.Mark(1)
-	default:
-		m.peerError.Mark(1)
-	}
 }

--- a/eth/protocols/beacon/peer.go
+++ b/eth/protocols/beacon/peer.go
@@ -1,0 +1,200 @@
+package beacon
+
+import (
+	"math/big"
+	"sync"
+
+	mapset "github.com/deckarep/golang-set/v2"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/p2p"
+)
+
+const (
+	// maxKnownBlocks is the maximum block hashes to keep in the known list
+	// before starting to randomly evict them.
+	maxKnownBlocks = 1024
+
+	// maxQueuedBlocks is the maximum number of block propagations to queue up before
+	// dropping broadcasts. There's not much point in queueing stale blocks, so a few
+	// that might cover uncles should be enough.
+	maxQueuedBlocks = 4
+
+	// maxQueuedBlockAnns is the maximum number of block announcements to queue up before
+	// dropping broadcasts. Similarly to block propagations, there's no point to queue
+	// above some healthy uncle limit, so use that.
+	maxQueuedBlockAnns = 4
+)
+
+// Peer is a collection of relevant information we have about a `beacon` peer.
+type Peer struct {
+	id string // Unique ID for the peer, cached
+
+	*p2p.Peer                   // The embedded P2P package peer
+	rw        p2p.MsgReadWriter // Input/output streams for blob
+	version   uint              // Protocol version negotiated
+
+	head common.Hash // Latest advertised head block hash
+	td   *big.Int    // Latest advertised head block total difficulty
+
+	knownBlocks     *knownCache            // Set of block hashes known to be known by this peer
+	queuedBlocks    chan *blockPropagation // Queue of blocks to broadcast to the peer
+	queuedBlockAnns chan *types.Block      // Queue of blocks to announce to the peer
+
+	reqDispatch chan *request  // Dispatch channel to send requests and track then until fulfillment
+	reqCancel   chan *cancel   // Dispatch channel to cancel pending requests and untrack them
+	resDispatch chan *response // Dispatch channel to fulfil pending requests and untrack them
+
+	term chan struct{} // Termination channel to stop the broadcasters
+	lock sync.RWMutex  // Mutex protecting the internal fields
+}
+
+// NewPeer create a wrapper for a network connection and negotiated protocol
+// version.
+func NewPeer(version uint, p *p2p.Peer, rw p2p.MsgReadWriter) *Peer {
+	id := p.ID().String()
+	peer := &Peer{
+		id:              id,
+		knownBlocks:     newKnownCache(maxKnownBlocks),
+		queuedBlocks:    make(chan *blockPropagation, maxQueuedBlocks),
+		queuedBlockAnns: make(chan *types.Block, maxQueuedBlockAnns),
+		Peer:            p,
+		rw:              rw,
+		version:         version,
+		term:            make(chan struct{}),
+	}
+	go peer.broadcastBlocks()
+	go peer.dispatcher()
+
+	return peer
+}
+
+// Close signals the broadcast goroutine to terminate. Only ever call this if
+// you created the peer yourself via NewPeer. Otherwise let whoever created it
+// clean it up!
+func (p *Peer) Close() {
+	close(p.term)
+}
+
+// ID retrieves the peer's unique identifier.
+func (p *Peer) ID() string {
+	return p.id
+}
+
+// Version retrieves the peer's negotiated `beacon` protocol version.
+func (p *Peer) Version() uint {
+	return p.version
+}
+
+// Head retrieves the current head hash and total difficulty of the peer.
+func (p *Peer) Head() (hash common.Hash, td *big.Int) {
+	p.lock.RLock()
+	defer p.lock.RUnlock()
+
+	copy(hash[:], p.head[:])
+	return hash, new(big.Int).Set(p.td)
+}
+
+// SetHead updates the head hash and total difficulty of the peer.
+func (p *Peer) SetHead(hash common.Hash, td *big.Int) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	copy(p.head[:], hash[:])
+	p.td.Set(td)
+}
+
+// KnownBlock returns whether peer is known to already have a block.
+func (p *Peer) KnownBlock(hash common.Hash) bool {
+	return p.knownBlocks.Contains(hash)
+}
+
+// markBlock marks a block as known for the peer, ensuring that the block will
+// never be propagated to this particular peer.
+func (p *Peer) markBlock(hash common.Hash) {
+	// If we reached the memory allowance, drop a previously known block hash
+	p.knownBlocks.Add(hash)
+}
+
+// SendNewBlockHashes announces the availability of a number of blocks through
+// a hash notification.
+func (p *Peer) SendNewBlockHashes(hashes []common.Hash, numbers []uint64) error {
+	// Mark all the block hashes as known, but ensure we don't overflow our limits
+	p.knownBlocks.Add(hashes...)
+
+	request := make(NewBlockHashesPacket, len(hashes))
+	for i := 0; i < len(hashes); i++ {
+		request[i].Hash = hashes[i]
+		request[i].Number = numbers[i]
+	}
+	return p2p.Send(p.rw, NewBlockHashesMsg, request)
+}
+
+// AsyncSendNewBlockHash queues the availability of a block for propagation to a
+// remote peer. If the peer's broadcast queue is full, the event is silently
+// dropped.
+func (p *Peer) AsyncSendNewBlockHash(block *types.Block) {
+	select {
+	case p.queuedBlockAnns <- block:
+		// Mark all the block hash as known, but ensure we don't overflow our limits
+		p.knownBlocks.Add(block.Hash())
+	default:
+		p.Log().Debug("Dropping block announcement", "number", block.NumberU64(), "hash", block.Hash())
+	}
+}
+
+// SendNewBlock propagates an entire block to a remote peer.
+func (p *Peer) SendNewBlock(block *types.Block, td *big.Int) error {
+	// Mark all the block hash as known, but ensure we don't overflow our limits
+	p.knownBlocks.Add(block.Hash())
+	return p2p.Send(p.rw, NewBlockMsg, &NewBlockPacket{
+		Block: block,
+		TD:    td,
+	})
+}
+
+// AsyncSendNewBlock queues an entire block for propagation to a remote peer. If
+// the peer's broadcast queue is full, the event is silently dropped.
+func (p *Peer) AsyncSendNewBlock(block *types.Block, td *big.Int) {
+	select {
+	case p.queuedBlocks <- &blockPropagation{block: block, td: td}:
+		// Mark all the block hash as known, but ensure we don't overflow our limits
+		p.knownBlocks.Add(block.Hash())
+	default:
+		p.Log().Debug("Dropping block propagation", "number", block.NumberU64(), "hash", block.Hash())
+	}
+}
+
+// knownCache is a cache for known hashes.
+type knownCache struct {
+	hashes mapset.Set[common.Hash]
+	max    int
+}
+
+// newKnownCache creates a new knownCache with a max capacity.
+func newKnownCache(max int) *knownCache {
+	return &knownCache{
+		max:    max,
+		hashes: mapset.NewSet[common.Hash](),
+	}
+}
+
+// Add adds a list of elements to the set.
+func (k *knownCache) Add(hashes ...common.Hash) {
+	for k.hashes.Cardinality() > max(0, k.max-len(hashes)) {
+		k.hashes.Pop()
+	}
+	for _, hash := range hashes {
+		k.hashes.Add(hash)
+	}
+}
+
+// Contains returns whether the given item is in the set.
+func (k *knownCache) Contains(hash common.Hash) bool {
+	return k.hashes.Contains(hash)
+}
+
+// Cardinality returns the number of elements in the set.
+func (k *knownCache) Cardinality() int {
+	return k.hashes.Cardinality()
+}

--- a/eth/protocols/beacon/peer_test.go
+++ b/eth/protocols/beacon/peer_test.go
@@ -1,0 +1,71 @@
+package beacon
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+)
+
+// testPeer is a simulated peer to allow testing direct network calls.
+type testPeer struct {
+	*Peer
+
+	net p2p.MsgReadWriter // Network layer reader/writer to simulate remote messaging
+	app *p2p.MsgPipeRW    // Application layer reader/writer to simulate the local side
+}
+
+// newTestPeer creates a new peer registered at the given data backend.
+func newTestPeer(name string, version uint, backend Backend) (*testPeer, <-chan error) {
+	// Create a message pipe to communicate through
+	app, net := p2p.MsgPipe()
+
+	// Start the peer on a new thread
+	var id enode.ID
+	rand.Read(id[:])
+
+	peer := NewPeer(version, p2p.NewPeer(id, name, nil), net)
+	errc := make(chan error, 1)
+	go func() {
+		defer app.Close()
+
+		errc <- backend.RunPeer(peer, func(peer *Peer) error {
+			return Handle(backend, peer)
+		})
+	}()
+	return &testPeer{app: app, net: net, Peer: peer}, errc
+}
+
+// close terminates the local side of the peer, notifying the remote protocol
+// manager of termination.
+func (p *testPeer) close() {
+	p.Peer.Close()
+	p.app.Close()
+}
+
+func TestPeerSet(t *testing.T) {
+	size := 5
+	s := newKnownCache(size)
+
+	// add 10 items
+	for i := 0; i < size*2; i++ {
+		s.Add(common.Hash{byte(i)})
+	}
+
+	if s.Cardinality() != size {
+		t.Fatalf("wrong size, expected %d but found %d", size, s.Cardinality())
+	}
+
+	vals := []common.Hash{}
+	for i := 10; i < 20; i++ {
+		vals = append(vals, common.Hash{byte(i)})
+	}
+
+	// add item in batch
+	s.Add(vals...)
+	if s.Cardinality() < size {
+		t.Fatalf("bad size")
+	}
+}

--- a/eth/protocols/beacon/protocol.go
+++ b/eth/protocols/beacon/protocol.go
@@ -1,0 +1,143 @@
+package beacon
+
+import (
+	"errors"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/forkid"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+// Constants to match up protocol versions and messages
+const (
+	BEACON1 = 1
+)
+
+// ProtocolName is the official short name of the `beacon` protocol used during
+// devp2p capability negotiation.
+const ProtocolName = "beacon"
+
+// ProtocolVersions are the supported versions of the `beacon` protocol (first
+// is primary).
+var ProtocolVersions = []uint{BEACON1}
+
+// protocolLengths are the number of implemented message corresponding to
+// different protocol versions.
+var protocolLengths = map[uint]uint64{BEACON1: 3}
+
+// maxMessageSize is the maximum cap on the size of a protocol message.
+const maxMessageSize = 10 * 1024 * 1024
+
+const (
+	StatusMsg         = 0x00
+	NewBlockHashesMsg = 0x01
+	NewBlockMsg       = 0x02
+)
+
+var (
+	errNoStatusMsg             = errors.New("no status message")
+	errMsgTooLarge             = errors.New("message too long")
+	errDecode                  = errors.New("invalid message")
+	errInvalidMsgCode          = errors.New("invalid message code")
+	errProtocolVersionMismatch = errors.New("protocol version mismatch")
+	errNetworkIDMismatch       = errors.New("network ID mismatch")
+	errGenesisMismatch         = errors.New("genesis mismatch")
+	errForkIDRejected          = errors.New("fork ID rejected")
+	errInvalidBlobs            = errors.New("invalid blobs packet")
+)
+
+// Packet represents a p2p message in the `beacon` protocol.
+type Packet interface {
+	Name() string // Name returns a string corresponding to the message type.
+	Kind() byte   // Kind returns the message type.
+}
+
+// StatusPacket is the network packet for the status message.
+type StatusPacket struct {
+	ProtocolVersion uint32
+	NetworkID       uint64
+	TD              *big.Int
+	Head            common.Hash
+	Genesis         common.Hash
+	ForkID          forkid.ID
+}
+
+// NewBlockHashesPacket is the network packet for the block announcements.
+type NewBlockHashesPacket []struct {
+	Hash   common.Hash // Hash of one particular block being announced
+	Number uint64      // Number of one particular block being announced
+}
+
+// Unpack retrieves the block hashes and numbers from the announcement packet
+// and returns them in a split flat format that's more consistent with the
+// internal data structures.
+func (p *NewBlockHashesPacket) Unpack() ([]common.Hash, []uint64) {
+	var (
+		hashes  = make([]common.Hash, len(*p))
+		numbers = make([]uint64, len(*p))
+	)
+	for i, body := range *p {
+		hashes[i], numbers[i] = body.Hash, body.Number
+	}
+	return hashes, numbers
+}
+
+// NewBlockPacket is the network packet for the block propagation message.
+type NewBlockPacket struct {
+	Block *types.Block
+	TD    *big.Int
+}
+
+// GetBlobsRequest represents a blobs query.
+type GetBlobsRequest []common.Hash
+
+// GetBlobsPacket is the request packet for blob query by block hash.
+type GetBlobsPacket struct {
+	RequestId uint64
+	GetBlobsRequest
+}
+
+// BlobsResponse is the response packet for blobs by block hash.
+type BlobsResponse [][]*types.BlobTxSidecar
+
+// BlobsPacket is the response packet for blobs by block hash with request
+// ID wrapping.
+type BlobsPacket struct {
+	RequestId uint64
+	BlobsResponse
+}
+
+// BlobsRLPResponse is used for replying to blobs by block hash requests, in cases
+// where we already have them RLP-encoded, and thus can avoid the decode-encode
+// roundtrip.
+type BlobsRLPResponse []rlp.RawValue
+
+// BlobsRLPPacket is the BlobsRLPResponse with request ID wrapping.
+type BlobsRLPPacket struct {
+	RequestId uint64
+	BlobsRLPResponse
+}
+
+func (packet *BlobsPacket) sanityCheck() error {
+	if len(packet.BlobsResponse) > 0 {
+		for _, sidecars := range packet.BlobsResponse {
+			for _, sidecar := range sidecars {
+				if len(sidecar.Blobs) != len(sidecar.Commitments) || len(sidecar.Blobs) != len(sidecar.Proofs) {
+					return errInvalidBlobs
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (*StatusPacket) Name() string { return "Status" }
+func (*StatusPacket) Kind() byte   { return StatusMsg }
+
+func (*NewBlockHashesPacket) Name() string { return "NewBlockHashes" }
+func (*NewBlockHashesPacket) Kind() byte   { return NewBlockHashesMsg }
+
+func (*NewBlockPacket) Name() string { return "NewBlock" }
+func (*NewBlockPacket) Kind() byte   { return NewBlockMsg }

--- a/eth/protocols/beacon/tracker.go
+++ b/eth/protocols/beacon/tracker.go
@@ -1,0 +1,10 @@
+package beacon
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/p2p/tracker"
+)
+
+// requestTracker is a singleton tracker for request times.
+var requestTracker = tracker.New(ProtocolName, 5*time.Minute)

--- a/eth/protocols/eth/broadcast.go
+++ b/eth/protocols/eth/broadcast.go
@@ -17,8 +17,6 @@
 package eth
 
 import (
-	"math/big"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
@@ -28,37 +26,6 @@ const (
 	// pack can get larger than this if a single transactions exceeds this size.
 	maxTxPacketSize = 100 * 1024
 )
-
-// blockPropagation is a block propagation event, waiting for its turn in the
-// broadcast queue.
-type blockPropagation struct {
-	block *types.Block
-	td    *big.Int
-}
-
-// broadcastBlocks is a write loop that multiplexes blocks and block announcements
-// to the remote peer. The goal is to have an async writer that does not lock up
-// node internals and at the same time rate limits queued data.
-func (p *Peer) broadcastBlocks() {
-	for {
-		select {
-		case prop := <-p.queuedBlocks:
-			if err := p.SendNewBlock(prop.block, prop.td); err != nil {
-				return
-			}
-			p.Log().Trace("Propagated block", "number", prop.block.Number(), "hash", prop.block.Hash(), "td", prop.td)
-
-		case block := <-p.queuedBlockAnns:
-			if err := p.SendNewBlockHashes([]common.Hash{block.Hash()}, []uint64{block.NumberU64()}); err != nil {
-				return
-			}
-			p.Log().Trace("Announced block", "number", block.Number(), "hash", block.Hash())
-
-		case <-p.term:
-			return
-		}
-	}
-}
 
 // broadcastTransactions is a write loop that schedules transaction broadcasts
 // to the remote peer. The goal is to have an async writer that does not lock up

--- a/eth/protocols/eth/handler_test.go
+++ b/eth/protocols/eth/handler_test.go
@@ -79,7 +79,6 @@ func newTestBackendWithGenerator(blocks int, shanghai bool, cancun bool, generat
 		config = params.TestChainConfig
 		engine = beacon.New(ethash.NewFaker())
 	)
-
 	if shanghai {
 		config = &params.ChainConfig{
 			ChainID:                 big.NewInt(1),

--- a/eth/protocols/eth/handlers.go
+++ b/eth/protocols/eth/handlers.go
@@ -18,6 +18,7 @@ package eth
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -284,43 +285,11 @@ func ServiceGetReceiptsQuery(chain *core.BlockChain, query GetReceiptsRequest) [
 }
 
 func handleNewBlockhashes(backend Backend, msg Decoder, peer *Peer) error {
-	// A batch of new block announcements just arrived
-	ann := new(NewBlockHashesPacket)
-	if err := msg.Decode(ann); err != nil {
-		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
-	}
-	// Mark the hashes as present at the remote node
-	for _, block := range *ann {
-		peer.markBlock(block.Hash)
-	}
-	// Deliver them all to the backend for queuing
-	return backend.Handle(peer, ann)
+	return errors.New("block announcements disallowed") // We dropped support for non-merge networks
 }
 
 func handleNewBlock(backend Backend, msg Decoder, peer *Peer) error {
-	// Retrieve and decode the propagated block
-	ann := new(NewBlockPacket)
-	if err := msg.Decode(ann); err != nil {
-		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
-	}
-	if err := ann.sanityCheck(); err != nil {
-		return err
-	}
-	if hash := types.CalcUncleHash(ann.Block.Uncles()); hash != ann.Block.UncleHash() {
-		log.Warn("Propagated block has invalid uncles", "have", hash, "exp", ann.Block.UncleHash())
-		return nil // TODO(karalabe): return error eventually, but wait a few releases
-	}
-	if hash := types.DeriveSha(ann.Block.Transactions(), trie.NewStackTrie(nil)); hash != ann.Block.TxHash() {
-		log.Warn("Propagated block has invalid body", "have", hash, "exp", ann.Block.TxHash())
-		return nil // TODO(karalabe): return error eventually, but wait a few releases
-	}
-	ann.Block.ReceivedAt = msg.Time()
-	ann.Block.ReceivedFrom = peer
-
-	// Mark the peer as owning the block
-	peer.markBlock(ann.Block.Hash())
-
-	return backend.Handle(peer, ann)
+	return errors.New("block broadcasts disallowed") // We dropped support for non-merge networks
 }
 
 func handleBlockHeaders(backend Backend, msg Decoder, peer *Peer) error {

--- a/eth/protocols/eth/peer.go
+++ b/eth/protocols/eth/peer.go
@@ -17,9 +17,7 @@
 package eth
 
 import (
-	"math/big"
 	"math/rand"
-	"sync"
 
 	mapset "github.com/deckarep/golang-set/v2"
 	"github.com/ethereum/go-ethereum/common"
@@ -33,10 +31,6 @@ const (
 	// before starting to randomly evict them.
 	maxKnownTxs = 32768
 
-	// maxKnownBlocks is the maximum block hashes to keep in the known list
-	// before starting to randomly evict them.
-	maxKnownBlocks = 1024
-
 	// maxQueuedTxs is the maximum number of transactions to queue up before dropping
 	// older broadcasts.
 	maxQueuedTxs = 4096
@@ -44,16 +38,6 @@ const (
 	// maxQueuedTxAnns is the maximum number of transaction announcements to queue up
 	// before dropping older announcements.
 	maxQueuedTxAnns = 4096
-
-	// maxQueuedBlocks is the maximum number of block propagations to queue up before
-	// dropping broadcasts. There's not much point in queueing stale blocks, so a few
-	// that might cover uncles should be enough.
-	maxQueuedBlocks = 4
-
-	// maxQueuedBlockAnns is the maximum number of block announcements to queue up before
-	// dropping broadcasts. Similarly to block propagations, there's no point to queue
-	// above some healthy uncle limit, so use that.
-	maxQueuedBlockAnns = 4
 )
 
 // Peer is a collection of relevant information we have about a `eth` peer.
@@ -63,13 +47,6 @@ type Peer struct {
 	*p2p.Peer                   // The embedded P2P package peer
 	rw        p2p.MsgReadWriter // Input/output streams for snap
 	version   uint              // Protocol version negotiated
-
-	head common.Hash // Latest advertised head block hash
-	td   *big.Int    // Latest advertised head block total difficulty
-
-	knownBlocks     *knownCache            // Set of block hashes known to be known by this peer
-	queuedBlocks    chan *blockPropagation // Queue of blocks to broadcast to the peer
-	queuedBlockAnns chan *types.Block      // Queue of blocks to announce to the peer
 
 	txpool      TxPool             // Transaction pool used by the broadcasters for liveness checks
 	knownTxs    *knownCache        // Set of transaction hashes known to be known by this peer
@@ -81,31 +58,26 @@ type Peer struct {
 	resDispatch chan *response // Dispatch channel to fulfil pending requests and untrack them
 
 	term chan struct{} // Termination channel to stop the broadcasters
-	lock sync.RWMutex  // Mutex protecting the internal fields
 }
 
 // NewPeer creates a wrapper for a network connection and negotiated  protocol
 // version.
 func NewPeer(version uint, p *p2p.Peer, rw p2p.MsgReadWriter, txpool TxPool) *Peer {
 	peer := &Peer{
-		id:              p.ID().String(),
-		Peer:            p,
-		rw:              rw,
-		version:         version,
-		knownTxs:        newKnownCache(maxKnownTxs),
-		knownBlocks:     newKnownCache(maxKnownBlocks),
-		queuedBlocks:    make(chan *blockPropagation, maxQueuedBlocks),
-		queuedBlockAnns: make(chan *types.Block, maxQueuedBlockAnns),
-		txBroadcast:     make(chan []common.Hash),
-		txAnnounce:      make(chan []common.Hash),
-		reqDispatch:     make(chan *request),
-		reqCancel:       make(chan *cancel),
-		resDispatch:     make(chan *response),
-		txpool:          txpool,
-		term:            make(chan struct{}),
+		id:          p.ID().String(),
+		Peer:        p,
+		rw:          rw,
+		version:     version,
+		knownTxs:    newKnownCache(maxKnownTxs),
+		txBroadcast: make(chan []common.Hash),
+		txAnnounce:  make(chan []common.Hash),
+		reqDispatch: make(chan *request),
+		reqCancel:   make(chan *cancel),
+		resDispatch: make(chan *response),
+		txpool:      txpool,
+		term:        make(chan struct{}),
 	}
 	// Start up all the broadcasters
-	go peer.broadcastBlocks()
 	go peer.broadcastTransactions()
 	go peer.announceTransactions()
 	go peer.dispatcher()
@@ -130,39 +102,9 @@ func (p *Peer) Version() uint {
 	return p.version
 }
 
-// Head retrieves the current head hash and total difficulty of the peer.
-func (p *Peer) Head() (hash common.Hash, td *big.Int) {
-	p.lock.RLock()
-	defer p.lock.RUnlock()
-
-	copy(hash[:], p.head[:])
-	return hash, new(big.Int).Set(p.td)
-}
-
-// SetHead updates the head hash and total difficulty of the peer.
-func (p *Peer) SetHead(hash common.Hash, td *big.Int) {
-	p.lock.Lock()
-	defer p.lock.Unlock()
-
-	copy(p.head[:], hash[:])
-	p.td.Set(td)
-}
-
-// KnownBlock returns whether peer is known to already have a block.
-func (p *Peer) KnownBlock(hash common.Hash) bool {
-	return p.knownBlocks.Contains(hash)
-}
-
 // KnownTransaction returns whether peer is known to already have a transaction.
 func (p *Peer) KnownTransaction(hash common.Hash) bool {
 	return p.knownTxs.Contains(hash)
-}
-
-// markBlock marks a block as known for the peer, ensuring that the block will
-// never be propagated to this particular peer.
-func (p *Peer) markBlock(hash common.Hash) {
-	// If we reached the memory allowance, drop a previously known block hash
-	p.knownBlocks.Add(hash)
 }
 
 // markTransaction marks a transaction as known for the peer, ensuring that it
@@ -238,55 +180,6 @@ func (p *Peer) ReplyPooledTransactionsRLP(id uint64, hashes []common.Hash, txs [
 		RequestId:                     id,
 		PooledTransactionsRLPResponse: txs,
 	})
-}
-
-// SendNewBlockHashes announces the availability of a number of blocks through
-// a hash notification.
-func (p *Peer) SendNewBlockHashes(hashes []common.Hash, numbers []uint64) error {
-	// Mark all the block hashes as known, but ensure we don't overflow our limits
-	p.knownBlocks.Add(hashes...)
-
-	request := make(NewBlockHashesPacket, len(hashes))
-	for i := 0; i < len(hashes); i++ {
-		request[i].Hash = hashes[i]
-		request[i].Number = numbers[i]
-	}
-	return p2p.Send(p.rw, NewBlockHashesMsg, request)
-}
-
-// AsyncSendNewBlockHash queues the availability of a block for propagation to a
-// remote peer. If the peer's broadcast queue is full, the event is silently
-// dropped.
-func (p *Peer) AsyncSendNewBlockHash(block *types.Block) {
-	select {
-	case p.queuedBlockAnns <- block:
-		// Mark all the block hash as known, but ensure we don't overflow our limits
-		p.knownBlocks.Add(block.Hash())
-	default:
-		p.Log().Debug("Dropping block announcement", "number", block.NumberU64(), "hash", block.Hash())
-	}
-}
-
-// SendNewBlock propagates an entire block to a remote peer.
-func (p *Peer) SendNewBlock(block *types.Block, td *big.Int) error {
-	// Mark all the block hash as known, but ensure we don't overflow our limits
-	p.knownBlocks.Add(block.Hash())
-	return p2p.Send(p.rw, NewBlockMsg, &NewBlockPacket{
-		Block: block,
-		TD:    td,
-	})
-}
-
-// AsyncSendNewBlock queues an entire block for propagation to a remote peer. If
-// the peer's broadcast queue is full, the event is silently dropped.
-func (p *Peer) AsyncSendNewBlock(block *types.Block, td *big.Int) {
-	select {
-	case p.queuedBlocks <- &blockPropagation{block: block, td: td}:
-		// Mark all the block hash as known, but ensure we don't overflow our limits
-		p.knownBlocks.Add(block.Hash())
-	default:
-		p.Log().Debug("Dropping block propagation", "number", block.NumberU64(), "hash", block.Hash())
-	}
 }
 
 // ReplyBlockHeadersRLP is the response to GetBlockHeaders.

--- a/eth/protocols/eth/protocol.go
+++ b/eth/protocols/eth/protocol.go
@@ -189,19 +189,6 @@ type NewBlockPacket struct {
 	TD    *big.Int
 }
 
-// sanityCheck verifies that the values are reasonable, as a DoS protection
-func (request *NewBlockPacket) sanityCheck() error {
-	if err := request.Block.SanityCheck(); err != nil {
-		return err
-	}
-	//TD at mainnet block #7753254 is 76 bits. If it becomes 100 million times
-	// larger, it will still fit within 100 bits
-	if tdlen := request.TD.BitLen(); tdlen > 100 {
-		return fmt.Errorf("too large block TD: bitlen %d", tdlen)
-	}
-	return nil
-}
-
 // GetBlockBodiesRequest represents a block body query.
 type GetBlockBodiesRequest []common.Hash
 

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/eth/protocols/beacon"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -155,12 +156,12 @@ func (cs *chainSyncer) nextSyncOp() *chainSyncOp {
 	// We have enough peers, pick the one with the highest TD, but avoid going
 	// over the terminal total difficulty. Above that we expect the consensus
 	// clients to direct the chain head to sync to.
-	peer := cs.handler.peers.peerWithHighestTD()
+	beacon, peer := cs.handler.peers.peerWithHighestTD()
 	if peer == nil {
 		return nil
 	}
 	mode, ourTD := cs.modeAndLocalHead()
-	op := peerToSyncOp(mode, peer)
+	op := peerToSyncOp(mode, beacon, peer)
 	if op.td.Cmp(ourTD) <= 0 {
 		// We seem to be in sync according to the legacy rules. In the merge
 		// world, it can also mean we're stuck on the merge block, waiting for
@@ -174,8 +175,8 @@ func (cs *chainSyncer) nextSyncOp() *chainSyncOp {
 	return op
 }
 
-func peerToSyncOp(mode downloader.SyncMode, p *eth.Peer) *chainSyncOp {
-	peerHead, peerTD := p.Head()
+func peerToSyncOp(mode downloader.SyncMode, b *beacon.Peer, p *eth.Peer) *chainSyncOp {
+	peerHead, peerTD := b.Head()
 	return &chainSyncOp{mode: mode, peer: p, td: peerTD, head: peerHead}
 }
 

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -91,9 +91,7 @@ func (cs *chainSyncer) handlePeerEvent() bool {
 func (cs *chainSyncer) loop() {
 	defer cs.handler.wg.Done()
 
-	cs.handler.blockFetcher.Start()
 	cs.handler.txFetcher.Start()
-	defer cs.handler.blockFetcher.Stop()
 	defer cs.handler.txFetcher.Stop()
 	defer cs.handler.downloader.Terminate()
 
@@ -234,7 +232,7 @@ func (h *handler) doSync(op *chainSyncOp) error {
 		// scenario will most often crop up in private and hackathon networks with
 		// degenerate connectivity, but it should be healthy for the mainnet too to
 		// more reliably update peers or the local TD state.
-		if block := h.chain.GetBlock(head.Hash(), head.Number.Uint64()); block != nil {
+		if block := h.chain.GetBlock(head.Hash(), head.Number.Uint64()); block != nil && h.beacon != nil {
 			h.BroadcastBlock(block, false)
 		}
 	}

--- a/eth/sync_test.go
+++ b/eth/sync_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/eth/downloader"
+	"github.com/ethereum/go-ethereum/eth/protocols/beacon"
 	"github.com/ethereum/go-ethereum/eth/protocols/eth"
 	"github.com/ethereum/go-ethereum/eth/protocols/snap"
 	"github.com/ethereum/go-ethereum/p2p"
@@ -28,11 +29,13 @@ import (
 )
 
 // Tests that snap sync is disabled after a successful sync cycle.
-func TestSnapSyncDisabling68(t *testing.T) { testSnapSyncDisabling(t, eth.ETH68, snap.SNAP1) }
+func TestSnapSyncDisabling68(t *testing.T) {
+	testSnapSyncDisabling(t, beacon.BEACON1, eth.ETH68, snap.SNAP1)
+}
 
 // Tests that snap sync gets disabled as soon as a real block is successfully
 // imported into the blockchain.
-func testSnapSyncDisabling(t *testing.T, ethVer uint, snapVer uint) {
+func testSnapSyncDisabling(t *testing.T, beaconVer uint, ethVer uint, snapVer uint) {
 	t.Parallel()
 
 	// Create an empty handler and ensure it's in snap sync mode
@@ -49,8 +52,24 @@ func testSnapSyncDisabling(t *testing.T, ethVer uint, snapVer uint) {
 	}
 	defer full.close()
 
-	// Sync up the two handlers via both `eth` and `snap`
-	caps := []p2p.Cap{{Name: "eth", Version: ethVer}, {Name: "snap", Version: snapVer}}
+	// Sync up the two handlers via `beacon`, `eth` and `snap`
+	caps := []p2p.Cap{{Name: "beacon", Version: beaconVer}, {Name: "eth", Version: ethVer}, {Name: "snap", Version: snapVer}}
+
+	emptyPipeBeacon, fullPipeBeacon := p2p.MsgPipe()
+	defer emptyPipeBeacon.Close()
+	defer fullPipeBeacon.Close()
+
+	emptyPeerBeacon := beacon.NewPeer(beaconVer, p2p.NewPeer(enode.ID{1}, "", caps), emptyPipeBeacon)
+	fullPeerBeacon := beacon.NewPeer(beaconVer, p2p.NewPeer(enode.ID{1}, "", caps), fullPipeBeacon)
+	defer emptyPeerBeacon.Close()
+	defer fullPeerBeacon.Close()
+
+	go empty.handler.runBeaconPeer(emptyPeerBeacon, func(peer *beacon.Peer) error {
+		return beacon.Handle((*beaconHandler)(empty.handler), peer)
+	})
+	go full.handler.runBeaconPeer(fullPeerBeacon, func(peer *beacon.Peer) error {
+		return beacon.Handle((*beaconHandler)(full.handler), peer)
+	})
 
 	emptyPipeEth, fullPipeEth := p2p.MsgPipe()
 	defer emptyPipeEth.Close()
@@ -85,7 +104,8 @@ func testSnapSyncDisabling(t *testing.T, ethVer uint, snapVer uint) {
 	time.Sleep(250 * time.Millisecond)
 
 	// Check that snap sync was disabled
-	op := peerToSyncOp(downloader.SnapSync, empty.handler.peers.peerWithHighestTD())
+	beacon, peer := empty.handler.peers.peerWithHighestTD()
+	op := peerToSyncOp(downloader.SnapSync, beacon, peer)
 	if err := empty.handler.doSync(op); err != nil {
 		t.Fatal("sync failed:", err)
 	}


### PR DESCRIPTION
Close #540, and is also an enhancement of #539.

By moving the block broadcasting and fetching to beacon layer, now the dBFT doesn't write to the EL blockchain directly.

TODO:
1. The downloader is still the old, so that it still needs both the `beacon` and `eth` protocols to work. We need to decouple it, since there is a post-merge way of synchronization. Let's include it in #541;
2. The blob-related message is not really functioning, needs some code from #526;
3. The dBFT consensus should execute a DA check on all blob sidecars in verification.