### PR TITLE
eth/downloader: set syncing to false after initial sync correctly

### DIFF
--- a/eth/downloader/skeleton.go
+++ b/eth/downloader/skeleton.go
@@ -208,7 +208,7 @@ type skeleton struct {
 	drop  peerDropFn                 // Drops a peer for misbehaving
 
 	progress *skeletonProgress // Sync progress tracker for resumption and metrics
-	syncing  atomic.Bool       // Whether the skeleton is currently syncing or waiting for a head
+	syncing  atomic.Bool       // Whether the skeleton is currently running the initial sync
 	started  time.Time         // Timestamp when the skeleton syncer was created
 	logged   time.Time         // Timestamp when progress was last logged to the user
 	pulled   uint64            // Number of headers downloaded in this run
@@ -287,6 +287,7 @@ func (s *skeleton) startup() {
 					// segment. Tear down the loop and restart it so, it can properly
 					// notify the backfiller. Don't account a new head.
 					head = nil
+					s.syncing.Store(false)
 
 				case err == errSyncMerged:
 					// Subchains were merged, we just need to reinit the internal


### PR DESCRIPTION
This is a fix/enhancement for #606.

The downloader skeleton `syncing` status should be set false after the initial beacon header sync, otherwise new CNs in the network can't enable the consensus handling correctly.