### PR TITLE
beacon/impl: eth: fix and improve the CL synchronizer service and dBFT syncing check

### DIFF
--- a/beacon/impl/beacon.go
+++ b/beacon/impl/beacon.go
@@ -142,6 +142,11 @@ func (b *Beacon) Syncing() bool {
 	return b.synchronizer.Syncing()
 }
 
+// InitialSynced returns whether the beacon client has ever been synced, which means a round of light sync has been completed.
+func (b *Beacon) InitialSynced() bool {
+	return b.synchronizer.InitialSynced()
+}
+
 func (b *Beacon) SubscribeSyncingEvents(ch chan<- bool) event.Subscription {
 	return b.miner.SubscribeSyncingEvents(ch)
 }

--- a/beacon/impl/synchronizer/synchronizer.go
+++ b/beacon/impl/synchronizer/synchronizer.go
@@ -20,9 +20,8 @@ const (
 )
 
 var (
-	errInvalidLightHeader   = errors.New("invalid light header")
-	errTooManyPendingChains = errors.New("too many pending header chains")
-	errExtendStartMismatch  = errors.New("extend start mismatch")
+	errInvalidLightHeader  = errors.New("invalid light header")
+	errExtendStartMismatch = errors.New("extend start mismatch")
 )
 
 // LightVerifyFn is a callback type for light protocal verification.
@@ -173,9 +172,16 @@ func (s *Synchronizer) NotifyNewHead(block *types.Block) error {
 		}
 	}
 	// If not found, then try add.
