### PR TITLE
consensus/dbft: fix seal hash and error return

### DIFF
--- a/consensus/dbft/dbft.go
+++ b/consensus/dbft/dbft.go
@@ -2663,6 +2663,18 @@ func encodeUnchangeableHeader(w io.Writer, header *types.Header) {
 	if header.WithdrawalsHash != nil {
 		enc = append(enc, header.WithdrawalsHash)
 	}
+	if header.BlobGasUsed != nil {
+		enc = append(enc, header.BlobGasUsed)
+	}
+	if header.ExcessBlobGas != nil {
+		enc = append(enc, header.ExcessBlobGas)
+	}
+	if header.ParentBeaconRoot != nil {
+		enc = append(enc, header.ParentBeaconRoot)
+	}
+	if header.RequestsHash != nil {
+		enc = append(enc, header.RequestsHash)
+	}
 	if err := rlp.Encode(w, enc); err != nil {
 		panic("can't encode: " + err.Error())
 	}
@@ -2954,10 +2966,6 @@ func (c *DBFT) getNextConsensus(h *types.Header, s *state.StateDB) (common.Hash,
 		threshold = dbftutil.GetNextConsensusHash([]dbftutil.Encodable{pub})
 	}
 	return multisig, threshold
-}
-
-func (c *DBFT) shouldUpdateCommitteeAt(blockNum uint64) bool {
-	return blockNum%uint64(len(c.config.StandByValidators)) == 0
 }
 
 func unpackContractExecutionResult(res interface{}, result *core.ExecutionResult, contractAbi abi.ABI, method string) error {

--- a/consensus/dbft/precommit.go
+++ b/consensus/dbft/precommit.go
@@ -124,7 +124,7 @@ func decodeShares(data []byte) ([]*tpke.DecryptionShare, []*tpke.DecryptionShare
 		curr[i] = &tpke.DecryptionShare{}
 		_, err := curr[i].FromBytes(data[offset : offset+tpke.DecryptionShareSize])
 		if err != nil {
-			fmt.Errorf("decoding current round share %d: %w", i, err)
+			return nil, nil, fmt.Errorf("decoding current round share %d: %w", i, err)
 		}
 		offset += tpke.DecryptionShareSize
 	}
@@ -132,7 +132,7 @@ func decodeShares(data []byte) ([]*tpke.DecryptionShare, []*tpke.DecryptionShare
 		prev[i] = &tpke.DecryptionShare{}
 		_, err := prev[i].FromBytes(data[offset : offset+tpke.DecryptionShareSize])
 		if err != nil {
-			fmt.Errorf("decoding previous round share %d: %w", i, err)
+			return nil, nil, fmt.Errorf("decoding previous round share %d: %w", i, err)
 		}
 		offset += tpke.DecryptionShareSize
 	}

--- a/consensus/dbft/prepare_request.go
+++ b/consensus/dbft/prepare_request.go
@@ -15,7 +15,7 @@ type prepareRequest struct {
 	// pre-NeoXAMEV fork. Starting from NeoXAMEV+1 height these fields are filled
 	// only if multisignature signing scheme is enforced, hence marked as optional
 	// for RLP serialization.
-	ParentSealHashV0 common.Hash `rlp:optional`
+	ParentSealHashV0 common.Hash `rlp:"optional"`
 	ParentExtra      []byte      `rlp:"optional"`
 }
 


### PR DESCRIPTION
Part of #590.

Since we are not working on the original PR, and IMO it may be left aside for quite a long time, I picked the unrelated changes here as an independent PR.