### PR TITLE
consensus/dbft: exclude tx blob sidecar in `OnTransaction` callback

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -2489,6 +2489,7 @@ func (c *DBFT) OnTransaction(txs []*types.Transaction) {
 	var cbList = c.txCbList.Load()
 	if cbList != nil {
 		for _, tx := range txs {
+			tx = tx.WithoutBlobTxSidecar()
 			_, found := slices.BinarySearchFunc(cbList.([]common.Hash), tx.Hash(), common.Hash.Cmp)
 			if found {
 				c.txs <- tx


### PR DESCRIPTION
Close #575.

The referred issue is mainly caused by an incorrect transaction root computation, since it's possible that some blob transaction with full blob data is committed to dBFT.