### PR TITLE
beacon, eth: enhance the overall synchronization status judgment

### DIFF
--- a/eth/backend.go
+++ b/eth/backend.go
@@ -454,7 +454,8 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.handler.connectBeacon(eth.beacon)
 	if bft != nil {
 		syncing := func() bool {
-			return eth.beacon.Syncing() || !eth.Synced()
+			log.Debug("Syncing status", "beacon", eth.beacon.Syncing(), "eth", eth.Syncing())
+			return eth.beacon.Syncing() || eth.Syncing()
 		}
 		// Connect BFT to beacon protocol
 		bft.WithBeacon(eth.beacon.BlockBroadcaster(), eth.beacon.RefreshPendingPayload, eth.beacon.SubscribeSyncingEvents, syncing)
@@ -863,4 +864,11 @@ func (s *Ethereum) SyncMode() ethconfig.SyncMode {
 	}
 	// Nope, we're really full syncing
 	return ethconfig.FullSync
+}
+
+// Syncing returns true if the node downloader is still syncing.
+// NOTE: the method Synced() now returns if the node has the latest head,
+// so CL needs another method to check downloader state directly.
+func (s *Ethereum) Syncing() bool {
+	return s.handler.downloader.Syncing()
 }

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -454,7 +454,7 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	eth.handler.connectBeacon(eth.beacon)
 	if bft != nil {
 		syncing := func() bool {
-			return eth.beacon.Syncing() || eth.Syncing()
+			return eth.beacon.Syncing() || !eth.Synced()
 		}
 		// Connect BFT to beacon protocol
 		bft.WithBeacon(eth.beacon.BlockBroadcaster(), eth.beacon.RefreshPendingPayload, eth.beacon.SubscribeSyncingEvents, syncing)
@@ -863,11 +863,4 @@ func (s *Ethereum) SyncMode() ethconfig.SyncMode {
 	}
 	// Nope, we're really full syncing
 	return ethconfig.FullSync
-}
-
-// Syncing returns true if the node downloader is still syncing.
-// NOTE: the method Synced() now returns if the node has the latest head,
-// so CL needs another method to check downloader state directly.
-func (s *Ethereum) Syncing() bool {
-	return s.handler.downloader.Syncing()
 }

