### PR TITLE
core: revert unused compatibility code

### DIFF
--- a/beacon/impl/synchronizer/synchronizer.go
+++ b/beacon/impl/synchronizer/synchronizer.go
@@ -51,8 +51,6 @@ type Choice struct {
 // for finding the latest and trusted chain head and announceing it to the EL API,
 // to trigger the EL synchronization on the canonical chain.
 // NOTE: This implementation only supports one-block reorg.
-// TODO: Use database to implement a cache of trusted header, so that we can resume
-// the light sync process after restart.
 type Synchronizer struct {
 	trustedHead   *types.Block           // The block believed to be the latest finalized block
 	latestHead    *types.Block           // The block believed to be the latest block

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -2480,7 +2480,8 @@ func (bc *BlockChain) reorg(oldHead *types.Header, newHead *types.Header) error 
 		// the ancestor of new head while these two blocks are not consecutive
 		log.Info("Extend chain", "add", len(newChain), "number", newChain[0].Number, "hash", newChain[0].Hash())
 		blockReorgAddMeter.Mark(int64(len(newChain)))
-	} else if len(newChain) == 0 && len(oldChain) > 0 {
+	} else {
+		// len(newChain) == 0 && len(oldChain) > 0
 		// rewind the canonical chain to a lower point.
 		log.Error("Impossible reorg, please file an issue", "oldnum", oldHead.Number, "oldhash", oldHead.Hash(), "oldblocks", len(oldChain), "newnum", newHead.Number, "newhash", newHead.Hash(), "newblocks", len(newChain))
 	}

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -879,7 +879,7 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	}
 	// Flush out any blobs from limbo that are older than the latest finality
 	if p.chain.Config().IsCancun(newHead.Number, newHead.Time) {
-		p.limbo.finalize(p.chain.CurrentFinalBlock(), newHead)
+		p.limbo.finalize(p.chain.CurrentFinalBlock())
 	}
 	// Reset the price heap for the new set of basefee/blobfee pairs
 	var (
@@ -2094,8 +2094,8 @@ func (p *BlobPool) SubscribeTransactions(ch chan<- core.NewTxsEvent, reorgs bool
 	}
 }
 
-// SubscribeTransactions registers a subscription for reannounce transaction events,
-// supporting feeding only pending transactions.
+// SubscribeReannoTransactions registers a subscription for reannounce transaction
+// events, supporting feeding only pending transactions.
 func (p *BlobPool) SubscribeReannoTransactions(ch chan<- core.ReannoTxsEvent) event.Subscription {
 	// Disable SubscribeReannoTransactions
 	return nil

--- a/core/txpool/blobpool/limbo.go
+++ b/core/txpool/blobpool/limbo.go
@@ -124,25 +124,15 @@ func (l *limbo) parseBlob(id uint64, data []byte) error {
 }
 
 // finalize evicts all blobs belonging to a recently finalized block or older.
-func (l *limbo) finalize(final *types.Header, current *types.Header) {
+func (l *limbo) finalize(final *types.Header) {
 	// Just in case there's no final block yet (network not yet merged, weird
-	// restart, sethead, etc), take 128 blocks ago as fallback.
-	// TODO: Remove this fallback once there is a stable source of finality.
-	// 128 is an impossible reorg depth, for about 10 mins under 5s block time.
-	last := uint64(0)
-	if final != nil {
-		last = final.Number.Uint64()
-	} else {
-		if current == nil {
-			log.Warn("Nil finalized and current block cannot evict old blobs")
-			return
-		}
-		if current.Number.Uint64() > 128 {
-			last = current.Number.Uint64() - 128
-		}
+	// restart, sethead, etc), fail gracefully.
+	if final == nil {
+		log.Warn("Nil finalized block cannot evict old blobs")
+		return
 	}
 	for block, ids := range l.groups {
-		if block > last {
+		if block > final.Number.Uint64() {
 			continue
 		}
 		for id, owner := range ids {


### PR DESCRIPTION
Close #591.

Since we have proposed #542 and #588, Neo X are now working on the same post-merge CL-EL model as Eth2. There are some temporary codes for module compatibility during the working process, and it's time to remove them safely.

I prefer to take this as the final change of v0.6.0, and will rebase to latest after other PRs are merged.