### PR TITLE
beacon/impl: eth: add proposal cache for missing tx searching

### DIFF
--- a/beacon/impl/beacon.go
+++ b/beacon/impl/beacon.go
@@ -30,11 +30,13 @@ type Beacon struct {
 	wg             sync.WaitGroup
 }
 
-// New creates a mock beacon client with basic mining functionality.
-func New(eth miner.Backend, rpc *rpc.Client, mux *event.TypeMux, coinbase common.Address, shouldPreserve func(header *types.Header) bool) *Beacon {
+// New creates a mock beacon client with basic mining functionality. It supports customized
+// fork choice rules and transaction filtering for messages from P2P beacon protocol.
+func New(eth miner.Backend, rpc *rpc.Client, mux *event.TypeMux, coinbase common.Address,
+	shouldPreserve miner.ShouldPreserveFn, txFilter miner.TransactionFilterFn) *Beacon {
 	b := &Beacon{
 		chain:   eth.BlockChain(),
-		miner:   miner.New(eth, rpc, mux, coinbase, shouldPreserve),
+		miner:   miner.New(eth, rpc, mux, coinbase, shouldPreserve, txFilter),
 		blockCh: make(chan *types.Block),
 	}
 
@@ -159,6 +161,23 @@ func (b *Beacon) StopMining() {
 // after view change happens, to trigger the new proposal generation and view update in miner.
 func (b *Beacon) RefreshPendingPayload() error {
 	return b.miner.RequestNewPayload()
+}
+
+// GetTransaction tries to find a transaction from the consensus level. This is useful for BFT
+// consensus, if a transaction is replaced or evited in the EL txpool.
+func (b *Beacon) GetTransaction(hash common.Hash) *types.Transaction {
+	return b.miner.GetTransaction(hash)
+}
+
+// NotifyTransactions notifies the miner about transactions seen in the beacon protocol.
+func (b *Beacon) NotifyTransactions(txs []*types.Transaction) {
+	b.miner.NotifyTransactions(txs)
+}
+
+// SubscribeTransactionEvents subscribes to transaction events from the miner.
+// This is useful for BFT consensus to listen on missing transaction responses.
+func (b *Beacon) SubscribeTransactionEvents(ch chan<- *types.Transaction) event.Subscription {
+	return b.miner.SubscribeTransactionEvents(ch)
 }
 
 // Close closes the beacon client service.

--- a/beacon/impl/miner/miner.go
+++ b/beacon/impl/miner/miner.go
@@ -14,6 +14,12 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
+// ShouldPreserveFn is the type of function to determine whether a block should be preserved in reorg.
+type ShouldPreserveFn func(header *types.Header) bool
+
+// TransactionFilterFn is the type of function to filter transactions before they are sent to subscribers.
+type TransactionFilterFn func(txs []*types.Transaction) []*types.Transaction
+
 // Backend wraps all methods required for mining. Only full node is capable
 // to offer all the functions here.
 type Backend interface {
@@ -34,20 +40,24 @@ type Miner struct {
 
 	worker      *worker
 	syncingFeed event.Feed              // Event feed for syncing status changes, a CL notifier as proxy
+	txFeed      event.Feed              // Event feed for new transactions delivered through CL
 	scope       event.SubscriptionScope // Subscription scope for miner events
+
+	txFilter TransactionFilterFn // Optional filter for transactions subscription
 
 	wg sync.WaitGroup
 }
 
 func New(eth Backend, rpc *rpc.Client, mux *event.TypeMux, coinbase common.Address,
-	shouldPreserve func(header *types.Header) bool) *Miner {
+	shouldPreserve ShouldPreserveFn, txFilter TransactionFilterFn) *Miner {
 	miner := &Miner{
-		mux:     mux,
-		backend: eth,
-		exitCh:  make(chan struct{}),
-		startCh: make(chan struct{}),
-		stopCh:  make(chan struct{}),
-		worker:  newWorker(eth, rpc, coinbase, shouldPreserve),
+		mux:      mux,
+		backend:  eth,
+		exitCh:   make(chan struct{}),
+		startCh:  make(chan struct{}),
+		stopCh:   make(chan struct{}),
+		worker:   newWorker(eth, rpc, coinbase, shouldPreserve),
+		txFilter: txFilter,
 	}
 	miner.wg.Add(1)
 	go miner.update()
@@ -68,6 +78,26 @@ func (miner *Miner) RequestNewPayload() error {
 	}
 	miner.worker.startCh <- struct{}{}
 	return nil
+}
+
+// GetTransaction tries to find a transaction from the latest payload that the
+// miner has seen.
+func (miner *Miner) GetTransaction(hash common.Hash) *types.Transaction {
+	return miner.worker.getTransaction(hash)
+}
+
+// NotifyTransactions notifies the miner about transactions seen in the beacon protocol.
+func (miner *Miner) NotifyTransactions(txs []*types.Transaction) {
+	if miner.txFilter != nil {
+		txs = miner.txFilter(txs)
+	}
+	if len(txs) == 0 {
+		return
+	}
+	for _, tx := range txs {
+		miner.txFeed.Send(tx)
+	}
+	miner.worker.cacheTransactions(txs)
 }
 
 // update keeps track of the downloader events. Please be aware that this is a one shot type of update loop.
@@ -164,4 +194,9 @@ func (miner *Miner) Mining() bool {
 // SubscribeSyncingEvents subscribes to syncing status changes, should only be used in CL.
 func (miner *Miner) SubscribeSyncingEvents(ch chan<- bool) event.Subscription {
 	return miner.scope.Track(miner.syncingFeed.Subscribe(ch))
+}
+
+// SubscribeTransactionEvents subscribes to transaction events from the miner, should only be used in CL.
+func (miner *Miner) SubscribeTransactionEvents(ch chan<- *types.Transaction) event.Subscription {
+	return miner.scope.Track(miner.txFeed.Subscribe(ch))
 }

--- a/beacon/impl/miner/miner_test.go
+++ b/beacon/impl/miner/miner_test.go
@@ -242,7 +242,7 @@ func createMiner(t *testing.T) (*Miner, *event.TypeMux, func(skipMiner bool)) {
 	shouldPreserve := func(_ *types.Header) bool {
 		return false
 	}
-	miner := New(backend, &rpc.Client{}, mux, etherbase, shouldPreserve)
+	miner := New(backend, &rpc.Client{}, mux, etherbase, shouldPreserve, nil)
 	cleanup := func(skipMiner bool) {
 		bc.Stop()
 		engine.Close()

--- a/beacon/impl/miner/worker.go
+++ b/beacon/impl/miner/worker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto/kzg4844"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
@@ -74,9 +75,12 @@ type worker struct {
 	syncing atomic.Bool // The indicator whether the node is still syncing.
 
 	// Mutex to prevent parallel fork request.
-	forkMu              sync.RWMutex
-	pendingPayloadID    *engine.PayloadID
-	pendingTransactions types.Transactions
+	forkMu                 sync.RWMutex
+	pendingPayloadID       *engine.PayloadID
+	pendingTransactions    types.Transactions
+	pendingVersionedHashes []common.Hash
+	isCellProofEnabled     bool
+	pendingBlobs           *engine.BlobsBundle
 }
 
 func newWorker(eth Backend, rpc *rpc.Client, feeRecipient common.Address, shouldPreserve func(header *types.Header) bool) *worker {
@@ -257,14 +261,17 @@ func (w *worker) requestWork(timestamp uint64) {
 		log.Error("Failed to commit payload", "err", err)
 		return
 	}
+	// Cache the new block's transactions for potential future use, e.g. for BFT missing transaction request.
+	w.pendingTransactions = block.Transactions()
+	w.pendingVersionedHashes = versionedHashes
+	w.isCellProofEnabled = w.chain.Config().IsOsaka(block.Number(), block.Time())
+	w.pendingBlobs = payload.BlobsBundle
 }
 
 // commit commits new work to consensus engine.
 func (w *worker) commit(block *types.Block, versionedHashes []common.Hash, requests [][]byte, start time.Time) error {
 	select {
 	case w.taskCh <- &task{block: block, versionedHashes: versionedHashes, requests: requests, createdAt: time.Now()}:
-		// Cache the new block's transactions for potential future use, e.g. for BFT missing transaction request.
-		w.pendingTransactions = block.Transactions()
 		log.Info("Commit new sealing work", "number", block.Number(), "sealhash", w.engine.SealHash(block.Header()),
 			"txs", len(block.Transactions()), "withdrawals", len(block.Withdrawals()), "gas", block.GasUsed(),
 			"elapsed", common.PrettyDuration(time.Since(start)))
@@ -283,7 +290,45 @@ func (w *worker) getTransaction(hash common.Hash) *types.Transaction {
 
 	for _, tx := range w.pendingTransactions {
 		if tx.Hash() == hash {
-			return tx
+			if tx.Type() == types.BlobTxType {
+				// For blob transaction, we need to rebuild the blob sidecar.
+				blobHashes := tx.BlobHashes()
+				blobs := make([]kzg4844.Blob, len(blobHashes))
+				commitments := make([]kzg4844.Commitment, len(blobHashes))
+				var version byte
+				var proofs []kzg4844.Proof
+				// The sidecar has different format based on its version.
+				if w.isCellProofEnabled {
+					version = types.BlobSidecarVersion1
+					proofs = make([]kzg4844.Proof, len(blobHashes)*kzg4844.CellProofsPerBlob)
+					for i, blobHash := range blobHashes {
+						for m, vHash := range w.pendingVersionedHashes {
+							if vHash == blobHash {
+								copy(blobs[i][:], w.pendingBlobs.Blobs[m])
+								copy(commitments[i][:], w.pendingBlobs.Commitments[m])
+								for n := range kzg4844.CellProofsPerBlob {
+									copy(proofs[i*kzg4844.CellProofsPerBlob+n][:], w.pendingBlobs.Proofs[m*kzg4844.CellProofsPerBlob+n])
+								}
+							}
+						}
+					}
+				} else {
+					version = types.BlobSidecarVersion0
+					proofs = make([]kzg4844.Proof, len(blobHashes))
+					for i, blobHash := range blobHashes {
+						for m, vHash := range w.pendingVersionedHashes {
+							if vHash == blobHash {
+								copy(blobs[i][:], w.pendingBlobs.Blobs[m])
+								copy(commitments[i][:], w.pendingBlobs.Commitments[m])
+								copy(proofs[i][:], w.pendingBlobs.Proofs[m])
+							}
+						}
+					}
+				}
+				return tx.WithBlobTxSidecar(types.NewBlobTxSidecar(version, blobs, commitments, proofs))
+			} else {
+				return tx
+			}
 		}
 	}
 	return nil
@@ -305,7 +350,25 @@ func (w *worker) cacheTransactions(txs []*types.Transaction) {
 		if len(w.pendingTransactions) >= transactionCacheSize {
 			return
 		}
-		w.pendingTransactions = append(w.pendingTransactions, tx)
+		// Ignore blob transaction if the sidecar is invalid.
+		if tx.Type() == types.BlobTxType {
+			sidecar := tx.BlobTxSidecar()
+			if sidecar == nil {
+				continue
+			}
+			if w.isCellProofEnabled && tx.BlobTxSidecar().Version == types.BlobSidecarVersion0 {
+				continue
+			}
+			w.pendingTransactions = append(w.pendingTransactions, tx.WithoutBlobTxSidecar())
+			w.pendingVersionedHashes = append(w.pendingVersionedHashes, tx.BlobHashes()...)
+			for i := range sidecar.Blobs {
+				w.pendingBlobs.Blobs = append(w.pendingBlobs.Blobs, sidecar.Blobs[i][:])
+				w.pendingBlobs.Commitments = append(w.pendingBlobs.Commitments, sidecar.Commitments[i][:])
+			}
+			for _, proof := range sidecar.Proofs {
+				w.pendingBlobs.Proofs = append(w.pendingBlobs.Proofs, proof[:])
+			}
+		}
 	}
 }
 

--- a/beacon/impl/miner/worker.go
+++ b/beacon/impl/miner/worker.go
@@ -297,31 +297,40 @@ func (w *worker) getTransaction(hash common.Hash) *types.Transaction {
 				commitments := make([]kzg4844.Commitment, len(blobHashes))
 				var version byte
 				var proofs []kzg4844.Proof
+				// Build a map from versioned hash to index for O(1) lookups.
+				hashToIndex := make(map[common.Hash]int, len(w.pendingVersionedHashes))
+				for idx, vHash := range w.pendingVersionedHashes {
+					hashToIndex[vHash] = idx
+				}
 				// The sidecar has different format based on its version.
 				if w.isCellProofEnabled {
 					version = types.BlobSidecarVersion1
 					proofs = make([]kzg4844.Proof, len(blobHashes)*kzg4844.CellProofsPerBlob)
 					for i, blobHash := range blobHashes {
-						for m, vHash := range w.pendingVersionedHashes {
-							if vHash == blobHash {
-								copy(blobs[i][:], w.pendingBlobs.Blobs[m])
-								copy(commitments[i][:], w.pendingBlobs.Commitments[m])
-								for n := range kzg4844.CellProofsPerBlob {
-									copy(proofs[i*kzg4844.CellProofsPerBlob+n][:], w.pendingBlobs.Proofs[m*kzg4844.CellProofsPerBlob+n])
-								}
+						m, exists := hashToIndex[blobHash]
+						if exists {
+							copy(blobs[i][:], w.pendingBlobs.Blobs[m])
+							copy(commitments[i][:], w.pendingBlobs.Commitments[m])
+							for n := range kzg4844.CellProofsPerBlob {
+								copy(proofs[i*kzg4844.CellProofsPerBlob+n][:], w.pendingBlobs.Proofs[m*kzg4844.CellProofsPerBlob+n])
 							}
+						} else {
+							log.Error("Blob is missing in the cache", "txhash", hash, "blobhash", blobHash)
+							return nil
 						}
 					}
 				} else {
 					version = types.BlobSidecarVersion0
 					proofs = make([]kzg4844.Proof, len(blobHashes))
 					for i, blobHash := range blobHashes {
-						for m, vHash := range w.pendingVersionedHashes {
-							if vHash == blobHash {
-								copy(blobs[i][:], w.pendingBlobs.Blobs[m])
-								copy(commitments[i][:], w.pendingBlobs.Commitments[m])
-								copy(proofs[i][:], w.pendingBlobs.Proofs[m])
-							}
+						m, exists := hashToIndex[blobHash]
+						if exists {
+							copy(blobs[i][:], w.pendingBlobs.Blobs[m])
+							copy(commitments[i][:], w.pendingBlobs.Commitments[m])
+							copy(proofs[i][:], w.pendingBlobs.Proofs[m])
+						} else {
+							log.Error("Blob is missing in the cache", "txhash", hash, "blobhash", blobHash)
+							return nil
 						}
 					}
 				}
@@ -339,12 +348,15 @@ func (w *worker) getTransaction(hash common.Hash) *types.Transaction {
 func (w *worker) cacheTransactions(txs []*types.Transaction) {
 	w.forkMu.Lock()
 	defer w.forkMu.Unlock()
+	// Build a map from versioned hash to index for O(1) lookups.
+	hashToIndex := make(map[common.Hash]int, len(w.pendingTransactions))
+	for idx, tx := range w.pendingTransactions {
+		hashToIndex[tx.Hash()] = idx
+	}
 	// If the transaction is already in the cache, skip it.
 	for _, tx := range txs {
-		for _, pendingTx := range w.pendingTransactions {
-			if pendingTx.Hash() == tx.Hash() {
-				continue
-			}
+		if _, exists := hashToIndex[tx.Hash()]; exists {
+			continue
 		}
 		// Ignore remote transaction if the cache is full.
 		if len(w.pendingTransactions) >= transactionCacheSize {
@@ -356,7 +368,19 @@ func (w *worker) cacheTransactions(txs []*types.Transaction) {
 			if sidecar == nil {
 				continue
 			}
-			if w.isCellProofEnabled && tx.BlobTxSidecar().Version == types.BlobSidecarVersion0 {
+			switch tx.BlobTxSidecar().Version {
+			case types.BlobSidecarVersion0:
+				if w.isCellProofEnabled {
+					continue
+				}
+			case types.BlobSidecarVersion1:
+				if !w.isCellProofEnabled {
+					continue
+				}
+			default:
+				continue
+			}
+			if err := core.ValidateBlobSidecar(sidecar, tx.BlobHashes()); err != nil {
 				continue
 			}
 			w.pendingTransactions = append(w.pendingTransactions, tx.WithoutBlobTxSidecar())

--- a/beacon/impl/miner/worker.go
+++ b/beacon/impl/miner/worker.go
@@ -26,6 +26,9 @@ const (
 
 	// chainHeadChanSize is the size of channel listening to ChainHeadEvent.
 	chainHeadChanSize = 10
+
+	// transactionCacheSize is the max size of pending transaction cache.
+	transactionCacheSize = 512
 )
 
 // newWorkReq represents a request for new sealing work submitting.
@@ -71,8 +74,9 @@ type worker struct {
 	syncing atomic.Bool // The indicator whether the node is still syncing.
 
 	// Mutex to prevent parallel fork request.
-	forkMu           sync.Mutex
-	pendingPayloadID *engine.PayloadID
+	forkMu              sync.RWMutex
+	pendingPayloadID    *engine.PayloadID
+	pendingTransactions types.Transactions
 }
 
 func newWorker(eth Backend, rpc *rpc.Client, feeRecipient common.Address, shouldPreserve func(header *types.Header) bool) *worker {
@@ -259,6 +263,8 @@ func (w *worker) requestWork(timestamp uint64) {
 func (w *worker) commit(block *types.Block, versionedHashes []common.Hash, requests [][]byte, start time.Time) error {
 	select {
 	case w.taskCh <- &task{block: block, versionedHashes: versionedHashes, requests: requests, createdAt: time.Now()}:
+		// Cache the new block's transactions for potential future use, e.g. for BFT missing transaction request.
+		w.pendingTransactions = block.Transactions()
 		log.Info("Commit new sealing work", "number", block.Number(), "sealhash", w.engine.SealHash(block.Header()),
 			"txs", len(block.Transactions()), "withdrawals", len(block.Withdrawals()), "gas", block.GasUsed(),
 			"elapsed", common.PrettyDuration(time.Since(start)))
@@ -267,6 +273,40 @@ func (w *worker) commit(block *types.Block, versionedHashes []common.Hash, reque
 		log.Info("Worker has exited")
 	}
 	return nil
+}
+
+// getTransaction tries to find a transaction from the pending transaction cache.
+func (w *worker) getTransaction(hash common.Hash) *types.Transaction {
+	// The pending payload is also protected by the fork mutex, here we borrow it.
+	w.forkMu.RLock()
+	defer w.forkMu.RUnlock()
+
+	for _, tx := range w.pendingTransactions {
+		if tx.Hash() == hash {
+			return tx
+		}
+	}
+	return nil
+}
+
+// cacheTransactions adds transactions to the pending transaction cache, so mark as
+// seen during this round of consensus.
+func (w *worker) cacheTransactions(txs []*types.Transaction) {
+	w.forkMu.Lock()
+	defer w.forkMu.Unlock()
+	// If the transaction is already in the cache, skip it.
+	for _, tx := range txs {
+		for _, pendingTx := range w.pendingTransactions {
+			if pendingTx.Hash() == tx.Hash() {
+				continue
+			}
+		}
+		// Ignore remote transaction if the cache is full.
+		if len(w.pendingTransactions) >= transactionCacheSize {
+			return
+		}
+		w.pendingTransactions = append(w.pendingTransactions, tx)
+	}
 }
 
 // feedback sends signed block back to EL for execution.

--- a/consensus/dbft/beacon.go
+++ b/consensus/dbft/beacon.go
@@ -1,0 +1,14 @@
+package dbft
+
+import (
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Beacon is a CL API abstraction needed for proper dBFT work.
+type Beacon interface {
+	RefreshPendingPayload() error
+	BlockBroadcaster() chan<- *types.Block
+	SubscribeSyncingEvents(ch chan<- bool) event.Subscription
+	SubscribeTransactionEvents(ch chan<- *types.Transaction) event.Subscription
+}

--- a/consensus/dbft/chainreader.go
+++ b/consensus/dbft/chainreader.go
@@ -28,14 +28,5 @@ type ChainHeaderReader interface {
 // ChainInsertFn is a callback type to insert a block into the local chain.
 type ChainInsertFn func(*types.Block) error
 
-// RefreshProposalFn is a callback type to request a new proposal from the miner.
-type RefreshProposalFn func() error
-
 // SyncingFn is a callback type to check whether the node is syncing.
 type SyncingFn func() bool
-
-// SubscribeSyncingFn is a callback type to subscribe to syncing status changes.
-type SubscribeSyncingFn func(ch chan<- bool) event.Subscription
-
-// SubscribeMissingTxFn is a callback type to subscribe to missing transaction responses.
-type SubscribeMissingTxFn func(ch chan<- *types.Transaction) event.Subscription

--- a/consensus/dbft/chainreader.go
+++ b/consensus/dbft/chainreader.go
@@ -36,3 +36,6 @@ type SyncingFn func() bool
 
 // SubscribeSyncingFn is a callback type to subscribe to syncing status changes.
 type SubscribeSyncingFn func(ch chan<- bool) event.Subscription
+
+// SubscribeMissingTxFn is a callback type to subscribe to missing transaction responses.
+type SubscribeMissingTxFn func(ch chan<- *types.Transaction) event.Subscription

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -246,7 +246,7 @@ type DBFT struct {
 	// mutex since every access point is controlled by eventLoop, thus, not concurrent.
 	sealingProposal     *types.Header
 	sealingTransactions types.Transactions
-	refreshProposal     RefreshProposalFn
+	refreshProposal     func() error
 
 	// sealingState, sealingBlock and sealingReceipts are Primary-only set of fields got
 	// after sealingProposal construction and processing. These fields are not protected
@@ -1561,16 +1561,15 @@ func (c *DBFT) WithRequestTxs(f func(hashed []common.Hash)) {
 }
 
 // WithBeacon initializes beacon protocol related channels and functions.
-func (c *DBFT) WithBeacon(ch chan<- *types.Block, refreshProposal RefreshProposalFn,
-	subMissingTx SubscribeMissingTxFn, subSyncing SubscribeSyncingFn, syncing SyncingFn) {
+func (c *DBFT) WithBeacon(beacon Beacon, syncing SyncingFn) {
 	// The channel to broadcast new blocks in beacon protocol.
-	c.scope.Track(c.blockFeed.Subscribe(ch))
+	c.scope.Track(c.blockFeed.Subscribe(beacon.BlockBroadcaster()))
 	// The callback to request a new block proposal for view change.
-	c.refreshProposal = refreshProposal
+	c.refreshProposal = beacon.RefreshPendingPayload
 	// The channel to receive transactions from CL.
-	c.txSub = subMissingTx(c.txEvents)
+	c.txSub = beacon.SubscribeTransactionEvents(c.txEvents)
 	// The direct checker of miner working state.
-	c.syncingSub = subSyncing(c.syncingEvents)
+	c.syncingSub = beacon.SubscribeSyncingEvents(c.syncingEvents)
 	c.syncing = syncing
 }
 

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -196,7 +196,8 @@ type DBFT struct {
 	// buffered txs channel.
 	requestTxs func(hashed []common.Hash)
 	txCbList   atomic.Value
-	txs        chan *types.Transaction
+	txSub      event.Subscription
+	txEvents   chan *types.Transaction
 
 	// various chain/mempool events and subscription management:
 	chainHeadSub    event.Subscription
@@ -343,7 +344,7 @@ func New(chainCfg *params.ChainConfig, _ ethdb.Database) (*DBFT, error) {
 		signerConfig: types.LatestSigner(chainCfg),
 
 		messages:        make(chan Payload, msgsChCap),
-		txs:             make(chan *types.Transaction, txSubCap),
+		txEvents:        make(chan *types.Transaction, txSubCap),
 		chainHeadEvents: make(chan core.ChainHeadEvent, 2),
 		syncingEvents:   make(chan bool, 2),
 
@@ -1560,11 +1561,14 @@ func (c *DBFT) WithRequestTxs(f func(hashed []common.Hash)) {
 }
 
 // WithBeacon initializes beacon protocol related channels and functions.
-func (c *DBFT) WithBeacon(ch chan<- *types.Block, refreshProposal RefreshProposalFn, subSyncing SubscribeSyncingFn, syncing SyncingFn) {
+func (c *DBFT) WithBeacon(ch chan<- *types.Block, refreshProposal RefreshProposalFn,
+	subMissingTx SubscribeMissingTxFn, subSyncing SubscribeSyncingFn, syncing SyncingFn) {
 	// The channel to broadcast new blocks in beacon protocol.
 	c.scope.Track(c.blockFeed.Subscribe(ch))
 	// The callback to request a new block proposal for view change.
 	c.refreshProposal = refreshProposal
+	// The channel to receive transactions from CL.
+	c.txSub = subMissingTx(c.txEvents)
 	// The direct checker of miner working state.
 	c.syncingSub = subSyncing(c.syncingEvents)
 	c.syncing = syncing
@@ -2342,8 +2346,8 @@ events:
 			}
 			log.Debug("received message", fields...)
 			c.dbft.OnReceive(&msg)
-		case tx := <-c.txs:
-			c.dbft.OnTransaction(&Transaction{Tx: tx})
+		case tx := <-c.txEvents:
+			c.dbft.OnTransaction(&Transaction{Tx: tx.WithoutBlobTxSidecar()})
 		case h := <-c.chainHeadEvents:
 			c.handleChainBlock(h.Header, true)
 		case err := <-c.chainHeadSub.Err():
@@ -2407,20 +2411,19 @@ events:
 	}
 	c.dbft.Timer.Stop()
 	c.chainHeadSub.Unsubscribe()
+	c.txSub.Unsubscribe()
 	c.syncingSub.Unsubscribe()
 	c.eventLoopRunning.Store(false)
 drainLoop:
 	for {
 		select {
 		case <-c.messages:
-		case <-c.txs:
 		case <-c.chainHeadEvents:
 		default:
 			break drainLoop
 		}
 	}
 	close(c.messages)
-	close(c.txs)
 	close(c.chainHeadEvents)
 	close(c.eventLoopToCloseCh)
 	log.Info("dBFT event loop stopped")
@@ -2463,25 +2466,24 @@ func (c *DBFT) getBlockExtraVersion(height *big.Int) dbftutil.ExtraVersion {
 	return dbftutil.ExtraV0
 }
 
-// OnTransaction is a dBFT callback that reacts on new incoming transaction arrived
-// via P2P. It's important to call this callback on every incoming transaction
-// skipping mempool filtering for proper dBFT functioning.
-func (c *DBFT) OnTransaction(txs []*types.Transaction) {
+// FilterMissingTransaction is a dBFT helper to filter transactions that are known as missing.
+func (c *DBFT) FilterMissingTransaction(txs []*types.Transaction) []*types.Transaction {
 	if c.dbft == nil || !c.dbftStarted.Load() {
-		log.Debug("Skip txs batch handling: dbft is inactive or not started yet")
-		return
+		return nil
 	}
 
-	var cbList = c.txCbList.Load()
+	known := make([]*types.Transaction, 0, len(txs))
+	cbList := c.txCbList.Load()
 	if cbList != nil {
 		for _, tx := range txs {
 			tx = tx.WithoutBlobTxSidecar()
 			_, found := slices.BinarySearchFunc(cbList.([]common.Hash), tx.Hash(), common.Hash.Cmp)
 			if found {
-				c.txs <- tx
+				known = append(known, tx)
 			}
 		}
 	}
+	return known
 }
 
 func payloadFromMessage(ep *dbftproto.Message, getBlockExtraVersion func(*big.Int) dbftutil.ExtraVersion) *Payload {

--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -2476,7 +2476,6 @@ func (c *DBFT) FilterMissingTransaction(txs []*types.Transaction) []*types.Trans
 	cbList := c.txCbList.Load()
 	if cbList != nil {
 		for _, tx := range txs {
-			tx = tx.WithoutBlobTxSidecar()
 			_, found := slices.BinarySearchFunc(cbList.([]common.Hash), tx.Hash(), common.Hash.Cmp)
 			if found {
 				known = append(known, tx)

--- a/core/file_system.go
+++ b/core/file_system.go
@@ -13,7 +13,8 @@ import (
 )
 
 var (
-	errBlobTxNotFound       = fmt.Errorf("blob tx not found in blob pool")
+	errBlobTxNotFound       = fmt.Errorf("blob tx not found")
+	errSidecarLessBlobTx    = fmt.Errorf("sidecar-less blob transaction")
 	errUnknownBlock         = fmt.Errorf("unknown block")
 	errBlobNumberMismatch   = fmt.Errorf("blob number mismatch")
 	errNoBlobsInBlock       = fmt.Errorf("no blobs in block")
@@ -21,27 +22,32 @@ var (
 	errTooManyBlobsInBlock  = fmt.Errorf("too many blobs in block")
 )
 
-type BlobPool interface {
-	// Get returns a transaction if it is contained in the pool, or nil otherwise.
-	Get(hash common.Hash) *types.Transaction
-}
+// GetTransactionFn returns a transaction if it is contained in the pool, or nil otherwise.
+type GetTransactionFn func(hash common.Hash) *types.Transaction
 
 // FileSystem manages blob sidecars associated with blocks.
 type FileSystem struct {
-	bc          *BlockChain
-	blobPool    BlobPool
-	blobStorage *filesystem.BlobStorage
+	bc             *BlockChain
+	getTransaction GetTransactionFn
+	blobStorage    *filesystem.BlobStorage
 
 	annoBlobFeed event.Feed
 }
 
-func NewFileSystem(bc *BlockChain, blobPool BlobPool, blobStorage *filesystem.BlobStorage) (*FileSystem, error) {
+func NewFileSystem(bc *BlockChain, getTransaction GetTransactionFn, blobStorage *filesystem.BlobStorage) (*FileSystem, error) {
 	fs := &FileSystem{
-		bc:          bc,
-		blobPool:    blobPool,
-		blobStorage: blobStorage,
+		bc:             bc,
+		getTransaction: getTransaction,
+		blobStorage:    blobStorage,
 	}
 	return fs, nil
+}
+
+// SetGetTransactionFn sets the function to retrieve transactions, which is used
+// to find blob transactions in the blob pool or beacon pending pool when committing
+// sealed block hashes.
+func (fs *FileSystem) SetGetTransactionFn(getTransaction GetTransactionFn) {
+	fs.getTransaction = getTransaction
 }
 
 // CommitSealBlockHash commits the sealed block hash associated with committed blobs.
@@ -54,10 +60,14 @@ func (fs *FileSystem) CommitSealBlockHash(block *types.Block) error {
 		if tx.Type() != types.BlobTxType {
 			continue
 		}
-		originTx := fs.blobPool.Get(tx.Hash())
+		originTx := fs.getTransaction(tx.Hash())
 		if originTx == nil {
-			log.Debug("blob tx not found in blob pool", "tx_hash", tx.Hash())
+			log.Debug("blob tx not found", "tx_hash", tx.Hash())
 			return errBlobTxNotFound
+		}
+		if originTx.BlobTxSidecar() == nil {
+			log.Error("sidecar-less blob transaction", "tx_hash", tx.Hash())
+			return errSidecarLessBlobTx
 		}
 		blobs = append(blobs, originTx.BlobTxSidecar())
 	}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/antimev"
 	beaconImpl "github.com/ethereum/go-ethereum/beacon/impl"
+	beaconMiner "github.com/ethereum/go-ethereum/beacon/impl/miner"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/consensus"
@@ -449,8 +450,13 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	stack.RegisterLifecycle(eth)
 
 	// Set up local beacon client
+	var txCacheFilter beaconMiner.TransactionFilterFn
+	if bft != nil {
+		txCacheFilter = bft.FilterMissingTransaction
+	}
 	eth.internalRPC = stack.Attach()
-	eth.beacon = beaconImpl.New(eth, eth.internalRPC, eth.eventMux, eth.feeRecipient, eth.shouldPreserve)
+	eth.beacon = beaconImpl.New(eth, eth.internalRPC, eth.eventMux, eth.feeRecipient,
+		eth.shouldPreserve, txCacheFilter)
 	eth.handler.connectBeacon(eth.beacon)
 	if bft != nil {
 		syncing := func() bool {
@@ -458,7 +464,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			return eth.beacon.Syncing() || eth.Syncing()
 		}
 		// Connect BFT to beacon protocol
-		bft.WithBeacon(eth.beacon.BlockBroadcaster(), eth.beacon.RefreshPendingPayload, eth.beacon.SubscribeSyncingEvents, syncing)
+		bft.WithBeacon(eth.beacon.BlockBroadcaster(), eth.beacon.RefreshPendingPayload,
+			eth.beacon.SubscribeTransactionEvents, eth.beacon.SubscribeSyncingEvents, syncing)
 	}
 
 	// Successful startup; push a marker and check previous unclean shutdowns.

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -430,7 +430,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		bft.WithEthAPIBackend(eth.APIBackend)
 		bft.WithBroadcast(eth.dbftSrv.BroadcastMessage)
 		bft.WithTxPool(eth.TxPool())
-		bft.WithRequestTxs(eth.handler.BroadcastRequestTxs)
+		bft.WithRequestTxs(eth.handler.RequestTransactions)
 		err := bft.WithLogLevel(config.DBFTLogLevel)
 		if err != nil {
 			return nil, err

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -370,7 +370,10 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 		return nil, err
 	}
 	blobStorage.WarmCache()
-	eth.filesystem, err = core.NewFileSystem(eth.blockchain, eth.blobTxPool, blobStorage)
+	eth.filesystem, err = core.NewFileSystem(eth.blockchain,
+		func(hash common.Hash) *types.Transaction {
+			return eth.blobTxPool.Get(hash)
+		}, blobStorage)
 	if err != nil {
 		return nil, err
 	}
@@ -458,6 +461,12 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.beacon = beaconImpl.New(eth, eth.internalRPC, eth.eventMux, eth.feeRecipient,
 		eth.shouldPreserve, txCacheFilter)
 	eth.handler.connectBeacon(eth.beacon)
+	eth.filesystem.SetGetTransactionFn(func(hash common.Hash) *types.Transaction {
+		if tx := eth.blobTxPool.Get(hash); tx != nil {
+			return tx
+		}
+		return eth.beacon.GetTransaction(hash)
+	})
 	if bft != nil {
 		syncing := func() bool {
 			log.Debug("Syncing status", "beacon", eth.beacon.Syncing(), "eth", eth.Syncing())

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -473,8 +473,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 			return eth.beacon.Syncing() || eth.Syncing()
 		}
 		// Connect BFT to beacon protocol
-		bft.WithBeacon(eth.beacon.BlockBroadcaster(), eth.beacon.RefreshPendingPayload,
-			eth.beacon.SubscribeTransactionEvents, eth.beacon.SubscribeSyncingEvents, syncing)
+		bft.WithBeacon(eth.beacon, syncing)
 	}
 
 	// Successful startup; push a marker and check previous unclean shutdowns.

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -941,12 +941,12 @@ func (st *blockRangeState) currentRange() eth.BlockRangeUpdatePacket {
 	return *st.next.Load()
 }
 
-// BroadcastRequestTxs will send GetPooledTransactionsMsg to neighbor peers
-func (h *handler) BroadcastRequestTxs(txHashes []common.Hash) {
+// RequestTransactions will send GetTransactionsMsg to neighbor peers.
+func (h *handler) RequestTransactions(txHashes []common.Hash) {
 	if len(txHashes) == 0 {
 		return
 	}
-	peers := h.peers.all()
+	peers := h.peers.allBeacons()
 	for i := 0; i <= len(txHashes)/maxHashesCount; i++ {
 		start := i * maxHashesCount
 		stop := (i + 1) * maxHashesCount
@@ -956,13 +956,11 @@ func (h *handler) BroadcastRequestTxs(txHashes []common.Hash) {
 		if start == stop {
 			break
 		}
-		// Broadcast RequestTxs
+		// Broadcast request to all neighbors.
 		for _, peer := range peers {
-			err := peer.RequestTxs(txHashes[start:stop])
+			err := peer.RequestTransactions(txHashes[start:stop])
 			if err != nil {
-				log.Error("BroadcastRequestTxs", "txHashes", txHashes,
-					"peer", peer.ID(),
-					"error", err)
+				log.Error("Failed to request transactions", "txHashes", txHashes, "peer", peer.ID(), "error", err)
 			}
 		}
 	}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -33,7 +33,6 @@ import (
 	beaconSync "github.com/ethereum/go-ethereum/beacon/impl/synchronizer"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/beacon"
-	"github.com/ethereum/go-ethereum/consensus/dbft"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/txpool"
@@ -114,6 +113,8 @@ type Beacon interface {
 	)
 	NotifyBlockAnnon(peer string, hash common.Hash, number uint64, time time.Time)
 	EnqueueBlock(peer string, block *types.Block)
+	GetTransaction(hash common.Hash) *types.Transaction
+	NotifyTransactions(txs []*types.Transaction)
 }
 
 // FileSystem is enough of a FileSystem to satisfy [Service].
@@ -247,20 +248,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 		}
 		return p.RequestTxs(hashes)
 	}
-	var bft *dbft.DBFT
-	switch t := h.chain.Engine().(type) {
-	case *dbft.DBFT:
-		bft = t
-	case *beacon.Beacon:
-		switch inner := t.InnerEngine().(type) {
-		case *dbft.DBFT:
-			bft = inner
-		}
-	}
 	addTxs := func(txs []*types.Transaction) []error {
-		if bft != nil {
-			bft.OnTransaction(txs)
-		}
 		return h.txpool.Add(txs, false, false)
 	}
 	h.txFetcher = fetcher.NewTxFetcher(h.txpool.Has, addTxs, fetchTx, h.removePeer)

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -946,6 +946,9 @@ func (h *handler) RequestTransactions(txHashes []common.Hash) {
 		}
 		// Broadcast request to all neighbors.
 		for _, peer := range peers {
+			if peer.Version() < beaconproto.BEACON2 {
+				continue
+			}
 			err := peer.RequestTransactions(txHashes[start:stop])
 			if err != nil {
 				log.Error("Failed to request transactions", "txHashes", txHashes, "peer", peer.ID(), "error", err)

--- a/eth/handler_beacon.go
+++ b/eth/handler_beacon.go
@@ -2,6 +2,7 @@ package eth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -405,8 +406,8 @@ func (h *beaconHandler) handleGetTransactionsPacket(peer *beacon.Peer, packet *b
 		if tx == nil {
 			continue
 		}
-		// Encode without blob sidecat, we don't need it for consensus retrieval and it can be large.
-		encoded, err := rlp.EncodeToBytes(tx.WithoutBlobTxSidecar())
+		// Encode the full transaction, even though the blob sidecar is large.
+		encoded, err := rlp.EncodeToBytes(tx)
 		if err != nil {
 			log.Error("Failed to encoded transaction in beacon handler", "hash", hash, "err", err)
 			return err
@@ -419,6 +420,19 @@ func (h *beaconHandler) handleGetTransactionsPacket(peer *beacon.Peer, packet *b
 }
 
 func (h *beaconHandler) handleTransactions(peer *beacon.Peer, packet *beacon.TransactionsPacket) error {
+	// If we receive any blob transactions missing sidecars, or with
+	// sidecars that don't correspond to the versioned hashes reported
+	// in the header, disconnect from the sending peer.
+	for _, tx := range packet.TransactionsResponse {
+		if tx.Type() == types.BlobTxType {
+			if tx.BlobTxSidecar() == nil {
+				return errors.New("received sidecar-less blob transaction")
+			}
+			if err := tx.BlobTxSidecar().ValidateBlobCommitmentHashes(tx.BlobHashes()); err != nil {
+				return err
+			}
+		}
+	}
 	h.beacon.NotifyTransactions(packet.TransactionsResponse)
 	return nil
 }

--- a/eth/handler_beacon.go
+++ b/eth/handler_beacon.go
@@ -2,7 +2,6 @@ package eth
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -396,10 +395,21 @@ func (h *beaconHandler) handleGetTransactionsPacket(peer *beacon.Peer, packet *b
 		if bytes >= softResponseLimit {
 			break
 		}
-		// Retrieve the requested transaction, skipping if unknown to us
-		encoded := h.txpool.GetRLP(hash)
-		if len(encoded) == 0 {
+		// First try to find it from the EL txpool.
+		tx := h.txpool.Get(hash)
+		if tx == nil {
+			// Then try to find the transaction from the CL.
+			tx = h.beacon.GetTransaction(hash)
+		}
+		// If not found, skip it.
+		if tx == nil {
 			continue
+		}
+		// Encode without blob sidecat, we don't need it for consensus retrieval and it can be large.
+		encoded, err := rlp.EncodeToBytes(tx.WithoutBlobTxSidecar())
+		if err != nil {
+			log.Error("Failed to encoded transaction in beacon handler", "hash", hash, "err", err)
+			return err
 		}
 		hashes = append(hashes, hash)
 		txs = append(txs, encoded)
@@ -409,18 +419,6 @@ func (h *beaconHandler) handleGetTransactionsPacket(peer *beacon.Peer, packet *b
 }
 
 func (h *beaconHandler) handleTransactions(peer *beacon.Peer, packet *beacon.TransactionsPacket) error {
-	// If we receive any blob transactions missing sidecars, or with
-	// sidecars that don't correspond to the versioned hashes reported
-	// in the header, disconnect from the sending peer.
-	for _, tx := range packet.TransactionsResponse {
-		if tx.Type() == types.BlobTxType {
-			if tx.BlobTxSidecar() == nil {
-				return errors.New("received sidecar-less blob transaction")
-			}
-			if err := tx.BlobTxSidecar().ValidateBlobCommitmentHashes(tx.BlobHashes()); err != nil {
-				return err
-			}
-		}
-	}
-	return h.txFetcher.Enqueue(peer.ID(), packet.TransactionsResponse, true)
+	h.beacon.NotifyTransactions(packet.TransactionsResponse)
+	return nil
 }

--- a/eth/handler_beacon.go
+++ b/eth/handler_beacon.go
@@ -2,6 +2,7 @@ package eth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -76,6 +77,12 @@ func (h *beaconHandler) Handle(peer *beacon.Peer, packet beacon.Packet) error {
 
 	case *beacon.GetBatchBlobsPacket:
 		return h.handleGetBatchBlobsPacket(peer, packet)
+
+	case *beacon.GetTransactionsPacket:
+		return h.handleGetTransactionsPacket(peer, packet)
+
+	case *beacon.TransactionsPacket:
+		return h.handleTransactions(peer, packet)
 
 	default:
 		return fmt.Errorf("unexpected beacon packet type: %T", packet)
@@ -373,4 +380,47 @@ func (h *beaconHandler) selectBlobTransferPeers(excludePeer *string) []*beaconPe
 		transfer = peers[:min(k, len(peers))]
 	}
 	return transfer
+}
+
+// handleGetTransactionsPacket is CL-level search for transactions by hash. It extends
+// the EL transaction retrieval by taking pending payloads into consideration. This is
+// useful for BFT consensus to find missing transactions during block processing.
+func (h *beaconHandler) handleGetTransactionsPacket(peer *beacon.Peer, packet *beacon.GetTransactionsPacket) error {
+	// Gather transactions until the fetch or network limits is reached
+	var (
+		bytes  int
+		hashes []common.Hash
+		txs    []rlp.RawValue
+	)
+	for _, hash := range packet.GetTransactionsRequest {
+		if bytes >= softResponseLimit {
+			break
+		}
+		// Retrieve the requested transaction, skipping if unknown to us
+		encoded := h.txpool.GetRLP(hash)
+		if len(encoded) == 0 {
+			continue
+		}
+		hashes = append(hashes, hash)
+		txs = append(txs, encoded)
+		bytes += len(encoded)
+	}
+	return peer.ReplyTransactionsRLP(packet.RequestId, hashes, txs)
+}
+
+func (h *beaconHandler) handleTransactions(peer *beacon.Peer, packet *beacon.TransactionsPacket) error {
+	// If we receive any blob transactions missing sidecars, or with
+	// sidecars that don't correspond to the versioned hashes reported
+	// in the header, disconnect from the sending peer.
+	for _, tx := range packet.TransactionsResponse {
+		if tx.Type() == types.BlobTxType {
+			if tx.BlobTxSidecar() == nil {
+				return errors.New("received sidecar-less blob transaction")
+			}
+			if err := tx.BlobTxSidecar().ValidateBlobCommitmentHashes(tx.BlobHashes()); err != nil {
+				return err
+			}
+		}
+	}
+	return h.txFetcher.Enqueue(peer.ID(), packet.TransactionsResponse, true)
 }

--- a/eth/protocols/beacon/handler.go
+++ b/eth/protocols/beacon/handler.go
@@ -95,13 +95,15 @@ var beacon1 = map[uint64]msgHandler{
 }
 
 var beacon2 = map[uint64]msgHandler{
-	NewBlockHashesMsg: handleNewBlockhashes,
-	NewBlockMsg:       handleNewBlock,
-	NewBlobsRootMsg:   handleNewBlobsRoot,
-	GetBlobsMsg:       handleGetBlobs,
-	BlobsMsg:          handleBlobs,
-	GetBatchBlobsMsg:  handleGetBatchBlobs,
-	BatchBlobsMsg:     handleBatchBlobs,
+	NewBlockHashesMsg:  handleNewBlockhashes,
+	NewBlockMsg:        handleNewBlock,
+	NewBlobsRootMsg:    handleNewBlobsRoot,
+	GetBlobsMsg:        handleGetBlobs,
+	BlobsMsg:           handleBlobs,
+	GetBatchBlobsMsg:   handleGetBatchBlobs,
+	BatchBlobsMsg:      handleBatchBlobs,
+	GetTransactionsMsg: handleGetTransactions,
+	TransactionsMsg:    handleTransactions,
 }
 
 // handleMessage is invoked whenever an inbound message is received from a

--- a/eth/protocols/beacon/handlers.go
+++ b/eth/protocols/beacon/handlers.go
@@ -149,3 +149,29 @@ func handleBatchBlobs(backend Backend, msg Decoder, peer *Peer) error {
 	log.Debug("Receive BatchBlobs response", "from", peer.id, "requestId", res.RequestId, "batchBlobs", len(res.BatchBlobsResponse), "err", err)
 	return nil
 }
+
+func handleGetTransactions(backend Backend, msg Decoder, peer *Peer) error {
+	req := new(GetTransactionsPacket)
+	if err := msg.Decode(req); err != nil {
+		return fmt.Errorf("msg %v, decode err: %v", GetTransactionsMsg, err)
+	}
+
+	log.Debug("Receive GetTransactions request", "from", peer.id, "req", req)
+
+	return backend.Handle(peer, req)
+}
+
+func handleTransactions(backend Backend, msg Decoder, peer *Peer) error {
+	res := new(TransactionsPacket)
+	if err := msg.Decode(res); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	for i, tx := range res.TransactionsResponse {
+		// Validate and mark the remote transaction
+		if tx == nil {
+			return fmt.Errorf("%w: transaction %d is nil", errDecode, i)
+		}
+	}
+
+	return backend.Handle(peer, res)
+}

--- a/eth/protocols/beacon/handlers.go
+++ b/eth/protocols/beacon/handlers.go
@@ -171,9 +171,6 @@ func handleTransactions(backend Backend, msg Decoder, peer *Peer) error {
 		if tx == nil {
 			return fmt.Errorf("%w: transaction %d is nil", errDecode, i)
 		}
-		if tx.BlobTxSidecar() != nil {
-			return fmt.Errorf("%w: transaction %d has blob sidecar", errDecode, i)
-		}
 	}
 	log.Debug("Receive Transactions response", "from", peer.id, "requestId", res.RequestId, "transactions", len(res.TransactionsResponse))
 	return backend.Handle(peer, res)

--- a/eth/protocols/beacon/handlers.go
+++ b/eth/protocols/beacon/handlers.go
@@ -171,7 +171,10 @@ func handleTransactions(backend Backend, msg Decoder, peer *Peer) error {
 		if tx == nil {
 			return fmt.Errorf("%w: transaction %d is nil", errDecode, i)
 		}
+		if tx.BlobTxSidecar() != nil {
+			return fmt.Errorf("%w: transaction %d has blob sidecar", errDecode, i)
+		}
 	}
-
+	log.Debug("Receive Transactions response", "from", peer.id, "requestId", res.RequestId, "transactions", len(res.TransactionsResponse))
 	return backend.Handle(peer, res)
 }

--- a/eth/protocols/beacon/peer.go
+++ b/eth/protocols/beacon/peer.go
@@ -282,6 +282,26 @@ func (p *Peer) AsyncSendNewBlobsRoot(hash common.Hash) {
 	}
 }
 
+// ReplyTransactionsRLP is the response to RequestTxs.
+func (p *Peer) ReplyTransactionsRLP(id uint64, hashes []common.Hash, txs []rlp.RawValue) error {
+	return p2p.Send(p.rw, TransactionsMsg, &TransactionsRLPPacket{
+		RequestId:               id,
+		TransactionsRLPResponse: txs,
+	})
+}
+
+// RequestTransactions fetches a batch of transactions from a remote node.
+func (p *Peer) RequestTransactions(hashes []common.Hash) error {
+	p.Log().Debug("Fetching batch of transactions", "count", len(hashes))
+	id := rand.Uint64()
+
+	requestTracker.Track(p.id, p.version, GetTransactionsMsg, TransactionsMsg, id)
+	return p2p.Send(p.rw, GetTransactionsMsg, &GetTransactionsPacket{
+		RequestId:              id,
+		GetTransactionsRequest: hashes,
+	})
+}
+
 // knownCache is a cache for known hashes.
 type knownCache struct {
 	hashes mapset.Set[common.Hash]

--- a/eth/protocols/beacon/protocol.go
+++ b/eth/protocols/beacon/protocol.go
@@ -26,20 +26,22 @@ var ProtocolVersions = []uint{BEACON1, BEACON2}
 
 // protocolLengths are the number of implemented message corresponding to
 // different protocol versions.
-var protocolLengths = map[uint]uint64{BEACON1: 8, BEACON2: 8}
+var protocolLengths = map[uint]uint64{BEACON1: 8, BEACON2: 10}
 
 // maxMessageSize is the maximum cap on the size of a protocol message.
 const maxMessageSize = 10 * 1024 * 1024
 
 const (
-	StatusMsg         = 0x00 // Status message
-	NewBlockHashesMsg = 0x01 // New block hashes message
-	NewBlockMsg       = 0x02 // New block message
-	NewBlobsRootMsg   = 0x03 // New blobs root message
-	GetBlobsMsg       = 0x04 // Get blobs message
-	BlobsMsg          = 0x05 // Blobs message
-	GetBatchBlobsMsg  = 0x06 // Get batch blobs message
-	BatchBlobsMsg     = 0x07 // Batch blobs message
+	StatusMsg          = 0x00 // Status message
+	NewBlockHashesMsg  = 0x01 // New block hashes message
+	NewBlockMsg        = 0x02 // New block message
+	NewBlobsRootMsg    = 0x03 // New blobs root message
+	GetBlobsMsg        = 0x04 // Get blobs message
+	BlobsMsg           = 0x05 // Blobs message
+	GetBatchBlobsMsg   = 0x06 // Get batch blobs message
+	BatchBlobsMsg      = 0x07 // Batch blobs message
+	GetTransactionsMsg = 0x08 // Get transactions message
+	TransactionsMsg    = 0x09 // Transactions message
 )
 
 var (
@@ -178,6 +180,35 @@ type BatchBlobsRLPPacket struct {
 	BatchBlobsRLPResponse
 }
 
+// GetTransactionsRequest represents a transaction query.
+type GetTransactionsRequest []common.Hash
+
+// GetTransactionsPacket represents a transaction query with request ID wrapping.
+type GetTransactionsPacket struct {
+	RequestId uint64
+	GetTransactionsRequest
+}
+
+// TransactionsResponse is the network packet for transaction distribution.
+type TransactionsResponse []*types.Transaction
+
+// TransactionsPacket is the network packet for transaction distribution
+// with request ID wrapping.
+type TransactionsPacket struct {
+	RequestId uint64
+	TransactionsResponse
+}
+
+// TransactionsRLPResponse is the network packet for transaction distribution, used
+// in the cases we already have them in rlp-encoded form
+type TransactionsRLPResponse []rlp.RawValue
+
+// TransactionsRLPPacket is TransactionsRLPResponse with request ID wrapping.
+type TransactionsRLPPacket struct {
+	RequestId uint64
+	TransactionsRLPResponse
+}
+
 func (*StatusPacket1) Name() string { return "Status" }
 func (*StatusPacket1) Kind() byte   { return StatusMsg }
 
@@ -210,3 +241,9 @@ func (*BatchBlobsPacket1) Kind() byte   { return BatchBlobsMsg }
 
 func (*BatchBlobsPacket) Name() string { return "BatchBlobs" }
 func (*BatchBlobsPacket) Kind() byte   { return BatchBlobsMsg }
+
+func (*GetTransactionsRequest) Name() string { return "GetTransactions" }
+func (*GetTransactionsRequest) Kind() byte   { return GetTransactionsMsg }
+
+func (*TransactionsResponse) Name() string { return "Transactions" }
+func (*TransactionsResponse) Kind() byte   { return TransactionsMsg }


### PR DESCRIPTION
Close #576. Close #604.

This PR moves the missing tx protocol to the CL, and adds the block proposal into the searching boundary, to solve the tx replacement issue on the Testnet.

I adopt the minor change here as the first step. If this works on the Testnet, then we may push the refactor forward.