### PR TITLE
consensus/dbft: enhance header time check

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1917,7 +1917,7 @@ func (c *DBFT) verifyCascadingFields(chain consensus.ChainHeaderReader, header *
 	if parent == nil || parent.Number.Uint64() != number-1 || (isSealed && parent.Hash() != header.ParentHash) {
 		return consensus.ErrUnknownAncestor
 	}
-	if parent.Time > header.Time {
+	if header.Time <= parent.Time {
 		return errInvalidTimestamp
 	}
 	// Verify that the gasUsed is <= gasLimit


### PR DESCRIPTION
Ref https://github.com/ethereum/go-ethereum/blob/v1.11.6/consensus/ethash/consensus.go#L279 and https://github.com/ethereum/go-ethereum/blob/v1.16.8/eth/catalyst/api.go#L742.
The current dBFT timestamp verification is not restrict enough to met the CL requirement, This PR prevents dBFT-accepted blocks get rejected by EL.