### PR TITLE
privnet: enforce hashDB for state storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ define run_node
 endef
 
 define init_node
-    @$(GOBIN)/geth init --datadir $(1)/$(2) $(1)/$(GENESIS_WORK_JSON) > $(1)/$(2)/geth_init.log 2>&1
+    @$(GOBIN)/geth init --state.scheme hash --datadir $(1)/$(2) $(1)/$(GENESIS_WORK_JSON) > $(1)/$(2)/geth_init.log 2>&1
 endef
 
 #? geth: Build geth.


### PR DESCRIPTION
Related to #593, ref https://github.com/bane-labs/go-ethereum/pull/593#issuecomment-4278571281 and [8acbeff](https://github.com/bane-labs/go-ethereum/pull/593/commits/8acbeffb2a87439492128892d7022de25d4394cc).

The current codebase has an issue for PathDB when synchronizing chains shorter than 128 blocks. It may affect the our Privnets, since they always start as short chains. E.g. if one of the CN doesn't start quickly enough, then it has to wait 128 blocks to connect to the consensus, which will cause CVs or even network breakdown.

By enforcing HashDB, IMO this should get solved.