### PR TITLE
core: use ErrTxGasPriceTooLow for policy price check

### DIFF
--- a/core/error.go
+++ b/core/error.go
@@ -153,7 +153,7 @@ var (
 	// ErrBlockedSender is returned if the transaction sender is blocked by policy.
 	ErrBlockedSender = errors.New("blocked sender")
 
-	// ErrUnderpriced is returned if a transaction's gas price is below the minimum
-	// configured for the transaction pool.
-	ErrUnderpriced = errors.New("transaction underpriced")
+	// ErrTxGasPriceTooLow is returned if a transaction's gas price is below the
+	// minimum configured for the transaction pool.
+	ErrTxGasPriceTooLow = errors.New("transaction gas price below minimum")
 )

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -397,7 +397,7 @@ func (st *stateTransition) preCheck() error {
 				}
 				if effectiveTip.Cmp(minGasTipCap) < 0 {
 					return fmt.Errorf("%w: address %v, gasTipCap %v, gasFeeCap %v, policy minGasTipCap (including Envelope fee for Envelopes) %v, baseFee %v ",
-						ErrUnderpriced, msg.From.Hex(), msg.GasTipCap, msg.GasFeeCap, minGasTipCap, st.evm.Context.BaseFee)
+						ErrTxGasPriceTooLow, msg.From.Hex(), msg.GasTipCap, msg.GasFeeCap, minGasTipCap, st.evm.Context.BaseFee)
 				}
 			}
 		}

--- a/core/txpool/validation.go
+++ b/core/txpool/validation.go
@@ -249,8 +249,9 @@ func ValidateTransactionWithState(tx *types.Transaction, signer types.Signer, op
 		effectiveTip = tx.GasTipCap()
 	}
 	if effectiveTip.Cmp(minGasTipCap) < 0 {
+		// This is a stateful validation, but the policy is more like a static rule, and we expect the error to be returned directly.
 		return fmt.Errorf("%w: policy minGasTipCap (including Envelope fee for Envelopes) needed %v, baseFee needed %v, gasTipCap %v, gasFeeCap %v ",
-			ErrUnderpriced, minGasTipCap, baseFee, tx.GasTipCap(), tx.GasFeeCap())
+			ErrTxGasPriceTooLow, minGasTipCap, baseFee, tx.GasTipCap(), tx.GasFeeCap())
 	}
 	// Apply policy blacklist
 	var blocked = opts.State.GetState(systemcontracts.PolicyProxyHash, systemcontracts.GetBlackListStateHash(from))


### PR DESCRIPTION
Close #618.

There is a new error `ErrTxGasPriceTooLow` and the original usage of `ErrUnderpriced` has changed since `0.5.0`, so caused a misbehavior of RPC transaction handling.