### PR TITLE
consensus/dbft: beacon/impl: avoid timstamp error for upgradability and enhance atomicity

### DIFF
--- a/beacon/impl/miner/worker.go
+++ b/beacon/impl/miner/worker.go
@@ -199,8 +199,11 @@ func (w *worker) requestWork(timestamp uint64) {
 	}
 	start := time.Now()
 
+	// Lock to ensure EL RW atomicity, no real reorg happens.
+	w.forkMu.Lock()
 	// Trigger payload build through the fork choice request.
 	resp, err := w.sendForkChoice(w.chain.CurrentHeader(), timestamp, true)
+	w.forkMu.Unlock()
 	if err != nil {
 		log.Error("Failed to prepare payload", "err", err)
 		return
@@ -273,6 +276,9 @@ func (w *worker) feedback(block *types.Block) error {
 		return fmt.Errorf("block rejected by EL, err: %v", *status.ValidationError)
 	}
 
+	// Lock to ensure EL RW atomicity, no concurrent reorg happens.
+	w.forkMu.Lock()
+	defer w.forkMu.Unlock()
 	// Set head based on reorg check.
 	reorg, err := w.forker.ReorgNeeded(w.chain.CurrentHeader(), block.Header())
 	if err != nil {
@@ -294,8 +300,6 @@ func (w *worker) feedback(block *types.Block) error {
 
 // sendForkChoice sends new chain head information to EL miner API through RPC.
 func (w *worker) sendForkChoice(head *types.Header, timestamp uint64, requestMine bool) (engine.ForkChoiceResponse, error) {
-	w.forkMu.Lock()
-	defer w.forkMu.Unlock()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()
 

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -1917,7 +1917,7 @@ func (c *DBFT) verifyCascadingFields(chain consensus.ChainHeaderReader, header *
 	if parent == nil || parent.Number.Uint64() != number-1 || (isSealed && parent.Hash() != header.ParentHash) {
 		return consensus.ErrUnknownAncestor
 	}
-	if header.Time <= parent.Time {
+	if parent.Time > header.Time {
 		return errInvalidTimestamp
 	}
 	// Verify that the gasUsed is <= gasLimit

--- a/eth/catalyst/api.go
+++ b/eth/catalyst/api.go
@@ -924,7 +924,7 @@ func (api *ConsensusAPI) newPayload(params engine.ExecutableData, versionedHashe
 		log.Error("Ignoring pre-merge parent block", "number", params.Number, "hash", params.BlockHash, "td", ptd, "ttd", ttd)
 		return engine.INVALID_TERMINAL_BLOCK, nil
 	}
-	if block.Time() <= parent.Time() {
+	if parent.Time() > block.Time() {
 		log.Warn("Invalid timestamp", "parent", block.Time(), "block", block.Time())
 		return api.invalid(errors.New("invalid timestamp"), parent.Header()), nil
 	}


### PR DESCRIPTION
Close #548. This also includes an improvement for EL reorg security.