### PR TITLE
eth: notify block fetcher when handshake if necessary

### DIFF
--- a/beacon/impl/synchronizer/synchronizer.go
+++ b/beacon/impl/synchronizer/synchronizer.go
@@ -33,7 +33,9 @@ type LightVerifyFn func(headers []*types.Header) bool
 type LightSyncFn func(extend BeaconExtendFn, complete func(), start chan *types.Header) error
 
 // BeaconExtendFn is a callback type for extending the trusted header chain with headers received from the network.
-type BeaconExtendFn func(verifiedHeaderHashes []common.Hash, finalized *types.Block, latest *types.Block) (linked bool, err error)
+// It will stop the synchronizer and try to start EL sync if there's a link between pending chains and the trusted chain,
+// or if a force signal is received.
+type BeaconExtendFn func(verifiedHeaderHashes []common.Hash, finalized *types.Block, latest *types.Block, complete bool) (linked bool, err error)
 
 // completeFn is a callback type for synchronizer is synced but still receiving notifications.
 type completeFn func(block *types.Block) error
@@ -192,7 +194,7 @@ func (s *Synchronizer) NotifyNewHead(block *types.Block) error {
 
 // BeaconExtend tries to extend the trusted header chain with the untrusted but verified
 // headers received from the network, and returns the new latest trusted header.
-func (s *Synchronizer) BeaconExtend(verifiedHeaderHashes []common.Hash, finalized *types.Block, latest *types.Block) (linked bool, err error) {
+func (s *Synchronizer) BeaconExtend(verifiedHeaderHashes []common.Hash, finalized *types.Block, latest *types.Block, complete bool) (linked bool, err error) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
@@ -214,8 +216,8 @@ func (s *Synchronizer) BeaconExtend(verifiedHeaderHashes []common.Hash, finalize
 	s.latestHead = latest
 	s.finalize()
 	log.Info("Beacon trust successfully extended", "head", s.trustedHead.Hash(), "number", s.trustedHead.NumberU64())
-	// If the trust is extended to the latest, send the first head signal.
-	if connected {
+	// If the trust is extended to the latest, or a force signal is received, send the first head signal.
+	if connected || complete {
 		s.complete(s.trustedHead)
 	}
 	// The light sync using this callback should stop depends on the connected result,

--- a/beacon/impl/synchronizer/synchronizer_test.go
+++ b/beacon/impl/synchronizer/synchronizer_test.go
@@ -66,7 +66,7 @@ func newTestSynchronizer(chain []*types.Block, complete completeFn) *Synchronize
 			}
 			trustedHeader = newBlocks[len(newBlocks)-2].Header()
 			completed := len(newBlocks) < ExpectedHeadersNum
-			if _, err := extend(metas, newBlocks[len(newBlocks)-2], newBlocks[len(newBlocks)-1]); err != nil {
+			if _, err := extend(metas, newBlocks[len(newBlocks)-2], newBlocks[len(newBlocks)-1], completed); err != nil {
 				shouldSync.Store(false)
 				complete()
 				continue

--- a/eth/downloader/beaconlightsync.go
+++ b/eth/downloader/beaconlightsync.go
@@ -525,7 +525,7 @@ func (b *beaconLightSyncer) processResponse(res *beaconLightResponse) (completed
 		// Try to extend the chain trusted to pending headers from the network
 		var linked bool
 		var err error
-		if linked, err = b.extend(nextResp.metas, nextResp.finalizedBlock, nextResp.latestBlock); err != nil {
+		if linked, err = b.extend(nextResp.metas, nextResp.finalizedBlock, nextResp.latestBlock, completed); err != nil {
 			// Wait for a new start signal to recover
 			return true, nil
 		}

--- a/eth/handler.go
+++ b/eth/handler.go
@@ -342,6 +342,17 @@ func (h *handler) runBeaconPeer(peer *beaconproto.Peer, handler beaconproto.Hand
 	}
 	defer h.unregisterBeacon(peer.ID())
 
+	// Send a notification to the beacon synchronizer, to enable a sync
+	// without waiting for the first head announcement
+	if peer.Version() >= beaconproto.BEACON2 {
+		head, td, number := peer.Head()
+		localHead := h.chain.CurrentHeader()
+		if td.Cmp(h.chain.GetTd(localHead.Hash(), localHead.Number.Uint64())) > 0 {
+			// Mock a block announcement if necessary.
+			h.beacon.NotifyBlockAnnon(peer.ID(), head, number, time.Now())
+		}
+	}
+
 	return handler(peer)
 }
 


### PR DESCRIPTION
Close #613. Based on #598.

Also contains a fix, ref https://github.com/bane-labs/go-ethereum/pull/615#issuecomment-4598653743.