### PR TITLE
beacon/impl: eth: improve the initial fetch height in sidecar fetcher

### DIFF
--- a/beacon/impl/fetcher/sidecar_fetcher.go
+++ b/beacon/impl/fetcher/sidecar_fetcher.go
@@ -47,6 +47,10 @@ type BlobPeersFn func() []string
 // MarkNoBlobPeerFn is a callback type to mark a peer as not having blobs.
 type MarkNoBlobPeerFn func(id string)
 
+// HighestHeaderNumberFn is a callback type to retrieve the highest header number seen,
+// used to determine when to fetch sidecars for new blocks.
+type HighestHeaderNumberFn func() (uint64, bool)
+
 // fetchingTask represents a scheduled sidecar fetching operation.
 type fetchingTask struct {
 	block *types.Block // The block to fetch sidecars for
@@ -87,10 +91,11 @@ type SidecarFetcher struct {
 	fetching  map[common.Hash]*fetchingTask   // Currently fetching
 
 	// Callbacks
-	announceSidecars SidecarsAnnouncerFn // Announces sidecars to the network
-	blobPeers        BlobPeersFn         // Retrieves all known blob peers
-	markNoBlobPeer   MarkNoBlobPeerFn    // Marks a peer as not having blobs, to avoid scheduling future fetches to it
-	dropPeer         PeerDropFn          // Drops a peer for misbehaving
+	announceSidecars    SidecarsAnnouncerFn   // Announces sidecars to the network
+	blobPeers           BlobPeersFn           // Retrieves all known blob peers
+	markNoBlobPeer      MarkNoBlobPeerFn      // Marks a peer as not having blobs, to avoid scheduling future fetches to it
+	dropPeer            PeerDropFn            // Drops a peer for misbehaving
+	highestHeaderNumber HighestHeaderNumberFn // Highest header number seen, used to determine when to fetch sidecars for new blocks
 
 	fetchSidecars     SidecarRequesterFn     // Fetcher function to retrieve the blob sidecars of a block
 	deepFetchSidecars SidecarDeepRequesterFn // Deep-fetcher function to retrieve blob sidecars of a block
@@ -100,24 +105,26 @@ type SidecarFetcher struct {
 }
 
 // NewSidecarFetcher creates a sidecar fetcher to retrieve blob sidecars.
-func NewSidecarFetcher(chain BlockChain, fs FileSystem, blobPeers BlobPeersFn, markNoBlobPeer MarkNoBlobPeerFn, dropPeer PeerDropFn,
-	announceSidecars SidecarsAnnouncerFn, fetchSidecars SidecarRequesterFn, deepFetchSidecars SidecarDeepRequesterFn) *SidecarFetcher {
+func NewSidecarFetcher(chain BlockChain, fs FileSystem, blobPeers BlobPeersFn, markNoBlobPeer MarkNoBlobPeerFn,
+	dropPeer PeerDropFn, highestHeaderNumber HighestHeaderNumberFn, announceSidecars SidecarsAnnouncerFn,
+	fetchSidecars SidecarRequesterFn, deepFetchSidecars SidecarDeepRequesterFn) *SidecarFetcher {
 	return &SidecarFetcher{
-		notify:            make(chan *blobAnnounce),
-		done:              make(chan common.Hash),
-		quit:              make(chan struct{}),
-		announces:         make(map[string]int),
-		announced:         make(map[common.Hash][]*blobAnnounce),
-		scheduled:         make(map[common.Hash]*fetchingTask),
-		fetching:          make(map[common.Hash]*fetchingTask),
-		blobPeers:         blobPeers,
-		markNoBlobPeer:    markNoBlobPeer,
-		dropPeer:          dropPeer,
-		announceSidecars:  announceSidecars,
-		fetchSidecars:     fetchSidecars,
-		deepFetchSidecars: deepFetchSidecars,
-		fs:                fs,
-		chain:             chain,
+		notify:              make(chan *blobAnnounce),
+		done:                make(chan common.Hash),
+		quit:                make(chan struct{}),
+		announces:           make(map[string]int),
+		announced:           make(map[common.Hash][]*blobAnnounce),
+		scheduled:           make(map[common.Hash]*fetchingTask),
+		fetching:            make(map[common.Hash]*fetchingTask),
+		blobPeers:           blobPeers,
+		markNoBlobPeer:      markNoBlobPeer,
+		dropPeer:            dropPeer,
+		highestHeaderNumber: highestHeaderNumber,
+		announceSidecars:    announceSidecars,
+		fetchSidecars:       fetchSidecars,
+		deepFetchSidecars:   deepFetchSidecars,
+		fs:                  fs,
+		chain:               chain,
 	}
 }
 
@@ -159,14 +166,31 @@ func (f *SidecarFetcher) loop() {
 	timeoutTicker := time.NewTicker(fetchTimeout)
 	defer timeoutTicker.Stop()
 
+	// Determine the initial fetch height, which is the earliest block that may
+	// still have sidecars being propagated for it.
 	fetchHeight := uint64(0)
-	height := f.chain.CurrentBlock().Number.Uint64()
+	reinitFetchHeight := false
 	minRetainBlockNumbers := uint64(params.MinEthEpochsForBlobsSidecarsRequest * params.BlocksPerEthEpoch)
+	height := f.chain.CurrentBlock().Number.Uint64()
 	if height > minRetainBlockNumbers {
 		fetchHeight = height - minRetainBlockNumbers
 	}
 
 	for {
+		// Reinitialize fetch height based on the highest header number seen, to avoid missing sidecars for new blocks.
+		if !reinitFetchHeight {
+			if height, found := f.highestHeaderNumber(); found {
+				reinitFetchHeight = found
+				if height > minRetainBlockNumbers {
+					recommendedFetchHeight := height - minRetainBlockNumbers
+					if fetchHeight < recommendedFetchHeight {
+						fetchHeight = recommendedFetchHeight
+						log.Info("Reinitial fetch height set based on highest header number", "height", fetchHeight)
+					}
+				}
+			}
+		}
+
 		// Schedule new sidecar fetches if below the limit
 		f.scheduleNextSidecars(&fetchHeight, fetchTimer)
 

--- a/beacon/impl/fetcher/sidecar_fetcher.go
+++ b/beacon/impl/fetcher/sidecar_fetcher.go
@@ -53,8 +53,10 @@ type HighestHeaderNumberFn func() (uint64, bool)
 
 // fetchingTask represents a scheduled sidecar fetching operation.
 type fetchingTask struct {
-	block *types.Block // The block to fetch sidecars for
-	time  time.Time    // The time of the task created
+	block        *types.Block // The block to fetch sidecars for
+	time         time.Time    // The time of the task created
+	fetchingTime time.Time    // The time when the fetch was attempted
+	retryCount   int          // The number of times the task has been retried
 }
 
 // blobAnnounce represents a notification of a new block hash potentially having blob sidecars available.
@@ -225,8 +227,7 @@ func (f *SidecarFetcher) loop() {
 			// Periodically clean out any abandoned fetches
 			earliestHeight := fetchHeight
 			for hash, task := range f.fetching {
-				cost := time.Since(task.time)
-				if cost > maxRetryCount*fetchTimeout {
+				if task.retryCount > maxRetryCount {
 					f.forgetHash(hash)
 					if f.chain.GetBlockByHash(hash) == nil {
 						// If a block is found to be missing, then the fetchHeight
@@ -241,14 +242,14 @@ func (f *SidecarFetcher) loop() {
 					// Deep-fetch sidecars if normal fetch failed multiple times
 					go func() {
 						if _, err := f.deepFetchSidecars(hash); err != nil {
-							log.Error("Deep-fetching sidecars failed", "hash", hash, "err", err)
+							log.Warn("Deep-fetching sidecars failed", "hash", hash, "err", err)
 							return
 						} else {
 							f.done <- hash
 							f.announceSidecars(hash)
 						}
 					}()
-				} else if cost > fetchTimeout {
+				} else if time.Since(task.fetchingTime) > fetchTimeout {
 					// Reschedule the fetch
 					f.scheduled[hash] = task
 					delete(f.fetching, hash)
@@ -295,6 +296,7 @@ func (f *SidecarFetcher) loop() {
 						} else {
 							request[peer] = append(request[peer], hash)
 							reqTaskMap[peer] = append(reqTaskMap[peer], task)
+							task.fetchingTime = time.Now()
 							f.fetching[hash] = task
 						}
 					}
@@ -314,6 +316,11 @@ func (f *SidecarFetcher) loop() {
 						return
 					}
 					defer req.Close()
+
+					// The count is incremented only when the request is successful.
+					for _, task := range tasks {
+						task.retryCount++
+					}
 
 					timeout := time.NewTimer(2 * fetchTimeout) // 2x leeway before dropping the peer
 					defer timeout.Stop()
@@ -369,7 +376,7 @@ func (f *SidecarFetcher) importSidecars(peer string, task *fetchingTask, sidecar
 		// Quickly validate the sidecars and propagate the sidecars if it passes
 		if err := f.fs.CheckBlobsAvailable(block, sidecars); err != nil {
 			// Something went very wrong, drop the peer
-			log.Error("Propagated sidecars verification failed", "peer", peer, "number", block.Number(), "hash", block.Hash(), "err", err)
+			log.Debug("Propagated sidecars verification failed", "peer", peer, "number", block.Number(), "hash", block.Hash(), "err", err)
 			f.dropPeer(peer)
 			return
 		}

--- a/beacon/impl/fetcher/sidecar_fetcher.go
+++ b/beacon/impl/fetcher/sidecar_fetcher.go
@@ -1,6 +1,7 @@
 package fetcher
 
 import (
+	"context"
 	"math/big"
 	"math/rand"
 	"time"
@@ -36,7 +37,7 @@ var (
 type SidecarRequesterFn func(string, []common.Hash, chan *beacon.Response) (*beacon.Request, error)
 
 // SidecarDeepRequesterFn is a callback type for deep-fetching blob sidecars.
-type SidecarDeepRequesterFn func(blockHash common.Hash) (types.BlobSidecars, error)
+type SidecarDeepRequesterFn func(ctx context.Context, blockHash common.Hash) (types.BlobSidecars, error)
 
 // SidecarsAnnouncerFn is a callback type for announcing retrieved blob sidecars to the network.
 type SidecarsAnnouncerFn func(blockHash common.Hash)
@@ -167,6 +168,8 @@ func (f *SidecarFetcher) loop() {
 	defer fetchTimer.Stop()
 	timeoutTicker := time.NewTicker(fetchTimeout)
 	defer timeoutTicker.Stop()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Determine the initial fetch height, which is the earliest block that may
 	// still have sidecars being propagated for it.
@@ -241,7 +244,7 @@ func (f *SidecarFetcher) loop() {
 					}
 					// Deep-fetch sidecars if normal fetch failed multiple times
 					go func() {
-						if _, err := f.deepFetchSidecars(hash); err != nil {
+						if _, err := f.deepFetchSidecars(ctx, hash); err != nil {
 							log.Warn("Deep-fetching sidecars failed", "hash", hash, "err", err)
 							return
 						} else {

--- a/core/filesystem/blob.go
+++ b/core/filesystem/blob.go
@@ -325,8 +325,9 @@ func VerifiedROBlobFromDisk(fs afero.Fs, root [32]byte, path string) (types.Veri
 	if err != nil {
 		return types.VerifiedROBlob{}, err
 	}
-	s := &types.BlobSidecar{}
-	if err := rlp.DecodeBytes(encoded, s); err != nil {
+
+	s, err := decodeBlobSidecar(encoded)
+	if err != nil {
 		return types.VerifiedROBlob{}, err
 	}
 	ro, err := types.NewROBlobWithRoot(s, root)
@@ -334,4 +335,57 @@ func VerifiedROBlobFromDisk(fs afero.Fs, root [32]byte, path string) (types.Veri
 		return types.VerifiedROBlob{}, err
 	}
 	return types.NewVerifiedROBlob(ro), nil
+}
+
+func decodeBlobSidecar(input []byte) (*types.BlobSidecar, error) {
+	firstElem, _, err := rlp.SplitList(input)
+	if err != nil {
+		return nil, err
+	}
+	firstElemKind, _, secondElem, err := rlp.Split(firstElem)
+	if err != nil {
+		return nil, err
+	}
+	if firstElemKind != rlp.List {
+		return nil, errors.New("invalid blob sidecar encoding: first element is not a list")
+	}
+
+	// Now we know it's the storage encoding with the blob sidecar. Here we need to
+	// support multiple encodings: legacy sidecars (v0) with a blob proof, and versioned
+	// sidecars.
+	//
+	// The legacy encoding is:
+	//
+	//     [blobs, commitments, proofs, ...]
+	//
+	// The versioned encoding is:
+	//
+	//     [version, blobs, ...]
+	//
+	// We can tell the two apart by checking whether the first element is the version byte.
+	// For legacy sidecar the first element is a list of blobs.
+
+	secondElemKind, _, _, err := rlp.Split(secondElem)
+	if err != nil {
+		return nil, err
+	}
+	if secondElemKind == rlp.List {
+		// No version byte: blob sidecar v0.
+		v0 := &types.BlobSidecarV0{}
+		if err := rlp.DecodeBytes(input, v0); err != nil {
+			return nil, err
+		}
+		new := types.NewBlobSidecar(types.NewBlobTxSidecar(types.BlobSidecarVersion0, v0.Blobs, v0.Commitments, v0.Proofs),
+			v0.BlockNumber,
+			v0.BlockTime,
+			v0.Index,
+		)
+		return new, nil
+	}
+	// It has a version byte. Decode according to the versioned encoding.
+	s := &types.BlobSidecar{}
+	if err := rlp.DecodeBytes(input, s); err != nil {
+		return nil, err
+	}
+	return s, nil
 }

--- a/core/types/roblob.go
+++ b/core/types/roblob.go
@@ -5,10 +5,20 @@ import (
 	"math/big"
 )
 
-const BlobSidecarSize = 131190 // defined to match blob sidecar size in rlp codegen
+const BlobSidecarSize = 137423 // defined to match blob sidecar size in rlp codegen
 
 type BlobSidecar struct {
 	BlobTxSidecar
+	BlockNumber *big.Int // The block number this blob sidecar is associated with.
+	BlockTime   uint64   // The block time this blob sidecar is associated with.
+	Index       uint64   // The index of this blob sidecar within the block.
+}
+
+// BlobSidecarV0 represents the old blob sidecar format before versioning, which
+// only contains the BlobTxSidecar fields. This is used for decoding legacy blob
+// sidecars that were encoded without a version byte.
+type BlobSidecarV0 struct {
+	BlobTxSidecarV0
 	BlockNumber *big.Int // The block number this blob sidecar is associated with.
 	BlockTime   uint64   // The block time this blob sidecar is associated with.
 	Index       uint64   // The index of this blob sidecar within the block.

--- a/core/types/tx_blob.go
+++ b/core/types/tx_blob.go
@@ -67,6 +67,16 @@ type BlobTx struct {
 	S *uint256.Int
 }
 
+// BlobTxSidecarV0 contains the blobs of a blob transaction.
+type BlobTxSidecarV0 struct {
+	Blobs       []kzg4844.Blob       // Blobs needed by the blob pool
+	Commitments []kzg4844.Commitment // Commitments needed by the blob pool
+	Proofs      []kzg4844.Proof      // Proofs needed by the blob pool
+}
+
+// BlobSidecarV0s is a slice of blob transaction sidecars.
+type BlobSidecarV0s []*BlobTxSidecarV0
+
 // BlobTxSidecar contains the blobs of a blob transaction.
 type BlobTxSidecar struct {
 	Version     byte                 // Version

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -554,7 +554,7 @@ func (b *EthAPIBackend) BlobSidecarByRoot(ctx context.Context, hash common.Hash,
 		return nil, nil
 	}
 
-	blockBlobs, err := ((*beaconHandler)(b.eth.handler)).RetrieveSidecarsByRoot(hash)
+	blockBlobs, err := ((*beaconHandler)(b.eth.handler)).RetrieveSidecarsByRoot(ctx, hash)
 	if err != nil {
 		return nil, err
 	}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -266,7 +266,7 @@ func newHandler(config *handlerConfig) (*handler, error) {
 	h.txFetcher = fetcher.NewTxFetcher(h.txpool.Has, addTxs, fetchTx, h.removePeer)
 	if h.blobSync {
 		h.sidecarFetcher = beaconfetch.NewSidecarFetcher(h.chain, h.fs, h.peers.blobPeers, h.peers.markNoBlobPeer, h.removePeer,
-			h.announceBlobs, h.fetchSidecars, (*beaconHandler)(h).RetrieveSidecarsByRoot)
+			h.peers.highestNumberOfBeacons, h.announceBlobs, h.fetchSidecars, (*beaconHandler)(h).RetrieveSidecarsByRoot)
 	}
 	return h, nil
 }

--- a/eth/handler_beacon.go
+++ b/eth/handler_beacon.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -131,15 +132,13 @@ func (h *beaconHandler) handleBlockBroadcast(peer *beacon.Peer, packet *beacon.N
 func (h *beaconHandler) handleGetBlobsPacket(peer *beacon.Peer, packet *beacon.GetBlobsPacket) error {
 	if packet.Ttl > ttl {
 		log.Debug("GetBlobs request with invalid TTL", "from", peer.ID(), "req", packet)
-		// Suspicious peer. We should drop it.
-		(*handler)(h).removePeer(peer.ID())
 		return fmt.Errorf("invalid TTL %d for block hash %s", packet.Ttl, packet.BlockHash.Hex())
 	}
 	// Check if the block has blob txs
 	block := h.chain.GetBlockByHash(packet.BlockHash)
 	if block == nil {
-		log.Debug("GetBlobs request for unknown block", "from", peer.ID(), "req", packet)
-		return fmt.Errorf("unknown block hash %s", packet.BlockHash.Hex())
+		log.Debug("GetBlobs request for unknown block. It might not be synchronized yet.", "from", peer.ID(), "req", packet)
+		return nil
 	}
 	if !block.HasBlobTxs() {
 		log.Debug("GetBlobs request for block without blobs", "from", peer.ID(), "req", packet)
@@ -154,26 +153,26 @@ func (h *beaconHandler) handleGetBlobsPacket(peer *beacon.Peer, packet *beacon.G
 		encoded, err := rlp.EncodeToBytes(sidecars)
 		if err != nil {
 			log.Error("Failed to encode blobs", "err", err)
-			return err
+			return nil
 		}
 		return peer.ReplyBlobsRLP(packet.RequestId, encoded)
 	}
 	if packet.Ttl <= 1 {
 		log.Debug("GetBlobs request reached TTL limit", "from", peer.ID(), "req", packet)
-		return fmt.Errorf("blobs not found for block hash %s", packet.BlockHash.Hex())
+		return nil
 	}
 
 	targetPeer := peer.ID()
 	transfer := h.selectBlobTransferPeers(&targetPeer)
-	blobData, err := h.retrieveSidecars(transfer, packet.BlockHash, packet.Ttl-1)
+	blobData, err := h.retrieveSidecars(context.Background(), transfer, packet.BlockHash, packet.Ttl-1)
 	if err != nil {
 		log.Debug("Failed to retrieve blobs for GetBlobs request", "from", peer.ID(), "req", packet, "err", err)
-		return err
+		return nil
 	}
 	encoded, err := rlp.EncodeToBytes(blobData)
 	if err != nil {
 		log.Error("Failed to encode blobs", "err", err)
-		return err
+		return nil
 	}
 	return peer.ReplyBlobsRLP(packet.RequestId, encoded)
 }
@@ -188,6 +187,8 @@ func (h *beaconHandler) handleGetBatchBlobsPacket(peer *beacon.Peer, packet *bea
 	defer batchBlobsFetchTimer.Stop()
 	scChan := make(chan []byte)
 	defer close(scChan)
+	ctx, cancel := context.WithCancel(context.Background())
+	var wg sync.WaitGroup
 	interrupt := false
 	for lookups := range packet.GetBatchBlobsRequest {
 		if bytes >= softResponseLimit || len(blobsList) >= maxBlocksServe ||
@@ -195,8 +196,13 @@ func (h *beaconHandler) handleGetBatchBlobsPacket(peer *beacon.Peer, packet *bea
 			break
 		}
 
+		wg.Add(1)
 		go func() {
-			scChan <- h.getSidecarsRLP(peer.ID(), packet.GetBatchBlobsRequest[lookups])
+			defer wg.Done()
+			select {
+			case scChan <- h.getSidecarsRLP(ctx, peer.ID(), packet.GetBatchBlobsRequest[lookups]):
+			case <-ctx.Done():
+			}
 		}()
 		select {
 		case <-batchBlobsFetchTimer.C:
@@ -217,10 +223,14 @@ func (h *beaconHandler) handleGetBatchBlobsPacket(peer *beacon.Peer, packet *bea
 		}
 	}
 
+	// Notify the fetch goroutine to stop if it's still running
+	cancel()
+	wg.Wait()
+
 	return peer.ReplyBatchBlobsRLP(packet.RequestId, blobsList)
 }
 
-func (h *beaconHandler) getSidecarsRLP(targetPeer string, blockHash common.Hash) []byte {
+func (h *beaconHandler) getSidecarsRLP(ctx context.Context, targetPeer string, blockHash common.Hash) []byte {
 	// Check if the block has blob txs
 	block := h.chain.GetBlockByHash(blockHash)
 	if block == nil {
@@ -251,7 +261,7 @@ func (h *beaconHandler) getSidecarsRLP(targetPeer string, blockHash common.Hash)
 		return nil
 	}
 
-	sidecars, err := h.retrieveSidecars([]*beaconPeer{transfer[rand.Intn(len(transfer))]}, blockHash, 1)
+	sidecars, err := h.retrieveSidecars(ctx, []*beaconPeer{transfer[rand.Intn(len(transfer))]}, blockHash, 1)
 	if err != nil {
 		log.Debug("Failed to retrieve blobs for GetBatchBlobs request", "req", blockHash, "err", err)
 		return nil
@@ -273,9 +283,11 @@ func (h *beaconHandler) handleBlobsRootAnnounces(peer *beacon.Peer, packet *beac
 	return h.sidecarFetcher.Notify(peer.ID(), packet.BlockHash, time.Now())
 }
 
-func (h *beaconHandler) retrieveSidecars(transfer []*beaconPeer, blockHash common.Hash, ttl uint8) (types.BlobSidecars, error) {
+func (h *beaconHandler) retrieveSidecars(ctx context.Context, transfer []*beaconPeer, blockHash common.Hash, ttl uint8) (types.BlobSidecars, error) {
 	finishedCh := make(chan struct{})
 	retrievedCh := make(chan struct{})
+	ctx, cancel := context.WithTimeout(ctx, blobFetchTimeout*time.Duration(ttl))
+	defer cancel()
 	var wg sync.WaitGroup
 	resCh := make(chan *beacon.Response)
 	defer close(resCh)
@@ -290,13 +302,11 @@ func (h *beaconHandler) retrieveSidecars(transfer []*beaconPeer, blockHash commo
 			}
 			defer req.Close()
 
-			timeout := time.NewTimer(blobFetchTimeout * time.Duration(ttl))
-			defer timeout.Stop()
 			select {
-			case <-timeout.C:
-				log.Debug("Blob fetch timeout", "block hash", blockHash, "peer", p.ID())
-				return
 			case <-retrievedCh:
+				return
+			case <-ctx.Done():
+				log.Debug("Blob fetch failed", "block hash", blockHash, "peer", p.ID(), "error", ctx.Err())
 				return
 			}
 		}(p.Peer)
@@ -309,6 +319,11 @@ func (h *beaconHandler) retrieveSidecars(transfer []*beaconPeer, blockHash commo
 
 	select {
 	case <-finishedCh:
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
 		log.Debug("Not found blob data from other peers", "block hash", blockHash)
 		return nil, fmt.Errorf("not found blob data for block hash %s", blockHash.Hex())
 	case res := <-resCh:
@@ -327,10 +342,10 @@ func (h *beaconHandler) retrieveSidecars(transfer []*beaconPeer, blockHash commo
 }
 
 // RetrieveSidecarsByRoot retrieves blob sidecars by block hash.
-func (h *beaconHandler) RetrieveSidecarsByRoot(blockHash common.Hash) (types.BlobSidecars, error) {
+func (h *beaconHandler) RetrieveSidecarsByRoot(ctx context.Context, blockHash common.Hash) (types.BlobSidecars, error) {
 	transfer := h.selectBlobTransferPeers(nil)
 
-	blobData, err := h.retrieveSidecars(transfer, blockHash, ttl)
+	blobData, err := h.retrieveSidecars(ctx, transfer, blockHash, ttl)
 	if err != nil {
 		log.Debug("Failed to retrieve blobs for GetBlobs request", "blockHash", blockHash, "err", err)
 		return nil, err

--- a/eth/handler_beacon.go
+++ b/eth/handler_beacon.go
@@ -24,7 +24,7 @@ const (
 	// ttl is the time-to-live for blob requests.
 	ttl = 3
 	// Maximum allotted time to return an explicitly requested blob
-	blobFetchTimeout = 500 * time.Millisecond
+	blobFetchTimeout = 5 * time.Second
 	// Maximum allotted time to return a batch of blobs
 	batchBlobsFetchTimeout = 3 * time.Second
 

--- a/eth/handler_beacon.go
+++ b/eth/handler_beacon.go
@@ -119,10 +119,11 @@ func (h *beaconHandler) handleBlockBroadcast(peer *beacon.Peer, packet *beacon.N
 	var (
 		trueHead = block.ParentHash()
 		trueTD   = new(big.Int).Sub(td, block.Difficulty())
+		trueNum  = block.NumberU64() - 1
 	)
 	// Update the peer's total difficulty if better than the previous
-	if _, td := peer.Head(); trueTD.Cmp(td) > 0 {
-		peer.SetHead(trueHead, trueTD)
+	if _, td, _ := peer.Head(); trueTD.Cmp(td) > 0 {
+		peer.SetHead(trueHead, trueTD, trueNum)
 	}
 	return nil
 }

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -76,7 +76,8 @@ func (p *snapPeer) info() *snapPeerInfo {
 // beaconPeerInfo represents a short summary of the `beacon` sub-protocol metadata known
 // about a connected peer.
 type beaconPeerInfo struct {
-	Version uint `json:"version"` // Beacon protocol version negotiated
+	Version    uint   `json:"version"`    // Beacon protocol version negotiated
+	HeadNumber uint64 `json:"headNumber"` // Latest block number known by the peer
 }
 
 // beaconPeer is a wrapper around beacon.Peer to maintain a few extra metadata.
@@ -86,7 +87,9 @@ type beaconPeer struct {
 
 // info gathers and returns some `beacon` protocol metadata known about a peer.
 func (p *beaconPeer) info() *beaconPeerInfo {
+	_, _, headNumber := p.Head()
 	return &beaconPeerInfo{
-		Version: p.Version(),
+		Version:    p.Version(),
+		HeadNumber: headNumber,
 	}
 }

--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -347,7 +347,7 @@ func (ps *peerSet) peerWithHighestTD() (*beacon.Peer, *eth.Peer) {
 		bestTd     *big.Int
 	)
 	for _, b := range ps.beacons {
-		if _, td := b.Head(); bestPeer == nil || td.Cmp(bestTd) > 0 {
+		if _, td, _ := b.Head(); bestPeer == nil || td.Cmp(bestTd) > 0 {
 			if p := ps.peers[b.ID()]; p != nil {
 				bestBeacon, bestPeer, bestTd = b.Peer, p.Peer, td
 			}

--- a/eth/peerset.go
+++ b/eth/peerset.go
@@ -356,6 +356,21 @@ func (ps *peerSet) peerWithHighestTD() (*beacon.Peer, *eth.Peer) {
 	return bestBeacon, bestPeer
 }
 
+func (ps *peerSet) highestNumberOfBeacons() (uint64, bool) {
+	ps.lock.RLock()
+	defer ps.lock.RUnlock()
+
+	highestHeadNumber := uint64(0)
+	found := false
+	for _, b := range ps.beacons {
+		if _, _, headNumber := b.Head(); headNumber > highestHeadNumber {
+			highestHeadNumber = headNumber
+			found = true
+		}
+	}
+	return highestHeadNumber, found
+}
+
 // close disconnects all peers.
 func (ps *peerSet) close() {
 	ps.lock.Lock()

--- a/eth/protocols/beacon/handler.go
+++ b/eth/protocols/beacon/handler.go
@@ -94,6 +94,16 @@ var beacon1 = map[uint64]msgHandler{
 	BatchBlobsMsg:     handleBatchBlobs,
 }
 
+var beacon2 = map[uint64]msgHandler{
+	NewBlockHashesMsg: handleNewBlockhashes,
+	NewBlockMsg:       handleNewBlock,
+	NewBlobsRootMsg:   handleNewBlobsRoot,
+	GetBlobsMsg:       handleGetBlobs,
+	BlobsMsg:          handleBlobs,
+	GetBatchBlobsMsg:  handleGetBatchBlobs,
+	BatchBlobsMsg:     handleBatchBlobs,
+}
+
 // handleMessage is invoked whenever an inbound message is received from a
 // remote peer on the `beacon` protocol. The remote connection is torn down upon
 // returning any error.
@@ -108,7 +118,14 @@ func handleMessage(backend Backend, peer *Peer) error {
 	}
 	defer msg.Discard()
 
-	var handlers = beacon1
+	var handlers map[uint64]msgHandler
+	if peer.version == BEACON1 {
+		handlers = beacon1
+	} else if peer.version == BEACON2 {
+		handlers = beacon2
+	} else {
+		return fmt.Errorf("unknown beacon protocol version: %v", peer.version)
+	}
 
 	// Track the amount of time it takes to serve the request and run the handler
 	if metrics.Enabled() {

--- a/eth/protocols/beacon/handlers.go
+++ b/eth/protocols/beacon/handlers.go
@@ -75,8 +75,24 @@ func handleGetBlobs(backend Backend, msg Decoder, peer *Peer) error {
 
 func handleBlobs(backend Backend, msg Decoder, peer *Peer) error {
 	ann := new(BlobsPacket)
-	if err := msg.Decode(ann); err != nil {
-		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	switch peer.version {
+	case BEACON1:
+		ann1 := new(BlobsPacket1)
+		if err := msg.Decode(ann1); err != nil {
+			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		}
+		ann.RequestId = ann1.RequestId
+		bss := make(types.BlobSidecars, 0, len(ann1.Sidecars))
+		for _, sc := range ann1.Sidecars {
+			bss = append(bss, types.NewBlobTxSidecar(types.BlobSidecarVersion0, sc.Blobs, sc.Commitments, sc.Proofs))
+		}
+		ann.Sidecars = bss
+	case BEACON2:
+		if err := msg.Decode(ann); err != nil {
+			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		}
+	default:
+		return fmt.Errorf("unknown beacon protocol version: %v", peer.version)
 	}
 
 	err := peer.dispatchResponse(&Response{
@@ -101,8 +117,28 @@ func handleGetBatchBlobs(backend Backend, msg Decoder, peer *Peer) error {
 
 func handleBatchBlobs(backend Backend, msg Decoder, peer *Peer) error {
 	res := new(BatchBlobsPacket)
-	if err := msg.Decode(res); err != nil {
-		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	switch peer.version {
+	case BEACON1:
+		res1 := new(BatchBlobsPacket1)
+		if err := msg.Decode(res1); err != nil {
+			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		}
+		bbr := make(BatchBlobsResponse, 0, len(res1.BatchBlobsResponse1))
+		for _, scs1 := range res1.BatchBlobsResponse1 {
+			scs := make(types.BlobSidecars, 0, len(scs1))
+			for _, sc1 := range scs1 {
+				scs = append(scs, types.NewBlobTxSidecar(types.BlobSidecarVersion0, sc1.Blobs, sc1.Commitments, sc1.Proofs))
+			}
+			bbr = append(bbr, scs)
+		}
+		res.RequestId = res1.RequestId
+		res.BatchBlobsResponse = bbr
+	case BEACON2:
+		if err := msg.Decode(res); err != nil {
+			return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+		}
+	default:
+		return fmt.Errorf("unknown beacon protocol version: %v", peer.version)
 	}
 
 	err := peer.dispatchResponse(&Response{

--- a/eth/protocols/beacon/handshake.go
+++ b/eth/protocols/beacon/handshake.go
@@ -1,12 +1,14 @@
 package beacon
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/forkid"
+	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/p2p"
 )
 
@@ -19,6 +21,17 @@ const (
 // Handshake executes the eth protocol handshake, negotiating version number,
 // network IDs, difficulties, head and genesis blocks.
 func (p *Peer) Handshake(network uint64, chain *core.BlockChain, blobSync bool) error {
+	switch p.version {
+	case BEACON2:
+		return p.handshake2(network, chain, blobSync)
+	case BEACON1:
+		return p.handshake1(network, chain, blobSync)
+	default:
+		return errors.New("unsupported protocol version")
+	}
+}
+
+func (p *Peer) handshake1(network uint64, chain *core.BlockChain, blobSync bool) error {
 	var (
 		genesis    = chain.Genesis()
 		latest     = chain.CurrentBlock()
@@ -29,10 +42,10 @@ func (p *Peer) Handshake(network uint64, chain *core.BlockChain, blobSync bool) 
 	// Send out own handshake in a new thread
 	errc := make(chan error, 2)
 
-	var status StatusPacket // safe to read after two values have been received from errc
+	var status StatusPacket1 // safe to read after two values have been received from errc
 
 	go func() {
-		errc <- p2p.Send(p.rw, StatusMsg, &StatusPacket{
+		errc <- p2p.Send(p.rw, StatusMsg, &StatusPacket1{
 			ProtocolVersion: uint32(p.version),
 			NetworkID:       network,
 			TD:              td,
@@ -43,26 +56,14 @@ func (p *Peer) Handshake(network uint64, chain *core.BlockChain, blobSync bool) 
 		})
 	}()
 	go func() {
-		errc <- p.readStatus(network, &status, genesis.Hash(), forkFilter)
+		errc <- p.readStatus1(network, &status, genesis.Hash(), forkFilter)
 	}()
-	timeout := time.NewTimer(handshakeTimeout)
-	defer timeout.Stop()
-	for i := 0; i < 2; i++ {
-		select {
-		case err := <-errc:
-			if err != nil {
-				return err
-			}
-		case <-timeout.C:
-			return p2p.DiscReadTimeout
-		}
-	}
-	p.td, p.head = status.TD, status.Head
-	return nil
+
+	return waitForHandshake(errc, p)
 }
 
-// readStatus reads the remote handshake message.
-func (p *Peer) readStatus(network uint64, status *StatusPacket, genesis common.Hash, forkFilter forkid.Filter) error {
+// readStatus1 reads the remote handshake message.
+func (p *Peer) readStatus1(network uint64, status *StatusPacket1, genesis common.Hash, forkFilter forkid.Filter) error {
 	msg, err := p.rw.ReadMsg()
 	if err != nil {
 		return err
@@ -89,6 +90,112 @@ func (p *Peer) readStatus(network uint64, status *StatusPacket, genesis common.H
 	if err := forkFilter(status.ForkID); err != nil {
 		return fmt.Errorf("%w: %v", errForkIDRejected, err)
 	}
+	p.td, p.head = status.TD, status.Head
 	p.blobSync = status.BlobSync
 	return nil
+}
+
+func (p *Peer) handshake2(network uint64, chain *core.BlockChain, blobSync bool) error {
+	var (
+		genesis    = chain.Genesis()
+		latest     = chain.CurrentBlock()
+		forkID     = forkid.NewID(chain.Config(), genesis, latest.Number.Uint64(), latest.Time)
+		td         = chain.GetTd(latest.Hash(), latest.Number.Uint64())
+		forkFilter = forkid.NewFilter(chain)
+	)
+	// Send out own handshake in a new thread
+	errc := make(chan error, 2)
+
+	var status StatusPacket2 // safe to read after two values have been received from errc
+
+	go func() {
+		errc <- p2p.Send(p.rw, StatusMsg, &StatusPacket2{
+			ProtocolVersion: uint32(p.version),
+			NetworkID:       network,
+			TD:              td,
+			Head:            latest.Hash(),
+			HeadNumber:      latest.Number.Uint64(),
+			Genesis:         genesis.Hash(),
+			ForkID:          forkID,
+			BlobSync:        blobSync,
+		})
+	}()
+	go func() {
+		errc <- p.readStatus2(network, &status, genesis.Hash(), forkFilter)
+	}()
+
+	return waitForHandshake(errc, p)
+}
+
+// readStatus1 reads the remote handshake message.
+func (p *Peer) readStatus2(network uint64, status *StatusPacket2, genesis common.Hash, forkFilter forkid.Filter) error {
+	msg, err := p.rw.ReadMsg()
+	if err != nil {
+		return err
+	}
+	if msg.Code != StatusMsg {
+		return fmt.Errorf("%w: first msg has code %x (!= %x)", errNoStatusMsg, msg.Code, StatusMsg)
+	}
+	if msg.Size > maxMessageSize {
+		return fmt.Errorf("%w: %v > %v", errMsgTooLarge, msg.Size, maxMessageSize)
+	}
+	// Decode the handshake and make sure everything matches
+	if err := msg.Decode(&status); err != nil {
+		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
+	}
+	if status.NetworkID != network {
+		return fmt.Errorf("%w: %d (!= %d)", errNetworkIDMismatch, status.NetworkID, network)
+	}
+	if uint(status.ProtocolVersion) != p.version {
+		return fmt.Errorf("%w: %d (!= %d)", errProtocolVersionMismatch, status.ProtocolVersion, p.version)
+	}
+	if status.Genesis != genesis {
+		return fmt.Errorf("%w: %x (!= %x)", errGenesisMismatch, status.Genesis, genesis)
+	}
+	if err := forkFilter(status.ForkID); err != nil {
+		return fmt.Errorf("%w: %v", errForkIDRejected, err)
+	}
+	p.td, p.head, p.headNumber = status.TD, status.Head, status.HeadNumber
+	p.blobSync = status.BlobSync
+	return nil
+}
+
+func waitForHandshake(errc <-chan error, p *Peer) error {
+	timeout := time.NewTimer(handshakeTimeout)
+	defer timeout.Stop()
+	for range 2 {
+		select {
+		case err := <-errc:
+			if err != nil {
+				markError(p, err)
+				return err
+			}
+		case <-timeout.C:
+			markError(p, p2p.DiscReadTimeout)
+			return p2p.DiscReadTimeout
+		}
+	}
+	return nil
+}
+
+// markError registers the error with the corresponding metric.
+func markError(p *Peer, err error) {
+	if !metrics.Enabled() {
+		return
+	}
+	m := meters.get(p.Inbound())
+	switch errors.Unwrap(err) {
+	case errNetworkIDMismatch:
+		m.networkIDMismatch.Mark(1)
+	case errProtocolVersionMismatch:
+		m.protocolVersionMismatch.Mark(1)
+	case errGenesisMismatch:
+		m.genesisMismatch.Mark(1)
+	case errForkIDRejected:
+		m.forkidRejected.Mark(1)
+	case p2p.DiscReadTimeout:
+		m.timeoutError.Mark(1)
+	default:
+		m.peerError.Mark(1)
+	}
 }

--- a/eth/protocols/beacon/metrics.go
+++ b/eth/protocols/beacon/metrics.go
@@ -1,0 +1,81 @@
+// Copyright 2023 The go-ethereum Authors
+// This file is part of the go-ethereum library.
+//
+// The go-ethereum library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The go-ethereum library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
+
+package beacon
+
+import "github.com/ethereum/go-ethereum/metrics"
+
+// meters stores ingress and egress handshake meters.
+var meters bidirectionalMeters
+
+// bidirectionalMeters stores ingress and egress handshake meters.
+type bidirectionalMeters struct {
+	ingress *hsMeters
+	egress  *hsMeters
+}
+
+// get returns the corresponding meter depending if ingress or egress is
+// desired.
+func (h *bidirectionalMeters) get(ingress bool) *hsMeters {
+	if ingress {
+		return h.ingress
+	}
+	return h.egress
+}
+
+// hsMeters is a collection of meters which track metrics related to the
+// eth subprotocol handshake.
+type hsMeters struct {
+	// peerError measures the number of errors related to incorrect peer
+	// behaviour, such as invalid message code, size, encoding, etc.
+	peerError *metrics.Meter
+
+	// timeoutError measures the number of timeouts.
+	timeoutError *metrics.Meter
+
+	// networkIDMismatch measures the number of network id mismatch errors.
+	networkIDMismatch *metrics.Meter
+
+	// protocolVersionMismatch measures the number of differing protocol
+	// versions.
+	protocolVersionMismatch *metrics.Meter
+
+	// genesisMismatch measures the number of differing genesises.
+	genesisMismatch *metrics.Meter
+
+	// forkidRejected measures the number of differing forkids.
+	forkidRejected *metrics.Meter
+}
+
+// newHandshakeMeters registers and returns handshake meters for the given
+// base.
+func newHandshakeMeters(base string) *hsMeters {
+	return &hsMeters{
+		peerError:               metrics.NewRegisteredMeter(base+"error/peer", nil),
+		timeoutError:            metrics.NewRegisteredMeter(base+"error/timeout", nil),
+		networkIDMismatch:       metrics.NewRegisteredMeter(base+"error/network", nil),
+		protocolVersionMismatch: metrics.NewRegisteredMeter(base+"error/version", nil),
+		genesisMismatch:         metrics.NewRegisteredMeter(base+"error/genesis", nil),
+		forkidRejected:          metrics.NewRegisteredMeter(base+"error/forkid", nil),
+	}
+}
+
+func init() {
+	meters = bidirectionalMeters{
+		ingress: newHandshakeMeters("eth/protocols/beacon/ingress/handshake/"),
+		egress:  newHandshakeMeters("eth/protocols/beacon/egress/handshake/"),
+	}
+}

--- a/eth/protocols/beacon/peer.go
+++ b/eth/protocols/beacon/peer.go
@@ -43,8 +43,9 @@ type Peer struct {
 	rw        p2p.MsgReadWriter // Input/output streams for blob
 	version   uint              // Protocol version negotiated
 
-	head common.Hash // Latest advertised head block hash
-	td   *big.Int    // Latest advertised head block total difficulty
+	head       common.Hash // Latest advertised head block hash
+	headNumber uint64      // Latest advertised head block number
+	td         *big.Int    // Latest advertised head block total difficulty
 
 	knownBlocks     *knownCache            // Set of block hashes known to be known by this peer
 	queuedBlocks    chan *blockPropagation // Queue of blocks to broadcast to the peer
@@ -111,21 +112,22 @@ func (p *Peer) BlobSync() bool {
 }
 
 // Head retrieves the current head hash and total difficulty of the peer.
-func (p *Peer) Head() (hash common.Hash, td *big.Int) {
+func (p *Peer) Head() (hash common.Hash, td *big.Int, number uint64) {
 	p.lock.RLock()
 	defer p.lock.RUnlock()
 
 	copy(hash[:], p.head[:])
-	return hash, new(big.Int).Set(p.td)
+	return hash, new(big.Int).Set(p.td), p.headNumber
 }
 
 // SetHead updates the head hash and total difficulty of the peer.
-func (p *Peer) SetHead(hash common.Hash, td *big.Int) {
+func (p *Peer) SetHead(hash common.Hash, td *big.Int, number uint64) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
 	copy(p.head[:], hash[:])
 	p.td.Set(td)
+	p.headNumber = number
 }
 
 // KnownBlock returns whether peer is known to already have a block.

--- a/eth/protocols/beacon/protocol.go
+++ b/eth/protocols/beacon/protocol.go
@@ -120,6 +120,12 @@ type GetBlobsPacket struct {
 	Ttl       uint8
 }
 
+// BlobsPacket1 is the response packet for blobs by block hash, with BEACON1.
+type BlobsPacket1 struct {
+	RequestId uint64
+	Sidecars  types.BlobSidecarV0s
+}
+
 // BlobsPacket is the response packet for blobs by block hash.
 type BlobsPacket struct {
 	RequestId uint64
@@ -141,6 +147,15 @@ type GetBatchBlobsRequest []common.Hash
 type GetBatchBlobsPacket struct {
 	RequestId uint64
 	GetBatchBlobsRequest
+}
+
+// BatchBlobsResponse1 is the response packet for blobs by block hash, with BEACON1.
+type BatchBlobsResponse1 [][]*types.BlobTxSidecarV0
+
+// BatchBlobsPacket1 is the response packet for batch blobs by block hashes, with BEACON1.
+type BatchBlobsPacket1 struct {
+	RequestId uint64
+	BatchBlobsResponse1
 }
 
 // BatchBlobsResponse is the response packet for blobs by block hash.
@@ -181,11 +196,17 @@ func (*NewBlobsRootPacket) Kind() byte   { return NewBlobsRootMsg }
 func (*GetBlobsPacket) Name() string { return "GetBlobs" }
 func (*GetBlobsPacket) Kind() byte   { return GetBlobsMsg }
 
+func (*BlobsPacket1) Name() string { return "Blobs" }
+func (*BlobsPacket1) Kind() byte   { return BlobsMsg }
+
 func (*BlobsPacket) Name() string { return "Blobs" }
 func (*BlobsPacket) Kind() byte   { return BlobsMsg }
 
 func (*GetBatchBlobsPacket) Name() string { return "GetBatchBlobs" }
 func (*GetBatchBlobsPacket) Kind() byte   { return GetBatchBlobsMsg }
+
+func (*BatchBlobsPacket1) Name() string { return "BatchBlobs" }
+func (*BatchBlobsPacket1) Kind() byte   { return BatchBlobsMsg }
 
 func (*BatchBlobsPacket) Name() string { return "BatchBlobs" }
 func (*BatchBlobsPacket) Kind() byte   { return BatchBlobsMsg }

--- a/eth/protocols/beacon/protocol.go
+++ b/eth/protocols/beacon/protocol.go
@@ -13,6 +13,7 @@ import (
 // Constants to match up protocol versions and messages
 const (
 	BEACON1 = 1
+	BEACON2 = 2
 )
 
 // ProtocolName is the official short name of the `beacon` protocol used during
@@ -21,11 +22,11 @@ const ProtocolName = "beacon"
 
 // ProtocolVersions are the supported versions of the `beacon` protocol (first
 // is primary).
-var ProtocolVersions = []uint{BEACON1}
+var ProtocolVersions = []uint{BEACON1, BEACON2}
 
 // protocolLengths are the number of implemented message corresponding to
 // different protocol versions.
-var protocolLengths = map[uint]uint64{BEACON1: 8}
+var protocolLengths = map[uint]uint64{BEACON1: 8, BEACON2: 8}
 
 // maxMessageSize is the maximum cap on the size of a protocol message.
 const maxMessageSize = 10 * 1024 * 1024
@@ -58,12 +59,24 @@ type Packet interface {
 	Kind() byte   // Kind returns the message type.
 }
 
-// StatusPacket is the network packet for the status message.
-type StatusPacket struct {
+// StatusPacket1 is the network packet for the status message.
+type StatusPacket1 struct {
 	ProtocolVersion uint32
 	NetworkID       uint64
 	TD              *big.Int
 	Head            common.Hash
+	Genesis         common.Hash
+	ForkID          forkid.ID
+	BlobSync        bool
+}
+
+// StatusPacket2 is the network packet for the status message.
+type StatusPacket2 struct {
+	ProtocolVersion uint32
+	NetworkID       uint64
+	TD              *big.Int
+	Head            common.Hash
+	HeadNumber      uint64
 	Genesis         common.Hash
 	ForkID          forkid.ID
 	BlobSync        bool
@@ -150,8 +163,11 @@ type BatchBlobsRLPPacket struct {
 	BatchBlobsRLPResponse
 }
 
-func (*StatusPacket) Name() string { return "Status" }
-func (*StatusPacket) Kind() byte   { return StatusMsg }
+func (*StatusPacket1) Name() string { return "Status" }
+func (*StatusPacket1) Kind() byte   { return StatusMsg }
+
+func (*StatusPacket2) Name() string { return "Status" }
+func (*StatusPacket2) Kind() byte   { return StatusMsg }
 
 func (*NewBlockHashesPacket) Name() string { return "NewBlockHashes" }
 func (*NewBlockHashesPacket) Kind() byte   { return NewBlockHashesMsg }


### PR DESCRIPTION
Close #597 .

By upgrading the status message of the beacon protocol, the latest block header of the peer can be quickly obtained, which is used to initialize the fetch height in the sidecar fetcher.