--- a/eth/downloader/beaconsync.go
+++ b/eth/downloader/beaconsync.go
@@ -186,6 +186,7 @@ func (d *Downloader) beaconSync(mode SyncMode, head *types.Header, final *types.
 	if err := d.skeleton.Sync(head, final, force); err != nil {
 		return err
 	}
+	d.syncing.Store(true)
 	return nil
 }
 

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -122,6 +122,8 @@ type Downloader struct {
 	committed     atomic.Bool
 	ancientLimit  uint64 // The maximum block number which can be regarded as ancient data.
 
+	syncing atomic.Bool // Whether the downloader is currently syncing.
+
 	// The cutoff block number and hash before which chain segments (bodies
 	// and receipts) are skipped during synchronization. 0 means the entire
 	// chain segment is aimed for synchronization.
@@ -350,7 +352,10 @@ func (d *Downloader) synchronise(mode SyncMode, beaconPing chan struct{}) error 
 	if !d.synchronising.CompareAndSwap(false, true) {
 		return errBusy
 	}
-	defer d.synchronising.Store(false)
+	defer func() {
+		d.syncing.Store(false)
+		d.synchronising.Store(false)
+	}()
 
 	// Post a user notification of the sync (only once per session)
 	if d.notified.CompareAndSwap(false, true) {
@@ -665,6 +670,11 @@ func (d *Downloader) Terminate() {
 
 	// Cancel any pending download requests
 	d.Cancel()
+}
+
+// Syncing returns whether the downloader is currently running a synchronisation.
+func (d *Downloader) Syncing() bool {
+	return d.syncing.Load()
 }
 
 // fetchBodies iteratively downloads the scheduled block bodies, taking any

--- a/eth/downloader/downloader.go
+++ b/eth/downloader/downloader.go
@@ -667,11 +667,6 @@ func (d *Downloader) Terminate() {
 	d.Cancel()
 }
 
-// Syncing returns whether the downloader is currently running a synchronisation.
-func (d *Downloader) Syncing() bool {
-	return d.synchronising.Load() || d.skeleton.Syncing()
-}
-
 // fetchBodies iteratively downloads the scheduled block bodies, taking any
 // available peers, reserving a chunk of blocks for each, waiting for delivery
 // and also periodically checking for timeouts.

--- a/eth/downloader/skeleton.go
+++ b/eth/downloader/skeleton.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
-	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -208,7 +207,6 @@ type skeleton struct {
 	drop  peerDropFn                 // Drops a peer for misbehaving
 
 	progress *skeletonProgress // Sync progress tracker for resumption and metrics
-	syncing  atomic.Bool       // Whether the skeleton is currently syncing or waiting for a head
 	started  time.Time         // Timestamp when the skeleton syncer was created
 	logged   time.Time         // Timestamp when progress was last logged to the user
 	pulled   uint64            // Number of headers downloaded in this run
@@ -252,7 +250,6 @@ func (s *skeleton) startup() {
 	// Close a notification channel so anyone sending us events will know if the
 	// sync loop was torn down for good.
 	defer close(s.terminated)
-	defer s.syncing.Store(false)
 
 	// Wait for startup or teardown. This wait might loop a few times if a beacon
 	// client requests sync head extensions, but not forced reorgs (i.e. they are
@@ -274,7 +271,6 @@ func (s *skeleton) startup() {
 			event.errc <- nil // forced head accepted for startup
 			head := event.header
 			s.started = time.Now()
-			s.syncing.Store(true)
 
 			for {
 				// If the sync cycle terminated or was terminated, propagate up when
@@ -1262,9 +1258,4 @@ func (s *skeleton) Bounds() (head *types.Header, tail *types.Header, final *type
 // subsequent calls might return headers from different chains.
 func (s *skeleton) Header(number uint64) *types.Header {
 	return rawdb.ReadSkeletonHeader(s.db, number)
-}
-
-// Syncing returns whether the skeleton sync is activated by a head event.
-func (s *skeleton) Syncing() bool {
-	return s.syncing.Load()
 }

--- a/eth/downloader/skeleton.go
+++ b/eth/downloader/skeleton.go
@@ -309,9 +309,6 @@ func (s *skeleton) startup() {
 				default:
 					// Sync either successfully terminated or failed with an unhandled
 					// error. Abort and wait until Geth requests a termination.
-					s.syncing.Store(false)
-					// The loop is dead here and doesn't return, so a manual status update
-					// is needed before reaching this line.
 					errc := <-s.terminate
 					errc <- err
 					return
@@ -380,8 +377,6 @@ func (s *skeleton) sync(head *types.Header) (*types.Header, error) {
 		rawdb.HasBody(s.db, s.progress.Subchains[0].Next, s.scratchHead) &&
 		rawdb.HasReceipts(s.db, s.progress.Subchains[0].Next, s.scratchHead)
 	if linked {
-		// Need to set syncing to false, before the sync loops in waiting.
-		s.syncing.Store(false)
 		s.filler.resume()
 	}
 	defer func() {

--- a/eth/downloader/skeleton.go
+++ b/eth/downloader/skeleton.go
@@ -208,7 +208,7 @@ type skeleton struct {
 	drop  peerDropFn                 // Drops a peer for misbehaving
 
 	progress *skeletonProgress // Sync progress tracker for resumption and metrics
-	syncing  atomic.Bool       // Whether the skeleton is currently running the initial sync
+	syncing  atomic.Bool       // Whether the skeleton is currently syncing or waiting for a head
 	started  time.Time         // Timestamp when the skeleton syncer was created
 	logged   time.Time         // Timestamp when progress was last logged to the user
 	pulled   uint64            // Number of headers downloaded in this run
@@ -287,7 +287,6 @@ func (s *skeleton) startup() {
 					// segment. Tear down the loop and restart it so, it can properly
 					// notify the backfiller. Don't account a new head.
 					head = nil
-					s.syncing.Store(false)
 
 				case err == errSyncMerged:
 					// Subchains were merged, we just need to reinit the internal


### PR DESCRIPTION
Close #611 .

I added a timestamp for the completion of synchronization in both CL and EL. By comparing these two timestamps, we can determine the overall synchronization status where CL has completed synchronization but EL has not yet started.