### PR TITLE
consensus/dbft: use SSZ-style header encoding

### DIFF
--- a/consensus/dbft/block.go
+++ b/consensus/dbft/block.go
@@ -86,9 +86,9 @@ func (b *Block) Signature() []byte {
 
 // Sign implements [dbft.Block] interface.
 func (b *Block) Sign(key dbft.PrivateKey) error {
-	sighash, err := key.(*Signer).signBlock(b.header.Extra, dbftRLP(b.header))
+	sighash, err := key.(*Signer).signBlock(b.header.Extra, b.header)
 	if err != nil {
-		return fmt.Errorf("failed to sign dbftRLP header: %w", err)
+		return fmt.Errorf("failed to sign header: %w", err)
 	}
 
 	b.localSignatureBytes = sighash
@@ -100,7 +100,7 @@ func (b *Block) Verify(pub dbft.PublicKey, sign []byte) error {
 	extra := dbftutil.Extra(b.header.Extra)
 	switch v := extra.Version(); v {
 	case dbftutil.ExtraV0:
-		sealHash := HonestSealHashV0(b.header)
+		sealHash := honestSealHashKeccaak256(b.header, false)
 		pubkey, err := ecrypto.Ecrecover(sealHash.Bytes(), sign)
 		if err != nil {
 			return fmt.Errorf("failed to recover public key from signature: %w", err)
@@ -108,10 +108,10 @@ func (b *Block) Verify(pub dbft.PublicKey, sign []byte) error {
 		if pub.(*PublicKey).Account != ecrypto.PubkeyBytesToAddress(pubkey) {
 			return errors.New("invalid block signature")
 		}
-	case dbftutil.ExtraV1, dbftutil.ExtraV2:
+	case dbftutil.ExtraV1, dbftutil.ExtraV2, dbftutil.ExtraV3:
 		switch ss := extra.SignatureScheme(); ss {
-		case dbftutil.ExtraV1ECDSAScheme:
-			sealHash := HonestSealHashV0(b.header)
+		case dbftutil.ECDSAScheme:
+			sealHash := honestSealHashKeccaak256(b.header, v == dbftutil.ExtraV3)
 			pubkey, err := ecrypto.Ecrecover(sealHash.Bytes(), sign)
 			if err != nil {
 				return fmt.Errorf("failed to recover public key from signature: %w", err)
@@ -119,7 +119,7 @@ func (b *Block) Verify(pub dbft.PublicKey, sign []byte) error {
 			if pub.(*PublicKey).Account != ecrypto.PubkeyBytesToAddress(pubkey) {
 				return errors.New("invalid block signature")
 			}
-		case dbftutil.ExtraV1ThresholdScheme:
+		case dbftutil.ThresholdScheme:
 			// We don't have a way to verify signature share, because the only way to
 			// verify is to collect at least M shares and verify *the group* of shares
 			// against *the global* public key. Hence, always consider Commit as valid

--- a/consensus/dbft/commit.go
+++ b/consensus/dbft/commit.go
@@ -58,7 +58,7 @@ func (c *commit) DecodeRLP(s *rlp.Stream) error {
 // share returns [tpke.SignatureShare] unpacked from commit's signature in case of
 // [dbftutil.ExtraV1] commit version. No error is returned for other commit versions.
 func (c *commit) share() (*tpke.SignatureShare, error) {
-	if c.version != dbftutil.ExtraV1 && c.version != dbftutil.ExtraV2 {
+	if c.version == dbftutil.ExtraV0 {
 		return nil, nil
 	}
 	if c.shareCache == nil {

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -63,6 +63,7 @@ import (
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/ethereum/go-ethereum/trie"
+	ssz "github.com/ferranbt/fastssz"
 	"github.com/holiman/uint256"
 	"github.com/nspcc-dev/dbft"
 	"github.com/nspcc-dev/dbft/timer"
@@ -630,7 +631,7 @@ func (c *DBFT) newBlockFromContextCb(ctx *dbft.Context[common.Hash]) dbft.Block[
 	// treshold may be empty if some error occurs during calculation. Don't
 	// check it, we always have multisig as a backup scheme.
 	h.MixDigest = threshold
-	h.Extra = append(h.Extra[:dbftutil.ExtraVersionLen+dbftutil.ExtraV1SignatureSchemeLen], multisig.Bytes()...)
+	h.Extra = append(h.Extra[:dbftutil.ExtraVersionLen+dbftutil.SignatureSchemeLen], multisig.Bytes()...)
 
 	// Update state root, transactions root, receipts hash and bloom.
 	body := types.Body{Transactions: pre.finalTransactions, Withdrawals: ethBlock.Withdrawals()}
@@ -748,7 +749,7 @@ func (c *DBFT) newPrepareRequestCb(ts uint64, nonce uint64, txHashes []common.Ha
 	// Enforce V1 signing scheme startign from NeoXAMEV+1 height to be able to
 	// use block signature fallback mechanism starting from NeoXAMEV height.
 	if c.chain.Config().IsNeoXAMEV(new(big.Int).Add(header.Number, bigOne)) {
-		header.Extra = append(header.Extra[:dbftutil.ExtraVersionLen+dbftutil.ExtraV1SignatureSchemeLen], multisig.Bytes()...)
+		header.Extra = append(header.Extra[:dbftutil.ExtraVersionLen+dbftutil.SignatureSchemeLen], multisig.Bytes()...)
 	}
 
 	// Update state root, transactions root, receipts hash and bloom.
@@ -830,7 +831,7 @@ func (c *DBFT) verifyCommitCb(p dbft.ConsensusPayload[common.Hash]) error {
 	switch v {
 	case dbftutil.ExtraV0:
 		expectedLen = crypto.SignatureLength
-	case dbftutil.ExtraV1, dbftutil.ExtraV2:
+	case dbftutil.ExtraV1, dbftutil.ExtraV2, dbftutil.ExtraV3:
 		if c.config.enforceECDSASignatures || (!isAMEV && c.chain.Config().IsNeoXAMEV(new(big.Int).Add(h, bigOne))) {
 			expectedLen = crypto.SignatureLength
 		} else {
@@ -875,10 +876,10 @@ func (c *DBFT) verifyPrepareRequestCb(p dbft.ConsensusPayload[common.Hash]) erro
 	// A separate check for post-NeoXAMEV block signing scheme since it depends
 	// on runtime node configuration.
 	extra := dbftutil.Extra(req.SealingProposal.Extra)
-	if c.chain.Config().IsNeoXAMEV(req.SealingProposal.Number) && (extra.Version() == dbftutil.ExtraV1 || extra.Version() == dbftutil.ExtraV2) {
-		var expected = dbftutil.ExtraV1ThresholdScheme
+	if c.chain.Config().IsNeoXAMEV(req.SealingProposal.Number) && extra.Version() != dbftutil.ExtraV0 {
+		var expected = dbftutil.ThresholdScheme
 		if c.config.enforceECDSASignatures {
-			expected = dbftutil.ExtraV1ECDSAScheme
+			expected = dbftutil.ECDSAScheme
 		}
 		if extra.SignatureScheme() != expected {
 			return fmt.Errorf("%w: expected %d, got %d", dbftutil.ErrUnexpectedBlockSignatureScheme, expected, extra.SignatureScheme())
@@ -886,7 +887,7 @@ func (c *DBFT) verifyPrepareRequestCb(p dbft.ConsensusPayload[common.Hash]) erro
 	}
 
 	if req.SealingProposal.ParentHash != c.lastBlockHash {
-		if c.chain.Config().IsNeoXAMEV(new(big.Int).Sub(req.SealingProposal.Number, bigOne)) && c.lastBlockExtra.SignatureScheme() == dbftutil.ExtraV1ThresholdScheme {
+		if c.chain.Config().IsNeoXAMEV(new(big.Int).Sub(req.SealingProposal.Number, bigOne)) && c.lastBlockExtra.SignatureScheme() == dbftutil.ThresholdScheme {
 			return fmt.Errorf("invalid parent hash after NeoXAMEV with threshold signing scheme: expected %s, got %s", c.lastBlockHash, req.SealingProposal.ParentHash)
 		}
 		// Genesis block is hard-coded, thus its hash (as a parent hash) must always match
@@ -1488,7 +1489,7 @@ func (c *DBFT) getBlockWitness(pub *tpke.PublicKey, block *Block) ([]byte, error
 	switch v := dbftutil.Extra(block.header.Extra).Version(); v {
 	case dbftutil.ExtraV0:
 		return res, nil
-	case dbftutil.ExtraV1, dbftutil.ExtraV2:
+	case dbftutil.ExtraV1, dbftutil.ExtraV2, dbftutil.ExtraV3:
 		// Enforce multisignature-based signing scheme for NeoXAMEV-1 height or if
 		// enforcing configured.
 		cfg := c.chain.Config()
@@ -1520,7 +1521,12 @@ func (c *DBFT) getBlockWitness(pub *tpke.PublicKey, block *Block) ([]byte, error
 				}
 			}
 		}
-		msg := dbftRLP(block.header)
+		var msg []byte
+		if v == dbftutil.ExtraV1 || v == dbftutil.ExtraV2 {
+			msg = dbftRLP(block.header)
+		} else {
+			msg = dbftSSZ(block.header)
+		}
 		c.lock.RLock()
 		ks := c.amevKeystore
 		c.lock.RUnlock()
@@ -1676,7 +1682,7 @@ func (c *DBFT) Signers(header *types.Header) ([]common.Address, error) {
 	}
 	var (
 		signers = make([]common.Address, len(sigs))
-		h       = HonestSealHashV0(header).Bytes()
+		h       = honestSealHashKeccaak256(header, false).Bytes()
 	)
 	for i := range sigs {
 		pubkey, err := crypto.Ecrecover(h, sigs[i])
@@ -1752,8 +1758,10 @@ func (c *DBFT) verifyHeader(chain consensus.ChainHeaderReader, header *types.Hea
 		cfg           = chain.Config()
 		isAMEV        = cfg.IsNeoXAMEV(header.Number)
 		isEthSig      = cfg.IsNeoXEthSig(header.Number)
+		isSSZSig      = cfg.IsNeoXSSZSig(header.Number)
 		isV1Extra     = isAMEV || cfg.IsNeoXAMEV(new(big.Int).Add(header.Number, bigOne))
 		isV2Extra     = isEthSig || cfg.IsNeoXEthSig(new(big.Int).Add(header.Number, bigOne))
+		isV3Extra     = isSSZSig || cfg.IsNeoXSSZSig(new(big.Int).Add(header.Number, bigOne))
 		expectedExtra = dbftutil.ExtraV0
 		extra         = dbftutil.Extra(header.Extra)
 	)
@@ -1763,13 +1771,16 @@ func (c *DBFT) verifyHeader(chain consensus.ChainHeaderReader, header *types.Hea
 	if isV2Extra {
 		expectedExtra = dbftutil.ExtraV2
 	}
+	if isV3Extra {
+		expectedExtra = dbftutil.ExtraV3
+	}
 	if v := extra.Version(); v != expectedExtra {
 		return fmt.Errorf("%w: expected %d, got %d", dbftutil.ErrUnexpectedExtraVersion, expectedExtra, v)
 	}
 
 	// Check that extra-data contains hashable part filled.
 	var expectedHashableExtraLen = dbftutil.HashableExtraV0Len
-	if isV1Extra || isV2Extra {
+	if isV1Extra || isV2Extra || isV3Extra {
 		expectedHashableExtraLen = dbftutil.HashableExtraV1Len
 	}
 	if len(header.Extra) < expectedHashableExtraLen {
@@ -1782,14 +1793,14 @@ func (c *DBFT) verifyHeader(chain consensus.ChainHeaderReader, header *types.Hea
 			m        = crypto.GetBFTHonestNodeCount(n)
 			expected int
 		)
-		if isV1Extra || isV2Extra {
-			if !isAMEV && extra.SignatureScheme() != dbftutil.ExtraV1ECDSAScheme {
-				return fmt.Errorf("%w for pre-NeoXAMEV block: expected %d, got %d", dbftutil.ErrUnexpectedBlockSignatureScheme, dbftutil.ExtraV1ECDSAScheme, extra.SignatureScheme())
+		if isV1Extra || isV2Extra || isV3Extra {
+			if !isAMEV && extra.SignatureScheme() != dbftutil.ECDSAScheme {
+				return fmt.Errorf("%w for pre-NeoXAMEV block: expected %d, got %d", dbftutil.ErrUnexpectedBlockSignatureScheme, dbftutil.ECDSAScheme, extra.SignatureScheme())
 			}
 			switch ss := extra.SignatureScheme(); ss {
-			case dbftutil.ExtraV1ECDSAScheme:
+			case dbftutil.ECDSAScheme:
 				expected = dbftutil.HashableExtraV1Len + m*crypto.SignatureLength + n*common.AddressLength
-			case dbftutil.ExtraV1ThresholdScheme:
+			case dbftutil.ThresholdScheme:
 				expected = dbftutil.HashableExtraV1Len + tpke.PublicKeyLen + tpke.SignatureLen
 			default:
 				return fmt.Errorf("%w: %d", dbftutil.ErrUnexpectedBlockSignatureScheme, ss)
@@ -1802,7 +1813,7 @@ func (c *DBFT) verifyHeader(chain consensus.ChainHeaderReader, header *types.Hea
 		}
 
 		// Ensure that the mix digest is not zero.
-		if !isV1Extra && !isV2Extra && header.MixDigest == (common.Hash{}) {
+		if !isV1Extra && !isV2Extra && !isV3Extra && header.MixDigest == (common.Hash{}) {
 			return errInvalidMixDigest
 		}
 	}
@@ -1918,7 +1929,7 @@ func (c *DBFT) verifyCascadingFields(chain consensus.ChainHeaderReader, header *
 	if !isSealed {
 		return nil
 	}
-	return c.verifySeal(header, parents, parent)
+	return c.verifySeal(header, parent)
 }
 
 // VerifyUncles implements consensus.Engine, always returning an error for any
@@ -1934,7 +1945,7 @@ func (c *DBFT) VerifyUncles(chain consensus.ChainReader, block *types.Block) err
 // consensus protocol requirements. The method accepts an optional list of parent
 // headers that aren't yet part of the local blockchain to generate the snapshots
 // from.
-func (c *DBFT) verifySeal(header *types.Header, parents []*types.Header, parent *types.Header) error {
+func (c *DBFT) verifySeal(header *types.Header, parent *types.Header) error {
 	// Verifying the genesis block is not supported
 	number := header.Number.Uint64()
 	if number == 0 {
@@ -1986,9 +1997,9 @@ func (c *DBFT) verifyExtra(sealHashBytes []byte, extra dbftutil.Extra, parentNex
 			return fmt.Errorf("%w: %s", errUnauthorizedSigner, err)
 		}
 		return nil
-	case dbftutil.ExtraV1, dbftutil.ExtraV2:
+	case dbftutil.ExtraV1, dbftutil.ExtraV2, dbftutil.ExtraV3:
 		switch ss := extra.SignatureScheme(); ss {
-		case dbftutil.ExtraV1ECDSAScheme:
+		case dbftutil.ECDSAScheme:
 			vals, sigs, err := extra.ECDSASigners(len(c.config.StandByValidators))
 			if err != nil {
 				return fmt.Errorf("failed to retrieve validators and signatures from header: %w", err)
@@ -2001,7 +2012,7 @@ func (c *DBFT) verifyExtra(sealHashBytes []byte, extra dbftutil.Extra, parentNex
 			case dbftutil.ExtraV0:
 				expected = parentNextConsensus
 			case dbftutil.ExtraV1, dbftutil.ExtraV2:
-				var offset = dbftutil.ExtraVersionLen + dbftutil.ExtraV1SignatureSchemeLen
+				var offset = dbftutil.ExtraVersionLen + dbftutil.SignatureSchemeLen
 				expected.SetBytes(parentExtra[offset : offset+common.HashLength])
 			default:
 				return fmt.Errorf("%w of parent block: %d", dbftutil.ErrUnexpectedExtraVersion, pv)
@@ -2015,7 +2026,7 @@ func (c *DBFT) verifyExtra(sealHashBytes []byte, extra dbftutil.Extra, parentNex
 				return fmt.Errorf("%w: %s", errUnauthorizedSigner, err)
 			}
 			return nil
-		case dbftutil.ExtraV1ThresholdScheme:
+		case dbftutil.ThresholdScheme:
 			// Resolve the threshold signature and check against global public key.
 			pub, sig, err := extra.ThresholdSigners()
 			if err != nil {
@@ -2056,17 +2067,19 @@ func (c *DBFT) Prepare(chain consensus.ChainHeaderReader, header *types.Header) 
 	// signatures) are treated as changeable and are not filled in during Prepare.
 	if chain.Config().IsNeoXAMEV(new(big.Int).Add(header.Number, bigOne)) {
 		var extraVersion dbftutil.ExtraVersion
-		if chain.Config().IsNeoXEthSig(new(big.Int).Add(header.Number, bigOne)) {
+		if chain.Config().IsNeoXSSZSig(new(big.Int).Add(header.Number, bigOne)) {
+			extraVersion = dbftutil.ExtraV3
+		} else if chain.Config().IsNeoXEthSig(new(big.Int).Add(header.Number, bigOne)) {
 			extraVersion = dbftutil.ExtraV2
 		} else {
 			extraVersion = dbftutil.ExtraV1
 		}
-		var sigScheme dbftutil.ExtraV1SignatureScheme
+		var sigScheme dbftutil.SignatureScheme
 		// Enforce multisignature block signing if we're not at NeoXAMEV yet.
 		if c.config.enforceECDSASignatures || !chain.Config().IsNeoXAMEV(header.Number) {
-			sigScheme = dbftutil.ExtraV1ECDSAScheme
+			sigScheme = dbftutil.ECDSAScheme
 		} else {
-			sigScheme = dbftutil.ExtraV1ThresholdScheme
+			sigScheme = dbftutil.ThresholdScheme
 		}
 		header.Extra = []byte{byte(extraVersion), byte(sigScheme)}
 	} else {
@@ -2275,7 +2288,7 @@ func (c *DBFT) waitForNewSealingProposal(desiredHeight uint64, updateContext boo
 			return fmt.Errorf("can't verify sealing task: failed to get parent from chain: expected %s, got %s", c.lastBlockHash, b.ParentHash())
 		}
 		// Parent hash is constant starting from NeoXAMEV+1 height in case if threshold signature is used by parent.
-		if c.chain.Config().IsNeoXAMEV(new(big.Int).Sub(b.Number(), bigOne)) && dbftutil.Extra(parent.Extra).SignatureScheme() == dbftutil.ExtraV1ThresholdScheme {
+		if c.chain.Config().IsNeoXAMEV(new(big.Int).Sub(b.Number(), bigOne)) && dbftutil.Extra(parent.Extra).SignatureScheme() == dbftutil.ThresholdScheme {
 			return fmt.Errorf("invalid sealing task: parent hash mismatch with NeoXAMEV fork enabled and threshold signature scheme: expected %s, got %s", c.lastBlockHash, b.ParentHash())
 		}
 
@@ -2468,6 +2481,9 @@ func (c *DBFT) OnPayload(cp *dbftproto.Message) error {
 }
 
 func (c *DBFT) getBlockExtraVersion(height *big.Int) dbftutil.ExtraVersion {
+	if c.chain.Config().IsNeoXSSZSig(height) || c.chain.Config().IsNeoXSSZSig(new(big.Int).Add(height, bigOne)) {
+		return dbftutil.ExtraV3
+	}
 	if c.chain.Config().IsNeoXEthSig(height) || c.chain.Config().IsNeoXEthSig(new(big.Int).Add(height, bigOne)) {
 		return dbftutil.ExtraV2
 	}
@@ -2701,13 +2717,13 @@ func honestSealHash(header *types.Header) ([]byte, error) {
 	)
 	switch v := extra.Version(); v {
 	case dbftutil.ExtraV0:
-		sealHash = HonestSealHashV0(header).Bytes()
-	case dbftutil.ExtraV1, dbftutil.ExtraV2:
+		sealHash = honestSealHashKeccaak256(header, false).Bytes()
+	case dbftutil.ExtraV1, dbftutil.ExtraV2, dbftutil.ExtraV3:
 		switch ss := extra.SignatureScheme(); ss {
-		case dbftutil.ExtraV1ECDSAScheme:
-			sealHash = HonestSealHashV0(header).Bytes()
-		case dbftutil.ExtraV1ThresholdScheme:
-			b := HonestSealHashV1(header).Bytes()
+		case dbftutil.ECDSAScheme:
+			sealHash = honestSealHashKeccaak256(header, v == dbftutil.ExtraV3).Bytes()
+		case dbftutil.ThresholdScheme:
+			b := honestSealHashBLS12381(header, v == dbftutil.ExtraV3).Bytes()
 			sealHash = b[:]
 		default:
 			return sealHash, fmt.Errorf("%w: %d", dbftutil.ErrUnexpectedBlockSignatureScheme, ss)
@@ -2718,21 +2734,31 @@ func honestSealHash(header *types.Header) ([]byte, error) {
 	return sealHash, nil
 }
 
-// HonestSealHashV0 returns the hash of a block prior to it being sealed. It differs
+// honestSealHashKeccaak256 returns the hash of a block prior to it being sealed. It differs
 // from WorkerSealHash in that all block fields except Extra's signature bytes are being
 // hashed. This hash represents a Keccaak256 hash of header.
-func HonestSealHashV0(header *types.Header) (hash common.Hash) {
+func honestSealHashKeccaak256(header *types.Header, ssz bool) common.Hash {
+	var b []byte
+	if ssz {
+		b = dbftSSZ(header)
+	} else {
+		b = dbftRLP(header)
+	}
 	hasher := sha3.NewLegacyKeccak256()
-	encodeSigHeader(hasher, header)
-	hasher.(crypto.KeccakState).Read(hash[:])
-	return hash
+	return common.Hash(hasher.Sum(b))
 }
 
-// HonestSealHashV1 returns the hash of a block prior to it being sealed. It differs
+// honestSealHashBLS12381 returns the hash of a block prior to it being sealed. It differs
 // from WorkerSealHash in that all block fields except Extra's signature bytes are being
 // hashed. This hash represents a G2 point on BLS12381 curve.
-func HonestSealHashV1(header *types.Header) *bls12381.G2Affine {
-	res, _ := bls12381.HashToG2(dbftRLP(header), tpke.Domain)
+func honestSealHashBLS12381(header *types.Header, ssz bool) *bls12381.G2Affine {
+	var b []byte
+	if ssz {
+		b = dbftSSZ(header)
+	} else {
+		b = dbftRLP(header)
+	}
+	res, _ := bls12381.HashToG2(b, tpke.Domain)
 	return &res
 }
 
@@ -2744,12 +2770,6 @@ func HonestSealHashV1(header *types.Header) *bls12381.G2Affine {
 // panics. This is done to avoid accidentally using both forms (signature present
 // or not), which could be abused to produce different hashes for the same header.
 func dbftRLP(header *types.Header) []byte {
-	b := new(bytes.Buffer)
-	encodeSigHeader(b, header)
-	return b.Bytes()
-}
-
-func encodeSigHeader(w io.Writer, header *types.Header) {
 	var hashableExtraLen int
 	switch v := dbftutil.Extra(header.Extra).Version(); v {
 	case dbftutil.ExtraV0:
@@ -2759,6 +2779,7 @@ func encodeSigHeader(w io.Writer, header *types.Header) {
 	default:
 		panic(fmt.Errorf("%w: %d", dbftutil.ErrUnexpectedExtraVersion, v)) // a dangerous program bug
 	}
+	b := new(bytes.Buffer)
 	enc := []interface{}{
 		header.ParentHash,
 		header.UncleHash,
@@ -2794,9 +2815,63 @@ func encodeSigHeader(w io.Writer, header *types.Header) {
 	if header.RequestsHash != nil {
 		enc = append(enc, header.RequestsHash)
 	}
-	if err := rlp.Encode(w, enc); err != nil {
+	if err := rlp.Encode(b, enc); err != nil {
 		panic("can't encode: " + err.Error())
 	}
+	return b.Bytes()
+}
+
+// dbftSSZ returns the SSZ bytes which needs to be signed for the proof-of-authority
+// sealing. The SSZ to sign consists of the entire header apart from the 65 byte signature
+// contained at the end of the extra data.
+func dbftSSZ(header *types.Header) []byte {
+	var hashableExtraLen int
+	switch v := dbftutil.Extra(header.Extra).Version(); v {
+	case dbftutil.ExtraV3:
+		hashableExtraLen = dbftutil.HashableExtraV1Len
+	default:
+		panic(fmt.Errorf("%w: %d", dbftutil.ErrUnexpectedExtraVersion, v)) // a dangerous program bug
+	}
+	b := make([]byte, 0)
+	b = append(b, header.ParentHash.Bytes()...)  // 32
+	b = append(b, header.UncleHash.Bytes()...)   // 32
+	b = append(b, header.Coinbase.Bytes()...)    // 20
+	b = append(b, header.Root.Bytes()...)        // 32
+	b = append(b, header.TxHash.Bytes()...)      // 32
+	b = append(b, header.ReceiptHash.Bytes()...) // 32
+	b = append(b, header.Bloom.Bytes()...)       // 256
+	// Difficulty and number are safe in uint64.
+	ssz.MarshalUint64(b, header.Difficulty.Uint64()) // 8
+	ssz.MarshalUint64(b, header.Number.Uint64())     // 8
+	ssz.MarshalUint64(b, header.GasLimit)            // 8
+	ssz.MarshalUint64(b, header.GasUsed)             // 8
+	ssz.MarshalUint64(b, header.Time)                // 8
+	// Extra length is fixed in dBFT, but depends on extra version.
+	b = append(b, header.Extra[:hashableExtraLen]...) // 1 or 34
+	b = append(b, header.MixDigest.Bytes()...)        // 32
+	// We use nonce as int, to store primary index.
+	ssz.MarshalUint64(b, header.Nonce.Uint64()) // 8
+
+	if header.BaseFee != nil {
+		// BaseFee is defined as uint256, ref https://github.com/OffchainLabs/prysm/blob/v7.0.0/specrefs/containers.yml#L708.
+		b = append(b, marshalAsUint256(header.BaseFee)...) // 32
+	}
+	if header.WithdrawalsHash != nil {
+		b = append(b, header.WithdrawalsHash.Bytes()...) // 32
+	}
+	if header.BlobGasUsed != nil {
+		ssz.MarshalUint64(b, *header.BlobGasUsed) // 8
+	}
+	if header.ExcessBlobGas != nil {
+		ssz.MarshalUint64(b, *header.ExcessBlobGas) // 8
+	}
+	if header.ParentBeaconRoot != nil {
+		b = append(b, header.ParentBeaconRoot.Bytes()...) // 32
+	}
+	if header.RequestsHash != nil {
+		b = append(b, header.RequestsHash.Bytes()...) // 32
+	}
+	return b
 }
 
 // Close implements consensus.Engine.
@@ -2991,10 +3066,6 @@ func (c *DBFT) getNextConsensus(h *types.Header, s *state.StateDB) (common.Hash,
 	return multisig, threshold
 }
 
-func (c *DBFT) shouldUpdateCommitteeAt(blockNum uint64) bool {
-	return blockNum%uint64(len(c.config.StandByValidators)) == 0
-}
-
 func unpackContractExecutionResult(res interface{}, result *core.ExecutionResult, contractAbi abi.ABI, method string) error {
 	if len(result.Revert()) > 0 {
 		reason, errUnpack := abi.UnpackRevert(result.Revert())
@@ -3005,4 +3076,16 @@ func unpackContractExecutionResult(res interface{}, result *core.ExecutionResult
 		}
 	}
 	return contractAbi.UnpackIntoInterface(&res, method, result.Return())
+}
+
+// marshalAsUint256 converts a big.Int to a little-endian encoded uint256.
+func marshalAsUint256(v *big.Int) []byte {
+	res := make([]byte, 32)
+	bytes := v.Bytes()
+	if len(bytes) > 32 {
+		log.Crit("big integer overflow uint256", v)
+	}
+	slices.Reverse(bytes)
+	copy(res, bytes)
+	return res
 }

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -2677,6 +2677,18 @@ func encodeUnchangeableHeader(w io.Writer, header *types.Header) {
 	if header.WithdrawalsHash != nil {
 		enc = append(enc, header.WithdrawalsHash)
 	}
+	if header.BlobGasUsed != nil {
+		enc = append(enc, header.BlobGasUsed)
+	}
+	if header.ExcessBlobGas != nil {
+		enc = append(enc, header.ExcessBlobGas)
+	}
+	if header.ParentBeaconRoot != nil {
+		enc = append(enc, header.ParentBeaconRoot)
+	}
+	if header.RequestsHash != nil {
+		enc = append(enc, header.RequestsHash)
+	}
 	if err := rlp.Encode(w, enc); err != nil {
 		panic("can't encode: " + err.Error())
 	}

--- a/consensus/dbft/dbft_test.go
+++ b/consensus/dbft/dbft_test.go
@@ -1,0 +1,14 @@
+package dbft
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMarshalUint256_SSZ(t *testing.T) {
+	v := big.NewInt(113244324)
+	expect := []byte{0xa4, 0xf8, 0xbf, 0x06, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	require.Equal(t, marshalAsUint256(v), expect)
+}

--- a/consensus/dbft/dbftutil/util.go
+++ b/consensus/dbft/dbftutil/util.go
@@ -27,22 +27,26 @@ const (
 	// TPKE public key followed by aggregated validators' threshold signature compatible
 	// with Ethereum CL.
 	ExtraV2 ExtraVersion = 0x02
+	// ExtraV3 is the 3-rd version of block's Extra. Extra of this version includes global
+	// TPKE public key followed by aggregated validators' threshold signature, in which the
+	// header message is encoded with SSZ instead of RLP.
+	ExtraV3 ExtraVersion = 0x03
 )
 
-// ExtraV1SignatureScheme is a scheme of block signature (ECDSA multisignature or
-// threshold signature) that is used for ExtraV1 and ExtraV2 extra.
-type ExtraV1SignatureScheme byte
+// SignatureScheme is a scheme of block signature (ECDSA multisignature or
+// threshold signature) that is used since ExtraV1 extra.
+type SignatureScheme byte
 
 const (
-	// ExtraV1SignatureSchemeLen is the length of block signing scheme version for
-	// ExtraV1 and ExtraV2 extra.
-	ExtraV1SignatureSchemeLen = 1
-	// ExtraV1ECDSAScheme denotes fallback ECDSA multisignature block signing scheme
-	// for ExtraV1 and ExtraV2 extra.
-	ExtraV1ECDSAScheme ExtraV1SignatureScheme = 0x00
-	// ExtraV1ThresholdScheme denotes primary threshold signature block signing scheme
-	// for ExtraV1 and ExtraV2 extra.
-	ExtraV1ThresholdScheme ExtraV1SignatureScheme = 0x01
+	// SignatureSchemeLen is the length of block signing scheme version since
+	// ExtraV1 extra.
+	SignatureSchemeLen = 1
+	// ECDSAScheme denotes fallback ECDSA multisignature block signing scheme
+	// since ExtraV1 extra.
+	ECDSAScheme SignatureScheme = 0x00
+	// ThresholdScheme denotes primary threshold signature block signing scheme
+	// since ExtraV1 extra.
+	ThresholdScheme SignatureScheme = 0x01
 )
 
 // Constants denoting length of hashable part of block extra for different extra
@@ -51,9 +55,9 @@ const (
 	// HashableExtraV0Len is the length of hashable part of block extra data for
 	// ExtraV0 extra version.
 	HashableExtraV0Len = ExtraVersionLen
-	// HashableExtraV1Len is the length of hashable part of block extra data for
-	// ExtraV1 and ExtraV2 extra version.
-	HashableExtraV1Len = ExtraVersionLen + ExtraV1SignatureSchemeLen + common.HashLength // signing version byte + fallback NextConsensus address
+	// HashableExtraV1Len is the length of hashable part of block extra data since
+	// ExtraV1 extra version.
+	HashableExtraV1Len = ExtraVersionLen + SignatureSchemeLen + common.HashLength // signing version byte + fallback NextConsensus address
 )
 
 var (
@@ -67,7 +71,7 @@ var (
 
 	// ErrUnexpectedBlockSignatureScheme is returned when block's signing scheme is
 	// unknown or unexpected.
-	ErrUnexpectedBlockSignatureScheme = errors.New("unexpected block signing scheme for V1 extra")
+	ErrUnexpectedBlockSignatureScheme = errors.New("unexpected block signing scheme for V1/V2/V3 extra")
 )
 
 // Extra is a type providing versioning extension methods over block extra data.
@@ -78,23 +82,23 @@ func (e Extra) Version() ExtraVersion {
 	return ExtraVersion(e[0])
 }
 
-// SignatureScheme returns version of block signature for ExtraV1 and ExtraV2. It's no-op
+// SignatureScheme returns version of block signature starts from ExtraV1. It's no-op
 // to apply this method to V0 extra.
-func (e Extra) SignatureScheme() ExtraV1SignatureScheme {
-	return ExtraV1SignatureScheme(e[1])
+func (e Extra) SignatureScheme() SignatureScheme {
+	return SignatureScheme(e[1])
 }
 
 // ECDSASigners returns ECDSA multisignature signers and signatures from Extra depending
 // on the number of validators.
 func (e Extra) ECDSASigners(n int) ([]common.Address, [][]byte, error) {
-	if e.Version() != ExtraV0 && e.SignatureScheme() != ExtraV1ECDSAScheme {
+	if e.Version() != ExtraV0 && e.SignatureScheme() != ECDSAScheme {
 		return nil, nil, fmt.Errorf("ECDSA signers can't be recovered for threshold-based block signature scheme")
 	}
 	var buf []byte
 	switch e.Version() {
 	case ExtraV0:
 		buf = e[HashableExtraV0Len:]
-	case ExtraV1, ExtraV2:
+	case ExtraV1, ExtraV2, ExtraV3:
 		buf = e[HashableExtraV1Len:]
 	default:
 		return nil, nil, fmt.Errorf("%w: %d", ErrUnexpectedExtraVersion, e.Version())
@@ -128,11 +132,11 @@ func (e Extra) ECDSASigners(n int) ([]common.Address, [][]byte, error) {
 // ThresholdSigners returns global public key and threshold signature.
 func (e Extra) ThresholdSigners() (*tpke.PublicKey, *tpke.Signature, error) {
 	// Sanity check.
-	if v := e.Version(); v != ExtraV1 && v != ExtraV2 {
-		return nil, nil, fmt.Errorf("%w: expected %d or %d, got %d", ErrUnexpectedExtraVersion, ExtraV1, ExtraV2, v)
+	if v := e.Version(); v == ExtraV0 {
+		return nil, nil, fmt.Errorf("%w: unexpected %d", ErrUnexpectedExtraVersion, v)
 	}
-	if ss := e.SignatureScheme(); ss != ExtraV1ThresholdScheme {
-		return nil, nil, fmt.Errorf("%w: expected %d, got %d", ErrUnexpectedBlockSignatureScheme, ExtraV1ThresholdScheme, ss)
+	if ss := e.SignatureScheme(); ss != ThresholdScheme {
+		return nil, nil, fmt.Errorf("%w: expected %d, got %d", ErrUnexpectedBlockSignatureScheme, ThresholdScheme, ss)
 	}
 
 	if len(e) != HashableExtraV1Len+tpke.PublicKeyLen+tpke.SignatureLen {

--- a/consensus/dbft/precommit.go
+++ b/consensus/dbft/precommit.go
@@ -124,7 +124,7 @@ func decodeShares(data []byte) ([]*tpke.DecryptionShare, []*tpke.DecryptionShare
 		curr[i] = &tpke.DecryptionShare{}
 		_, err := curr[i].FromBytes(data[offset : offset+tpke.DecryptionShareSize])
 		if err != nil {
-			fmt.Errorf("decoding current round share %d: %w", i, err)
+			return nil, nil, fmt.Errorf("decoding current round share %d: %w", i, err)
 		}
 		offset += tpke.DecryptionShareSize
 	}
@@ -132,7 +132,7 @@ func decodeShares(data []byte) ([]*tpke.DecryptionShare, []*tpke.DecryptionShare
 		prev[i] = &tpke.DecryptionShare{}
 		_, err := prev[i].FromBytes(data[offset : offset+tpke.DecryptionShareSize])
 		if err != nil {
-			fmt.Errorf("decoding previous round share %d: %w", i, err)
+			return nil, nil, fmt.Errorf("decoding previous round share %d: %w", i, err)
 		}
 		offset += tpke.DecryptionShareSize
 	}

--- a/consensus/dbft/prepare_request.go
+++ b/consensus/dbft/prepare_request.go
@@ -15,7 +15,7 @@ type prepareRequest struct {
 	// pre-NeoXAMEV fork. Starting from NeoXAMEV+1 height these fields are filled
 	// only if multisignature signing scheme is enforced, hence marked as optional
 	// for RLP serialization.
-	ParentSealHashV0 common.Hash `rlp:optional`
+	ParentSealHashV0 common.Hash `rlp:"optional"`
 	ParentExtra      []byte      `rlp:"optional"`
 }
 

--- a/consensus/dbft/prepare_request_test.go
+++ b/consensus/dbft/prepare_request_test.go
@@ -34,7 +34,7 @@ func TestPrepareRequest_RLP(t *testing.T) {
 			ExcessBlobGas:    nil,
 			ParentBeaconRoot: nil,
 		},
-		TxHashes:         []common.Hash{common.Hash{}},
+		TxHashes:         []common.Hash{{}},
 		ParentSealHashV0: common.Hash{1, 2, 3},
 		ParentExtra:      []byte{1, 2, 3},
 	}

--- a/consensus/dbft/recovery_message_test.go
+++ b/consensus/dbft/recovery_message_test.go
@@ -41,7 +41,7 @@ func TestRecoverMessage_RLP(t *testing.T) {
 			ExcessBlobGas:    nil,
 			ParentBeaconRoot: nil,
 		},
-		TxHashes:         []common.Hash{common.Hash{}},
+		TxHashes:         []common.Hash{{}},
 		ParentSealHashV0: common.Hash{1, 2, 3},
 		ParentExtra:      []byte{1, 2, 3},
 	}

--- a/consensus/dbft/signer.go
+++ b/consensus/dbft/signer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/antimev"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/dbft/dbftutil"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/nspcc-dev/dbft"
 )
 
@@ -31,16 +32,22 @@ func (s *Signer) Sign(msg []byte) ([]byte, error) {
 }
 
 // signBlock signs block RLP bytes using the given extra version and signing scheme.
-func (s *Signer) signBlock(extra dbftutil.Extra, blockRLP []byte) ([]byte, error) {
+func (s *Signer) signBlock(extra dbftutil.Extra, header *types.Header) ([]byte, error) {
 	switch v := extra.Version(); v {
 	case dbftutil.ExtraV0:
-		return s.SignFn(accounts.Account{Address: s.Signer}, accounts.MimetypeTextPlain, blockRLP)
-	case dbftutil.ExtraV1, dbftutil.ExtraV2:
+		return s.SignFn(accounts.Account{Address: s.Signer}, accounts.MimetypeTextPlain, dbftRLP(header))
+	case dbftutil.ExtraV1, dbftutil.ExtraV2, dbftutil.ExtraV3:
+		var encode []byte
+		if v == dbftutil.ExtraV1 || v == dbftutil.ExtraV2 {
+			encode = dbftRLP(header)
+		} else {
+			encode = dbftSSZ(header)
+		}
 		switch ss := extra.SignatureScheme(); ss {
-		case dbftutil.ExtraV1ECDSAScheme:
-			return s.SignFn(accounts.Account{Address: s.Signer}, accounts.MimetypeTextPlain, blockRLP)
-		case dbftutil.ExtraV1ThresholdScheme:
-			share, err := s.AmevKeystore.SignShare(blockRLP, v == dbftutil.ExtraV1)
+		case dbftutil.ECDSAScheme:
+			return s.SignFn(accounts.Account{Address: s.Signer}, accounts.MimetypeTextPlain, encode)
+		case dbftutil.ThresholdScheme:
+			share, err := s.AmevKeystore.SignShare(encode, v == dbftutil.ExtraV1)
 			if err != nil {
 				return nil, fmt.Errorf("failed to sign share: %w", err)
 			}

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -592,9 +592,9 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database) (*types.Blo
 			if block.MixDigest() != expected {
 				return nil, fmt.Errorf("inconsistent MixHash (NextConsensus) genesis block setting: expected %s, got %s", expected, block.MixDigest())
 			}
-		case byte(dbftutil.ExtraV1), byte(dbftutil.ExtraV2):
+		case byte(dbftutil.ExtraV1), byte(dbftutil.ExtraV2), byte(dbftutil.ExtraV3):
 			switch extra[1] {
-			case byte(dbftutil.ExtraV1ECDSAScheme):
+			case byte(dbftutil.ECDSAScheme):
 				vals, _, err := dbftutil.Extra(extra).ECDSASigners(n)
 				if err != nil {
 					return nil, fmt.Errorf("failed to retrieve validators and signatures from header: %w", err)
@@ -603,7 +603,7 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database) (*types.Blo
 				if block.MixDigest() != expected {
 					return nil, fmt.Errorf("inconsistent MixHash (NextConsensus) genesis block setting: expected %s, got %s", expected, block.MixDigest())
 				}
-			case byte(dbftutil.ExtraV1ThresholdScheme):
+			case byte(dbftutil.ThresholdScheme):
 				pub, _, err := dbftutil.Extra(extra).ThresholdSigners()
 				if err != nil {
 					return nil, fmt.Errorf("failed to retrieve validators and signatures from header: %w", err)

--- a/params/config.go
+++ b/params/config.go
@@ -409,6 +409,7 @@ type ChainConfig struct {
 	NeoXDKGBlock    *big.Int `json:"neoXDKGBlock,omitempty"`    // Block-based switch to DKG related logic for dBFT, system contracts and processing engine (nil = no fork, 0 = already activated)
 	NeoXAMEVBlock   *big.Int `json:"neoXAMEVBlock,omitempty"`   // Block-based switch to anti-MEV related logic for dBFT (nil = no fork, 0 = already activated)
 	NeoXEthSigBlock *big.Int `json:"neoXEthSigBlock,omitempty"` // Block-based switch to fix block signature from NeoXAMEVBlock (nil = no fork, 0 = already activated)
+	NeoXSSZSigBlock *big.Int `json:"neoXSSZSigBlock,omitempty"` // Block-based switch to ZK-friendly block signature (nil = no fork, 0 = already activated)
 	CancunTime      *uint64  `json:"cancunTime,omitempty"`      // Cancun switch time (nil = no fork, 0 = already on cancun)
 	PragueTime      *uint64  `json:"pragueTime,omitempty"`      // Prague switch time (nil = no fork, 0 = already on prague)
 	OsakaTime       *uint64  `json:"osakaTime,omitempty"`       // Osaka switch time (nil = no fork, 0 = already on osaka)
@@ -675,6 +676,11 @@ func (c *ChainConfig) IsNeoXEthSig(num *big.Int) bool {
 	return c.IsLondon(num) && isBlockForked(c.NeoXEthSigBlock, num)
 }
 
+// IsNeoXSSZSig returns whether time is either equal to the NeoXSSZSig fork time or greater.
+func (c *ChainConfig) IsNeoXSSZSig(num *big.Int) bool {
+	return c.IsLondon(num) && isBlockForked(c.NeoXSSZSigBlock, num)
+}
+
 // IsCancun returns whether time is either equal to the Cancun fork time or greater.
 func (c *ChainConfig) IsCancun(num *big.Int, time uint64) bool {
 	return c.IsLondon(num) && isTimestampForked(c.CancunTime, time)
@@ -769,6 +775,7 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "neoXDKGBlock", block: c.NeoXDKGBlock, optional: true},
 		{name: "neoXAMEVBlock", block: c.NeoXAMEVBlock, optional: true},
 		{name: "neoXEthSigBlock", block: c.NeoXEthSigBlock, optional: true},
+		{name: "neoXSSZSigBlock", block: c.NeoXSSZSigBlock, optional: true},
 		{name: "cancunTime", timestamp: c.CancunTime, optional: true},
 		{name: "pragueTime", timestamp: c.PragueTime, optional: true},
 		{name: "osakaTime", timestamp: c.OsakaTime, optional: true},
@@ -918,6 +925,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, headNumber *big.Int, 
 	}
 	if isForkBlockIncompatible(c.NeoXEthSigBlock, newcfg.NeoXEthSigBlock, headNumber) {
 		return newBlockCompatError("NeoXEthSig fork block", c.NeoXEthSigBlock, newcfg.NeoXEthSigBlock)
+	}
+	if isForkBlockIncompatible(c.NeoXSSZSigBlock, newcfg.NeoXSSZSigBlock, headNumber) {
+		return newBlockCompatError("NeoXSSZSig fork block", c.NeoXSSZSigBlock, newcfg.NeoXSSZSigBlock)
 	}
 	if isForkTimestampIncompatible(c.CancunTime, newcfg.CancunTime, headTimestamp) {
 		return newTimestampCompatError("Cancun fork timestamp", c.CancunTime, newcfg.CancunTime)

--- a/privnet/four/genesis_privnet.json
+++ b/privnet/four/genesis_privnet.json
@@ -18,6 +18,7 @@
     "neoXDKGBlock": 0,
     "neoXAMEVBlock": 0,
     "neoXEthSigBlock": 0,
+    "neoXSSZSigBlock": 5,
     "cancunTime": 0,
     "pragueTime": 0,
     "blobSchedule": {

--- a/privnet/seven/genesis_privnet.json
+++ b/privnet/seven/genesis_privnet.json
@@ -18,6 +18,7 @@
     "neoXDKGBlock": 0,
     "neoXAMEVBlock": 0,
     "neoXEthSigBlock": 0,
+    "neoXSSZSigBlock": 5,
     "cancunTime": 0,
     "pragueTime": 0,
     "blobSchedule": {

--- a/privnet/single/genesis_privnet.json
+++ b/privnet/single/genesis_privnet.json
@@ -18,6 +18,7 @@
     "neoXDKGBlock": 0,
     "neoXAMEVBlock": 0,
     "neoXEthSigBlock": 0,
+    "neoXSSZSigBlock": 5,
     "cancunTime": 0,
     "pragueTime": 0,
     "blobSchedule": {

--- a/privnet/zk/genesis_privnet.json
+++ b/privnet/zk/genesis_privnet.json
@@ -18,6 +18,7 @@
     "neoXDKGBlock": 0,
     "neoXAMEVBlock": 0,
     "neoXEthSigBlock": 0,
+    "neoXSSZSigBlock": 5,
     "cancunTime": 0,
     "pragueTime": 0,
     "blobSchedule": {


### PR DESCRIPTION
Close #544. This also includes some fixes for dBFT, but needs further verifications on ZK before merge.