### PR TITLE
ci: remove redundant artifact uploads from build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,14 +21,6 @@ on:
         description: 'Ref to build geth [default: latest bane-main; examples: v0.92.0, 0a4ff9d3e4a9ab432fd5812eb18c98e03b5a7432]'
         required: false
         default: ''
-      upload_geth:
-        description: 'Upload Geth binary artifact [default: false; examples: true, false]'
-        required: false
-        default: 'false'
-      upload_alltools:
-        description: 'Upload Alltools binary artifacts [default: false; examples: true, false]'
-        required: false
-        default: 'false'
       push_image:
         description: 'Push images to DockerHub [default: false; examples: true, false]'
         required: false
@@ -86,22 +78,6 @@ jobs:
           mkdir ./build/standalone
           cp ./build/bin/geth ./build/standalone/geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}
           mv ./build/bin/ ./build/alltools-${{ matrix.os.bin-name }}-${{ matrix.arch }}
-
-      - name: Upload Geth artifact
-        if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_geth == 'true') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}
-          path: ./build/standalone/geth-${{ matrix.os.bin-name }}-${{ matrix.arch }}
-          if-no-files-found: error
-
-      - name: Upload Alltools artifact
-        if: ${{ github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.upload_alltools == 'true') }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: alltools-${{ matrix.os.bin-name }}-${{ matrix.arch }}
-          path: ./build/alltools-${{ matrix.os.bin-name }}-${{ matrix.arch }}
-          if-no-files-found: error
 
       - name: Attach binaries to the release as assets
         if: ${{ github.event_name == 'release' }}


### PR DESCRIPTION
### Summary

This PR removes redundant artifact-upload logic from the `Build` workflow.

### Changes

- Removed `Upload Geth artifact` step.
- Removed `Upload Alltools artifact` step.
- Removed unused `workflow_dispatch` inputs:
  - `upload_geth`
  - `upload_alltools`

### Background

Currently, the workflow builds the binaries (`geth`, `alltools`) and then:

1. uploads them as GitHub Actions artifacts  
2. uploads them again as release assets via `gh release upload`

Both steps operate on the same files within the same job, and no other job or workflow consumes the artifacts (no `download-artifact` usage).

### Why

Artifacts are intended for transferring data between jobs or for short-term debugging. In this workflow, they:

- are not consumed anywhere  
- duplicate the same binaries already attached to releases  
- are retained for 90 days by default  
- consume shared Actions storage quota  

The binaries are relatively large (~515 MB combined across four artifacts: ~196 MB, ~180 MB, ~71 MB, ~66 MB). Since artifacts are uploaded individually, a single workflow run can exceed the 0.5 GB storage quota without immediate failure. Once the total stored artifacts exceed the quota, all subsequent uploads (even very small ones) fail with `CreateArtifact`.

This behavior led to CI workflows being blocked due to exhausted artifact storage.

### Impact

- `pull_request` / `push`: no behavior change  
- `release`: binaries are still built and attached to the GitHub Release as before  
- `workflow_dispatch`: removes unused toggles for artifact uploads  

### Notes

If artifacts are needed for debugging in the future, they can be reintroduced with a short retention (e.g. `retention-days: 1`). For release builds, they are not required.