-	// TODO: implement a better pruning mechanism.
 	if len(s.pendingChains) >= maxPendingChain {
-		return errTooManyPendingChains
+		var oldestIdx common.Hash
+		var oldestTime uint64
+		for h, choice := range s.pendingChains {
+			if oldestIdx == (common.Hash{}) || choice.latest.Time() < oldestTime {
+				oldestIdx = h
+				oldestTime = choice.latest.Time()
+			}
+		}
+		delete(s.pendingChains, oldestIdx)
 	}
 	// Suppose the new block is finalized, if a reorg happen, then there will be another new chain.
 	s.pendingChains[block.ParentHash()] = Choice{

--- a/beacon/impl/synchronizer/synchronizer.go
+++ b/beacon/impl/synchronizer/synchronizer.go
@@ -57,6 +57,7 @@ type Synchronizer struct {
 	pendingChains map[common.Hash]Choice // map of pending sync targets, key is the earliest header
 	lock          sync.RWMutex           // Mutex to protect the synchronizer state
 	syncing       atomic.Bool            // Whether the synchronizer is syncing
+	initialSynced atomic.Bool            // Whether the synchronizer has ever been synced
 	db            ethdb.KeyValueStore    // The database to store the latest trusted head for beacon sync
 
 	startCh chan *types.Header // Channel to signal the synchronizer to start
@@ -231,6 +232,7 @@ func (s *Synchronizer) BeaconExtend(verifiedHeaderHashes []common.Hash, finalize
 // the sync process again.
 func (s *Synchronizer) Stop() {
 	s.syncing.Store(false)
+	s.initialSynced.Store(true)
 }
 
 // Close closes the synchronizer.
@@ -241,6 +243,11 @@ func (s *Synchronizer) Close() {
 // Syncing returns whether the synchronizer is currently syncing.
 func (s *Synchronizer) Syncing() bool {
 	return s.syncing.Load()
+}
+
+// InitialSynced returns whether the synchronizer has ever been synced, which means a round of light sync has been completed.
+func (s *Synchronizer) InitialSynced() bool {
+	return s.initialSynced.Load()
 }
 
 // merge connects pending chain choices when a latest block changes.

--- a/beacon/impl/synchronizer/synchronizer_test.go
+++ b/beacon/impl/synchronizer/synchronizer_test.go
@@ -42,31 +42,43 @@ func newTestSynchronizer(chain []*types.Block, complete completeFn) *Synchronize
 					trustedHeader = header
 					shouldSync.Store(true)
 				}
-				if trustedHeader == nil || trustedHeader.Number.Uint64() < header.Number.Uint64() {
-					trustedHeader = header
-				}
 			default:
 			}
 			// Do nothing if should wait.
 			if !shouldSync.Load() {
-				time.Sleep(time.Second * 3)
+				time.Sleep(time.Millisecond * 100)
 				continue
 			}
 			// Skip the download, mock the result.
-			endIndex := trustedHeader.Number.Uint64() + ExpectedHeadersNum
+			startIndex := trustedHeader.Number.Uint64()
+			// If the trusted header is beyond what we have, signal completion
+			if startIndex >= uint64(len(chain)) {
+				shouldSync.Store(false)
+				complete()
+				continue
+			}
+			endIndex := startIndex + ExpectedHeadersNum
 			if endIndex > uint64(len(chain)) {
 				endIndex = uint64(len(chain))
 			}
-			newBlocks := chain[trustedHeader.Number.Uint64():endIndex]
-			headers := make([]*types.Header, len(newBlocks))
+			newBlocks := chain[startIndex:endIndex]
+			if len(newBlocks) == 0 {
+				shouldSync.Store(false)
+				complete()
+				continue
+			}
 			metas := make([]common.Hash, len(newBlocks))
 			for i := range len(newBlocks) {
-				headers[i] = newBlocks[i].Header()
 				metas[i] = newBlocks[i].Hash()
 			}
-			trustedHeader = newBlocks[len(newBlocks)-2].Header()
+			finalized := newBlocks[0]
+			latest := newBlocks[len(newBlocks)-1]
+			if len(newBlocks) > 1 {
+				finalized = newBlocks[len(newBlocks)-2]
+			}
 			completed := len(newBlocks) < ExpectedHeadersNum
-			if _, err := extend(metas, newBlocks[len(newBlocks)-2], newBlocks[len(newBlocks)-1], completed); err != nil {
+			trustedHeader = finalized.Header()
+			if _, err := extend(metas, finalized, latest, completed); err != nil {
 				shouldSync.Store(false)
 				complete()
 				continue
@@ -91,7 +103,7 @@ func TestSynchronizerStatic(t *testing.T) {
 	defer syncer.Stop()
 	// Should be able to sync and finish automatically.
 	timer := time.NewTimer(time.Second * 3)
-	for syncer.trustedHead.NumberU64() < uint64(len(chain)-2) {
+	for syncer.trustedHead.NumberU64() < chain[len(chain)-2].NumberU64() {
 		select {
 		case <-timer.C:
 			t.Fatalf("Failed to sync chain in three seconds")
@@ -117,7 +129,7 @@ func TestSynchronizerContinues(t *testing.T) {
 		syncer.NotifyNewHead(chain[i])
 	}
 	timer := time.NewTimer(time.Second * 3)
-	for syncer.trustedHead.NumberU64() < uint64(len(chain)-3) {
+	for syncer.trustedHead.NumberU64() < chain[len(chain)-3].NumberU64() {
 		select {
 		case <-timer.C:
 			t.Fatalf("Failed to sync chain in three seconds")
@@ -129,8 +141,8 @@ func TestSynchronizerContinues(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if syncer.trustedHead.NumberU64() < uint64(len(chain)-2) {
-		t.Fatalf("trusted chain height mismatch, got %d, want %d", syncer.trustedHead.NumberU64(), uint64(len(chain)-2))
+	if syncer.trustedHead.NumberU64() < chain[len(chain)-2].NumberU64() {
+		t.Fatalf("trusted chain height mismatch, got %d, want %d", syncer.trustedHead.NumberU64(), chain[len(chain)-2].NumberU64())
 	}
 	if len(syncer.pendingChains) > 0 {
 		t.Fatalf("pending chain number mismatch, got %d, want %d", len(syncer.pendingChains), 0)
@@ -143,7 +155,7 @@ func TestSynchronizerDisordered(t *testing.T) {
 		t.Logf("chain trust extends to %d", block.NumberU64())
 		return nil
 	}
-	syncer := newTestSynchronizer(chain[:len(chain)/2+1], complete)
+	syncer := newTestSynchronizer(chain, complete)
 	syncer.Start()
 	defer syncer.Stop()
 	// Start from the half, but random annonce.
@@ -155,7 +167,7 @@ func TestSynchronizerDisordered(t *testing.T) {
 		syncer.NotifyNewHead(block)
 	}
 	timer := time.NewTimer(time.Second * 3)
-	for syncer.trustedHead.NumberU64() < uint64(len(chain)-3) {
+	for syncer.trustedHead.NumberU64() < chain[len(chain)-3].NumberU64() {
 		select {
 		case <-timer.C:
 			t.Fatalf("Failed to sync chain in three seconds")
@@ -167,8 +179,8 @@ func TestSynchronizerDisordered(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if syncer.trustedHead.NumberU64() < uint64(len(chain)-2) {
-		t.Fatalf("trusted chain height mismatch, got %d, want %d", syncer.trustedHead.NumberU64(), uint64(len(chain)-2))
+	if syncer.trustedHead.NumberU64() < chain[len(chain)-2].NumberU64() {
+		t.Fatalf("trusted chain height mismatch, got %d, want %d", syncer.trustedHead.NumberU64(), chain[len(chain)-2].NumberU64())
 	}
 	if len(syncer.pendingChains) > 0 {
 		t.Fatalf("pending chain number mismatch, got %d, want %d", len(syncer.pendingChains), 0)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -469,8 +469,9 @@ func New(stack *node.Node, config *ethconfig.Config) (*Ethereum, error) {
 	})
 	if bft != nil {
 		syncing := func() bool {
-			log.Debug("Syncing status", "beacon", eth.beacon.Syncing(), "eth", eth.Syncing())
-			return eth.beacon.Syncing() || eth.Syncing()
+			log.Debug("Syncing status", "initialized", eth.beacon.InitialSynced(), "beacon", eth.beacon.Syncing(), "eth", eth.Syncing())
+			// Ignore the beacon syncing status after the initial sync, to prevent blocking expected dBFT message handling.
+			return !eth.beacon.InitialSynced() || eth.Syncing()
 		}
 		// Connect BFT to beacon protocol
 		bft.WithBeacon(eth.beacon, syncing)

--- a/eth/downloader/beaconlightsync.go
+++ b/eth/downloader/beaconlightsync.go
@@ -109,18 +109,16 @@ func (b *beaconLightSyncer) loop(start chan *types.Header) error {
 			if !ok {
 				return nil
 			}
-			if b.trustedHeader == nil || b.trustedHeader.Number.Uint64() < header.Number.Uint64() {
-				log.Info("Starting beacon light sync", "head", header.Number.Uint64())
-				// If the header is newer than the current trusted header, update the trusted header and start syncing
-				b.trustedHeader = header
-				b.startHead = header.Number.Uint64()
-				completed = false
-				cancel = make(chan struct{})
+			log.Info("Starting beacon light sync", "head", header.Number.Uint64())
+			// If the header is newer than the current trusted header, update the trusted header and start syncing
+			b.trustedHeader = header
+			b.startHead = header.Number.Uint64()
+			completed = false
+			cancel = make(chan struct{})
 
-				b.scratchSpace = make([]*beaconLightResponse, beaconSync.ScratchSpaceLen)
-				b.scratchOwners = make([]string, beaconSync.ScratchSpaceLen)
-				b.scratchHead = header.Number.Uint64()
-			}
+			b.scratchSpace = make([]*beaconLightResponse, beaconSync.ScratchSpaceLen)
+			b.scratchOwners = make([]string, beaconSync.ScratchSpaceLen)
+			b.scratchHead = header.Number.Uint64()
 		case req := <-b.requestFails:
 			b.revertRequest(req)
 


### PR DESCRIPTION
Close #627.

- [x] Improve the syncing status check for smooth dBFT message handling;
- [x] Fix the status inconsistency that makes the node permanent waiting;
- [x] Implement a pending chain pruning mechanism for the CL synchronizer.