### PR TITLE
consensus/dbft: unify the error level of `handleDKG`

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -2193,10 +2193,9 @@ func (c *DBFT) Start(chain ChainHeaderReader, inserter ChainInsertFn) {
 				c.lock.RUnlock()
 				err := c.handleDKG(c.dkgSnapshot, ks, currHeader, nil, false)
 				if err != nil {
-					log.Crit("Failed to initialize DKG snapshot",
+					log.Error("Failed to initialize DKG snapshot",
 						"height", currHeader.Number.Uint64(),
 						"err", err.Error())
-					return
 				}
 			}
 		}


### PR DESCRIPTION
Close #555. The `Crit` handling of DKG init failure may stop the node from recovering from an interrupted synchronization.

But whether this is a safe change needs further testing.